### PR TITLE
Require explicit confirmation before deleting orphan workbooks

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -363,6 +363,7 @@ jobs:
             shared/lib/test_phase_metrics.rb
             shared/scripts/test-intake-triage.rb
             shared/scripts/test-assert-phase6.rb
+            shared/scripts/test-cleanup-orphan-workbooks.rb
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/test-intake-triage.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-validate-sigma-formula-cleanup.rb
             plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/test-validate-sigma-formula-wrap.rb

--- a/plugins/domo-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/domo-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "domo-to-sigma",
   "displayName": "Domo \u2192 Sigma",
-  "version": "0.16.90",
+  "version": "0.16.91",
   "description": "Migrate Domo dashboards to Sigma \u2014 DataSets \u2192 Sigma data model (flat materialized tables \u2192 table elements), Beast Mode calc fields \u2192 Sigma formulas (MySQL-dialect SQL via the shared SQL-formula converter), and cards \u2192 charts/KPIs/pivots (every card's Summary Number \u2192 a Sigma KPI, not a table). Ports page + card filters as controls, detects PDP policies for opt-in row-level security, pre-flights Domo dataset columns against the real warehouse schema before building the data model, and defers live parity verification. Bundles a read-only domo-assessment skill (public governance-dataset inventory \u2192 value/cost-ranked migration-readiness readout) and domo-import-to-snowflake for landing DataSets with no connector-backed warehouse source. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/hex-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/hex-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "hex-to-sigma",
   "displayName": "Hex \u2192 Sigma",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "Migrate Hex projects to Sigma \u2014 SQL cells, single-value/METRIC cells, and EXPLORE charts \u2192 Sigma data model + workbook, built from a project's .hex.yaml export (Hex's REST API doesn't return cell content), with app layout carried over and warehouse parity verification. Bundles a read-only hex-assessment skill (scaffolded, not yet built out). Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/looker-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/looker-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "looker-to-sigma",
   "displayName": "Looker \u2192 Sigma",
-  "version": "1.2.27",
+  "version": "1.2.28",
   "description": "Migrate Looker (LookML semantic model + dashboards) to Sigma \u2014 discovery via the Looker REST API 4.0 / Looker MCP (or offline .lkml), LookML\u2192data-model conversion via convert_lookml_to_sigma, dashboard\u2192workbook build from the Looker Dashboard API JSON (UDD or LookML dashboards), build via the Sigma REST API, and 3-way parity verification (Looker vs Sigma vs warehouse).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/microstrategy-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "microstrategy-to-sigma",
   "displayName": "MicroStrategy → Sigma",
-  "version": "0.2.35",
+  "version": "0.2.36",
   "description": "Migrate MicroStrategy (Strategy One) to Sigma — dossier + classic semantic model (attributes/facts/metrics over a star schema) → Sigma data model + workbook, with deterministic reproduction of Analytical-Engine row-collapse quirks and row-level parity verification. Live-validated with exact parity on the classic-schema grid path; chart-viz emission and the newer REST-authorable Data Model object are roadmap. Includes a read-only estate assessment. Companion to the sigma-migration-skills converters.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/mode-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/mode-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "mode-to-sigma",
   "displayName": "Mode \u2192 Sigma",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Convert a Mode Report (Queries + Charts) into a Sigma data model and matching workbook. Discovery via the Mode REST API (Queries, Charts, Filters, plus a live run to sample each Query's output columns), a reuse check before building a new data model, DM + workbook creation via REST (every Query wraps its raw SQL verbatim as a native-SQL table element \u2014 no formula translation needed, since Mode's SQL already runs in the target warehouse dialect), a notebook-flow layout, and parity verification against the source Mode Query values. Bundles mode-to-sigma (registered, converter-only for this release) + mode-assessment (not yet registered).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/powerbi-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "powerbi-to-sigma",
   "displayName": "Power BI \u2192 Sigma",
-  "version": "1.8.43",
+  "version": "1.8.44",
   "description": "Migrate Power BI models and reports to Sigma \u2014 TMSL + report extraction (incl. a fully-local .pbix front door: pbixray VertiPaq \u2192 TMSL model + UTF-16LE Report/Layout, no Fabric), DAX \u2192 Sigma formula translation (with a gap-scout for the hard cases), data model + workbook build, and parity verification. Includes a model assessment skill and an Import-mode \u2192 Snowflake data-landing skill for .pbix files with no live warehouse.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/qlik-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/qlik-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "qlik-to-sigma",
   "displayName": "Qlik \u2192 Sigma",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Migrate Qlik Sense / Qlik Cloud apps to Sigma \u2014 discovery via qlik-cli or corectl unbuild, Qlik-expression \u2192 Sigma-formula translation (incl. Set Analysis + calculated LOAD fields), REST-only warehouse catalog preflight, data model + source-covered workbook build, and parity verification. Also migrates legacy QlikView (.qvw) apps from the -prj project folder. Includes a tenant assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/quicksight-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "quicksight-to-sigma",
   "displayName": "QuickSight \u2192 Sigma",
-  "version": "1.5.25",
+  "version": "1.5.26",
   "description": "Migrate Amazon QuickSight analyses and dashboards to Sigma \u2014 analysis + dataset + data-source extraction over the AWS CLI, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, data model + workbook build, layout, and parity verification. Includes a QuickSight assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/sisense-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/sisense-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sisense-to-sigma",
   "displayName": "Sisense \u2192 Sigma",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "Migrate Sisense (ElastiCube / Live data model + dashboards) to Sigma \u2014 data model + workbook (indicator\u2192KPI, chart/*\u2192chart, pivot2\u2192pivot, table; JAQL\u2192Sigma formulas; filters\u2192controls; columnar layout\u219224-col grid), with data + layout parity gates and opt-in RLS. Bundles sisense-to-sigma + sisense-assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/tableau-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/tableau-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "tableau-to-sigma",
   "displayName": "Tableau \u2192 Sigma",
-  "version": "1.9.31",
+  "version": "1.9.32",
   "description": "Migrate Tableau workbooks and datasources to Sigma \u2014 discovery, calc/LOD translation, data model + workbook build, and parity verification against the source warehouse. Includes a tenant assessment skill and a VDS\u2192warehouse data-landing skill (Snowflake or Databricks).",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/thoughtspot-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "thoughtspot-to-sigma",
   "displayName": "ThoughtSpot \u2192 Sigma",
-  "version": "1.2.24",
+  "version": "1.2.25",
   "description": "Migrate ThoughtSpot models/worksheets and Liveboards to Sigma \u2014 TML discovery, model\u2192data-model conversion, Liveboard\u2192workbook build (KPI/bar/line/pie/pivot/table + search-query filters), grid layout, and parity verification. Includes an instance assessment skill.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/assert-phase6-ran.rb
+++ b/shared/scripts/assert-phase6-ran.rb
@@ -1384,7 +1384,22 @@ end
 unless opts[:skip_orphan]
   log = File.join(opts[:tab], 'posted-workbooks.jsonl')
   if File.exist?(log)
-    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    posted = []
+    invalid_lines = []
+    File.readlines(log).each_with_index do |line, index|
+      next if line.strip.empty?
+      entry = (JSON.parse(line) rescue nil)
+      if entry.is_a?(Hash) && entry['id'].is_a?(String) && !entry['id'].empty?
+        posted << entry
+      else
+        invalid_lines << index + 1
+      end
+    end
+    if invalid_lines.any?
+      warn "[FAIL] gate 2/7: posted-workbooks.jsonl has malformed/unsafe entries at line(s) #{invalid_lines.join(', ')}."
+      warn '       Refusing to infer cleanup state from a partial ledger.'
+      exit 4
+    end
     unique_ids = posted.map { |e| e['id'] }.uniq
     if unique_ids.length > 1
       marker_path = File.join(opts[:tab], 'cleanup-marker.json')
@@ -1392,25 +1407,66 @@ unless opts[:skip_orphan]
         warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
         warn "       posted-workbooks.jsonl entries:"
         unique_ids.each { |id| warn "         - #{id}" }
-        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        live_id = opts[:wb]
+        if live_id.nil?
+          wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+          live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+        end
+        warn "       Review: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]} --keep #{live_id || '<live-workbook-id>'} --dry-run"
+        warn '       Then run without --dry-run in an interactive terminal and confirm each deletion.'
         warn "       See beads-sigma-38a."
         exit 4
       end
       marker = JSON.parse(File.read(marker_path)) rescue {}
+      unless marker.is_a?(Hash) && marker['kept'].is_a?(String)
+        warn '[FAIL] gate 2/7: cleanup-marker.json is malformed or has no explicit kept workbook ID.'
+        exit 4
+      end
       if marker['failed'] && !marker['failed'].empty?
         warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
         warn "       Orphan workbooks are still in the customer's My Documents:"
         marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
         exit 4
       end
-      if marker['dry_run']
-        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
-        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+      if marker['skipped'] && !marker['skipped'].empty?
+        warn "[FAIL] gate 2/7: the user kept #{marker['skipped'].length} cleanup candidate(s)."
+        marker['skipped'].each { |entry| warn "         - #{entry['id']}" }
+        warn '       This is safe, but orphan cleanup is incomplete.'
         exit 4
       end
-      kept = marker['kept'] || '(unknown)'
-      deleted = (marker['deleted'] || []).length
-      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn '       Re-run cleanup-orphan-workbooks.rb without --dry-run in an interactive terminal.'
+        exit 4
+      end
+      kept = marker['kept']
+      unless unique_ids.include?(kept)
+        warn "[FAIL] gate 2/7: cleanup-marker.json kept #{kept}, which is not in the current ledger."
+        warn '       The marker is stale or belongs to another workdir/run.'
+        exit 4
+      end
+      live_id = opts[:wb]
+      if live_id.nil?
+        wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+        live_id = (JSON.parse(File.read(wb_ids_path))['workbookId'] rescue nil) if File.exist?(wb_ids_path)
+      end
+      if live_id && kept != live_id
+        warn "[FAIL] gate 2/7: cleanup kept #{kept}, but the authoritative live workbook is #{live_id}."
+        warn '       Refusing a marker that could describe deletion of the wrong workbook set.'
+        exit 4
+      end
+      deleted_ids = Array(marker['deleted']).map { |entry| entry.is_a?(Hash) ? entry['id'] : entry }.compact.uniq
+      expected_deleted = unique_ids - [kept]
+      missing = expected_deleted - deleted_ids
+      unexpected = deleted_ids - expected_deleted
+      if missing.any? || unexpected.any?
+        warn '[FAIL] gate 2/7: cleanup-marker.json does not exactly cover the current ledger.'
+        warn "       Missing confirmed deletions: #{missing.join(', ')}" if missing.any?
+        warn "       Unexpected deletion records: #{unexpected.join(', ')}" if unexpected.any?
+        warn '       Re-run the interactive cleanup review; stale markers cannot satisfy this gate.'
+        exit 4
+      end
+      puts "[OK] gate 2/7: user-confirmed orphan cleanup — kept #{kept}, deleted #{deleted_ids.length}"
     else
       puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
     end

--- a/shared/scripts/cleanup-orphan-workbooks.rb
+++ b/shared/scripts/cleanup-orphan-workbooks.rb
@@ -1,28 +1,33 @@
 #!/usr/bin/env ruby
-# Delete orphan Sigma workbooks left behind by spec-iteration retries during
-# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
-# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
-# and deletes everything older via DELETE /v2/files/{id} (per
-# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+# Review and, only with per-workbook user confirmation, delete orphan Sigma
+# workbooks left by spec-iteration retries.
 #
-# See beads-sigma-38a for the regression motivating this script: a customer
-# migration on 2026-05-28 created three workbooks (one final + two orphans
-# from iterative POSTs) and the agent declared done without cleaning up.
+# SAFETY CONTRACT:
+#   * --keep is mandatory when the ledger contains more than one workbook.
+#     The last ledger line is NOT assumed to be live: workdirs and their
+#     append-only ledgers can be reused across migration runs.
+#   * Every candidate is read back from BOTH the workbook and file APIs before
+#     deletion. It must resolve to the same workbook inode, folder, creator, and
+#     owner context as the explicitly kept workbook.
+#   * Deletion is interactive only. The operator must type each candidate's full
+#     ID after reviewing its live name/path/timestamps. There is deliberately no
+#     --yes/non-interactive bypass.
+#   * --dry-run performs all read-only validation and writes the proposed IDs,
+#     but never prompts or deletes.
 #
 # Usage:
-#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
-#     [--dry-run]               # report what would be deleted; don't call DELETE
-#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
-#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
-#                                 silently anyway; this flag is just for clarity)
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id>
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name> --keep <live-id> --dry-run
 #
-# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
-# assert-phase6-ran.rb can confirm cleanup ran.
+# This script is NOT a way to delete the workbook just built. It always preserves
+# --keep. Use Sigma's UI when the current workbook itself should be removed.
+#
+# Writes <workdir>/cleanup-marker.json for assert-phase6-ran.rb.
 #
 # Exit codes:
-#   0  cleanup ran (or no cleanup needed — single workbook in log)
-#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
-#   2  setup error (missing env, bad args)
+#   0  no cleanup needed, dry-run completed, or all candidates were confirmed/deleted
+#   1  a candidate was refused, skipped, or failed
+#   2  unsafe/invalid invocation (including a non-interactive destructive run)
 
 require 'net/http'
 require 'uri'
@@ -30,113 +35,276 @@ require 'json'
 require 'time'
 require 'optparse'
 
-opts = { dry_run: false }
-OptionParser.new do |p|
-  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
-  p.on('--dry-run')        { opts[:dry_run] = true }
-  p.on('--keep ID')        { |v| opts[:keep] = v }
-  p.on('--allow-empty-log') { opts[:allow_empty] = true }
-end.parse!
-abort('--workdir required') unless opts[:workdir]
+module OrphanWorkbookCleanup
+  ID_PATTERN = /\A[A-Za-z0-9_-]+\z/.freeze
 
-log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
-unless File.exist?(log)
-  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
-  exit 0
-end
+  module_function
 
-ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
-if ids.empty?
-  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
-  exit 0
-end
+  def parse_options(argv)
+    opts = { dry_run: false }
+    OptionParser.new do |parser|
+      parser.on('--workdir DIR') { |value| opts[:workdir] = value }
+      parser.on('--dry-run') { opts[:dry_run] = true }
+      parser.on('--keep ID') { |value| opts[:keep] = value }
+      # Retained for CLI compatibility. A missing ledger is always a safe no-op.
+      parser.on('--allow-empty-log') { opts[:allow_empty] = true }
+    end.parse!(argv)
+    opts
+  end
 
-# Keep target: --keep override, otherwise the most-recent (last appended) entry.
-keep_id = opts[:keep] || ids.last['id']
-to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
-
-if to_delete.empty?
-  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'dry_run' => opts[:dry_run]
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
-$LOAD_PATH.unshift File.expand_path('lib', __dir__)
-require 'sigma_rest'
-
-def http_delete(base, tok, path)
-  attempts = 0
-  loop do
-    attempts += 1
-    uri = URI("#{base}#{path}")
-    req = Net::HTTP::Delete.new(uri)
-    req['Authorization'] = "Bearer #{Sigma.auth_token}"
-    req['Accept']        = 'application/json'
-    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
-    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
-      Sigma.refresh_token!
-      next
+  def load_ledger(path)
+    records = []
+    File.readlines(path).each_with_index do |line, index|
+      next if line.strip.empty?
+      begin
+        record = JSON.parse(line)
+      rescue JSON::ParserError => e
+        raise ArgumentError, "invalid JSON at #{File.basename(path)} line #{index + 1}: #{e.message}"
+      end
+      unless record.is_a?(Hash) && record['id'].is_a?(String) &&
+             !record['id'].empty? && ID_PATTERN.match?(record['id'])
+        raise ArgumentError, "#{File.basename(path)} line #{index + 1} must contain a safe string id"
+      end
+      records << record
     end
-    return res
+    records
+  end
+
+  def parse_json_response(response, label)
+    code = response.code.to_i
+    raise "#{label} returned HTTP #{code}" unless code.between?(200, 299)
+    parsed = JSON.parse(response.body.to_s)
+    raise "#{label} returned a non-object body" unless parsed.is_a?(Hash)
+    parsed
+  rescue JSON::ParserError => e
+    raise "#{label} returned invalid JSON: #{e.message}"
+  end
+
+  def inspect_workbook(id, requester)
+    workbook = parse_json_response(requester.call(:get, "/v2/workbooks/#{id}"),
+                                   "GET /v2/workbooks/#{id}")
+    file = parse_json_response(requester.call(:get, "/v2/files/#{id}"),
+                               "GET /v2/files/#{id}")
+
+    raise "workbook API returned #{workbook['workbookId'].inspect}, expected #{id}" unless workbook['workbookId'] == id
+    raise "file API returned #{file['id'].inspect}, expected #{id}" unless file['id'] == id
+    raise "file #{id} is type #{file['type'].inspect}, not workbook" unless file['type'] == 'workbook'
+    if workbook['workbookUrlId'] && file['urlId'] && workbook['workbookUrlId'] != file['urlId']
+      raise "workbook/file URL identifiers disagree for #{id}"
+    end
+
+    {
+      'id' => id,
+      'name' => file['name'] || workbook['name'],
+      'path' => file['path'] || workbook['path'],
+      'parentId' => file['parentId'],
+      'ownerId' => file['ownerId'] || workbook['ownerId'],
+      'createdBy' => file['createdBy'] || workbook['createdBy'],
+      'createdAt' => file['createdAt'] || workbook['createdAt'],
+      'updatedAt' => file['updatedAt'] || workbook['updatedAt']
+    }
+  end
+
+  def same_cleanup_context?(candidate, kept)
+    %w[parentId ownerId createdBy].all? do |key|
+      candidate[key] && kept[key] && candidate[key] == kept[key]
+    end
+  end
+
+  def marker_path(workdir)
+    File.join(workdir, 'cleanup-marker.json')
+  end
+
+  def write_marker(workdir, marker)
+    File.write(marker_path(workdir), JSON.pretty_generate(marker))
+  end
+
+  def tty?(input)
+    input.respond_to?(:tty?) && input.tty?
+  end
+
+  def run(argv, env: ENV, input: $stdin, output: $stdout, error: $stderr, requester: nil)
+    opts = parse_options(argv.dup)
+    unless opts[:workdir]
+      error.puts '--workdir required'
+      return 2
+    end
+
+    log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+    unless File.exist?(log)
+      output.puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+      return 0
+    end
+
+    begin
+      records = load_ledger(log)
+    rescue ArgumentError => e
+      error.puts "REFUSED: #{e.message}"
+      return 2
+    end
+    if records.empty?
+      output.puts '[OK] posted-workbooks.jsonl is empty — nothing to clean up'
+      return 0
+    end
+
+    unique_ids = records.map { |record| record['id'] }.uniq
+    if unique_ids.length == 1
+      if opts[:keep] && opts[:keep] != unique_ids.first
+        error.puts "REFUSED: --keep #{opts[:keep]} is not the ledger workbook #{unique_ids.first}"
+        return 2
+      end
+      keep_id = opts[:keep] || unique_ids.first
+      output.puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+      write_marker(opts[:workdir], {
+                     'ran_at' => Time.now.utc.iso8601, 'kept' => keep_id,
+                     'deleted' => [], 'failed' => [], 'skipped' => [],
+                     'dry_run' => opts[:dry_run]
+                   })
+      return 0
+    end
+
+    keep_id = opts[:keep].to_s
+    if keep_id.empty?
+      error.puts 'REFUSED: --keep <live-workbook-id> is required; ledger order is not proof of which workbook is live.'
+      error.puts "Ledger IDs: #{unique_ids.join(', ')}"
+      return 2
+    end
+    unless ID_PATTERN.match?(keep_id) && unique_ids.include?(keep_id)
+      error.puts "REFUSED: --keep #{keep_id.inspect} is not a safe ID present in posted-workbooks.jsonl"
+      return 2
+    end
+    unless opts[:dry_run] || tty?(input)
+      error.puts 'REFUSED: workbook deletion requires an interactive terminal.'
+      error.puts "Review first: ruby #{__FILE__} --workdir #{opts[:workdir]} --keep #{keep_id} --dry-run"
+      error.puts 'Then run the same command without --dry-run and type each workbook ID when prompted.'
+      return 2
+    end
+
+    unless requester
+      base = env['SIGMA_BASE_URL']
+      unless base && !base.empty?
+        error.puts 'SIGMA_BASE_URL not set'
+        return 2
+      end
+      requester = real_requester(base, env)
+    end
+
+    begin
+      kept = inspect_workbook(keep_id, requester)
+    rescue StandardError => e
+      error.puts "REFUSED: could not validate the workbook to keep: #{e.message}"
+      return 2
+    end
+
+    candidates = unique_ids.reject { |id| id == keep_id }
+    output.puts "KEEPING (explicit --keep): #{kept['name'].inspect}"
+    output.puts "  id:      #{keep_id}"
+    output.puts "  path:    #{kept['path']}"
+    output.puts "  created: #{kept['createdAt']}"
+    output.puts
+    output.puts "Reviewing #{candidates.length} ledger candidate(s). Ledgers can span multiple runs."
+    output.puts 'Confirm only workbooks you recognize as retries from this migration.'
+
+    deleted = []
+    failed = []
+    skipped = []
+    would_delete = []
+
+    candidates.each do |id|
+      begin
+        candidate = inspect_workbook(id, requester)
+        unless same_cleanup_context?(candidate, kept)
+          raise 'folder, owner, or creator differs from the explicitly kept workbook'
+        end
+      rescue StandardError => e
+        error.puts "  [REFUSED] #{id}: #{e.message}"
+        failed << { 'id' => id, 'reason' => e.message }
+        next
+      end
+
+      output.puts
+      output.puts 'CANDIDATE:'
+      output.puts "  name:    #{candidate['name'].inspect}"
+      output.puts "  id:      #{id}"
+      output.puts "  path:    #{candidate['path']}"
+      output.puts "  created: #{candidate['createdAt']}"
+      output.puts "  updated: #{candidate['updatedAt']}"
+
+      if opts[:dry_run]
+        output.puts '  [DRY-RUN] validated; no deletion performed'
+        would_delete << candidate
+        next
+      end
+
+      output.print "Type the full workbook ID to delete this candidate, or press Enter to keep it:\n> "
+      output.flush
+      confirmation = input.gets.to_s.strip
+      unless confirmation == id
+        output.puts "  [KEPT] #{id} — confirmation did not match"
+        skipped << { 'id' => id, 'reason' => 'user did not type the full workbook ID' }
+        next
+      end
+
+      response = requester.call(:delete, "/v2/files/#{id}")
+      code = response.code.to_i
+      if code.between?(200, 299) || code == 404
+        output.puts "  [deleted] #{id} (HTTP #{code})"
+        deleted << { 'id' => id, 'status' => code }
+      else
+        body = response.body.to_s[0..200]
+        error.puts "  [FAIL] #{id} (HTTP #{code}) — #{body}"
+        failed << { 'id' => id, 'status' => code, 'body' => body }
+      end
+    end
+
+    marker = {
+      'ran_at' => Time.now.utc.iso8601,
+      'kept' => keep_id,
+      'deleted' => deleted,
+      'failed' => failed,
+      'skipped' => skipped,
+      'dry_run' => opts[:dry_run]
+    }
+    marker['would_delete'] = would_delete if opts[:dry_run]
+    write_marker(opts[:workdir], marker)
+
+    if opts[:dry_run]
+      output.puts "\n[DRY-RUN] #{would_delete.length} candidate(s) validated; no DELETE calls made."
+      return failed.empty? ? 0 : 1
+    end
+    if failed.any? || skipped.any?
+      error.puts "\nCleanup incomplete: deleted #{deleted.length}, refused/failed #{failed.length}, kept by user #{skipped.length}."
+      return 1
+    end
+
+    output.puts "\n[OK] user confirmed and deleted #{deleted.length} orphan workbook(s); kept #{keep_id}"
+    0
+  rescue OptionParser::ParseError => e
+    error.puts e.message
+    2
+  end
+
+  def real_requester(base, env)
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    lambda do |method, path|
+      attempts = 0
+      loop do
+        attempts += 1
+        uri = URI("#{base}#{path}")
+        request = method == :delete ? Net::HTTP::Delete.new(uri) : Net::HTTP::Get.new(uri)
+        request['Authorization'] = "Bearer #{Sigma.auth_token}"
+        request['Accept'] = 'application/json'
+        response = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https',
+                                  read_timeout: 30) { |http| http.request(request) }
+        if response.code.to_i == 401 && attempts == 1 && env['SIGMA_CLIENT_ID']
+          Sigma.refresh_token!
+          next
+        end
+        break response
+      end
+    end
   end
 end
 
-puts "Keeping:  #{keep_id}"
-puts "Orphans:  #{to_delete.length}"
-to_delete.each { |id| puts "          - #{id}" }
-puts ''
-
-if opts[:dry_run]
-  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
-  marker = {
-    'ran_at'  => Time.now.utc.iso8601,
-    'kept'    => keep_id,
-    'deleted' => [],
-    'would_delete' => to_delete,
-    'dry_run' => true
-  }
-  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-  exit 0
-end
-
-deleted = []
-failed  = []
-to_delete.each do |id|
-  r = http_delete(base, nil, "/v2/files/#{id}")
-  code = r.code.to_i
-  if code.between?(200, 299) || code == 404
-    # 404 = already gone; treat as success for idempotency
-    puts "  [deleted] #{id} (HTTP #{code})"
-    deleted << { 'id' => id, 'status' => code }
-  else
-    body = r.body.to_s[0..200]
-    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
-    failed << { 'id' => id, 'status' => code, 'body' => body }
-  end
-end
-
-marker = {
-  'ran_at'  => Time.now.utc.iso8601,
-  'kept'    => keep_id,
-  'deleted' => deleted,
-  'failed'  => failed,
-  'dry_run' => false
-}
-File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
-
-if failed.any?
-  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
-  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
-  warn "delete them manually via the Sigma UI before declaring done."
-  exit 1
-end
-
-puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
-exit 0
+exit OrphanWorkbookCleanup.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/shared/scripts/test-assert-phase6.rb
+++ b/shared/scripts/test-assert-phase6.rb
@@ -180,6 +180,39 @@ scenario('2 workbooks POSTed, no cleanup-marker.json -> exit 4', 4) do |dir|
   File.write(File.join(dir, 'posted-workbooks.jsonl'),
              [{ 'id' => 'wb-1' }, { 'id' => 'wb-2' }].map { |h| JSON.generate(h) }.join("\n") + "\n")
 end
+scenario('malformed workbook ledger entry -> exit 4', 4) do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             JSON.generate('id' => 'wb-happy-1') + "\nnot-json\n")
+end
+scenario('complete user-confirmed cleanup marker -> exit 0', 0) do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             [{ 'id' => 'wb-old' }, { 'id' => 'wb-happy-1' }].map { |h| JSON.generate(h) }.join("\n") + "\n")
+  write_json(dir, 'cleanup-marker.json',
+             'kept' => 'wb-happy-1', 'deleted' => [{ 'id' => 'wb-old', 'status' => 200 }],
+             'failed' => [], 'skipped' => [], 'dry_run' => false)
+end
+scenario('cleanup marker with a user-declined candidate -> exit 4', 4) do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             [{ 'id' => 'wb-old' }, { 'id' => 'wb-happy-1' }].map { |h| JSON.generate(h) }.join("\n") + "\n")
+  write_json(dir, 'cleanup-marker.json',
+             'kept' => 'wb-happy-1', 'deleted' => [],
+             'failed' => [], 'skipped' => [{ 'id' => 'wb-old' }], 'dry_run' => false)
+end
+scenario('stale cleanup marker missing a ledger deletion -> exit 4', 4) do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             [{ 'id' => 'wb-old-1' }, { 'id' => 'wb-old-2' }, { 'id' => 'wb-happy-1' }].
+               map { |h| JSON.generate(h) }.join("\n") + "\n")
+  write_json(dir, 'cleanup-marker.json',
+             'kept' => 'wb-happy-1', 'deleted' => [{ 'id' => 'wb-old-1', 'status' => 200 }],
+             'failed' => [], 'skipped' => [], 'dry_run' => false)
+end
+scenario('cleanup marker kept id disagrees with wb-ids.json -> exit 4', 4) do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             [{ 'id' => 'wb-old' }, { 'id' => 'wb-happy-1' }].map { |h| JSON.generate(h) }.join("\n") + "\n")
+  write_json(dir, 'cleanup-marker.json',
+             'kept' => 'wb-old', 'deleted' => [{ 'id' => 'wb-happy-1', 'status' => 200 }],
+             'failed' => [], 'skipped' => [], 'dry_run' => false)
+end
 
 puts '== gate 3 (live /columns, fail-closed without creds) =='
 # No --skip-column-check passed: wb-ids.json resolves a workbook id and

--- a/shared/scripts/test-cleanup-orphan-workbooks.rb
+++ b/shared/scripts/test-cleanup-orphan-workbooks.rb
@@ -1,0 +1,222 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+require 'stringio'
+require_relative 'cleanup-orphan-workbooks'
+
+Response = Struct.new(:code, :body)
+
+class TtyInput < StringIO
+  def tty?
+    true
+  end
+end
+
+failures = []
+
+def check(condition, message, failures)
+  if condition
+    puts "  ok - #{message}"
+  else
+    warn "  FAIL - #{message}"
+    failures << message
+  end
+end
+
+def response(body, code = 200)
+  Response.new(code.to_s, JSON.generate(body))
+end
+
+def workbook(id, name: "Migration #{id}", owner: 'member-1', creator: 'member-1')
+  {
+    'workbookId' => id,
+    'workbookUrlId' => "url-#{id}",
+    'name' => name,
+    'path' => 'My Documents/Migrations',
+    'ownerId' => owner,
+    'createdBy' => creator,
+    'createdAt' => '2026-08-27T12:00:00Z',
+    'updatedAt' => '2026-08-27T12:05:00Z'
+  }
+end
+
+def file_record(id, name: "Migration #{id}", parent: 'folder-1', owner: 'member-1', creator: 'member-1',
+                type: 'workbook')
+  {
+    'id' => id,
+    'urlId' => "url-#{id}",
+    'name' => name,
+    'type' => type,
+    'parentId' => parent,
+    'path' => 'My Documents/Migrations',
+    'ownerId' => owner,
+    'createdBy' => creator,
+    'createdAt' => '2026-08-27T12:00:00Z',
+    'updatedAt' => '2026-08-27T12:05:00Z'
+  }
+end
+
+def requester_for(records, calls)
+  lambda do |method, path|
+    calls << [method, path]
+    if method == :delete
+      Response.new('200', '{}')
+    elsif path =~ %r{\A/v2/workbooks/([^/]+)\z}
+      response(records.fetch(Regexp.last_match(1)).fetch(:workbook))
+    elsif path =~ %r{\A/v2/files/([^/]+)\z}
+      response(records.fetch(Regexp.last_match(1)).fetch(:file))
+    else
+      Response.new('404', '{}')
+    end
+  end
+end
+
+def write_ledger(dir, records)
+  File.write(File.join(dir, 'posted-workbooks.jsonl'),
+             records.map { |record| JSON.generate(record) }.join("\n") + "\n")
+end
+
+def run_cleanup(dir, args: [], input: StringIO.new, requester: nil)
+  out = StringIO.new
+  err = StringIO.new
+  code = OrphanWorkbookCleanup.run(
+    ['--workdir', dir, *args],
+    env: {},
+    input: input,
+    output: out,
+    error: err,
+    requester: requester
+  )
+  [code, out.string, err.string]
+end
+
+puts '== malformed ledgers fail closed =='
+Dir.mktmpdir do |dir|
+  File.write(File.join(dir, 'posted-workbooks.jsonl'), "{\"id\":\"wb-1\"}\nnot-json\n")
+  calls = []
+  code, _out, err = run_cleanup(dir, args: ['--keep', 'wb-1'], requester: ->(*parts) { calls << parts })
+  check(code == 2, 'invalid JSON exits 2', failures)
+  check(err.include?('invalid JSON'), 'invalid ledger line is reported', failures)
+  check(calls.empty?, 'invalid ledger causes no API calls', failures)
+end
+
+puts '== multiple entries require an explicit keep id =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-old' }, { 'id' => 'wb-live' }])
+  calls = []
+  code, _out, err = run_cleanup(dir, requester: ->(*parts) { calls << parts })
+  check(code == 2, 'missing --keep exits 2', failures)
+  check(err.include?('--keep <live-workbook-id> is required'), 'refusal explains explicit keep requirement', failures)
+  check(calls.empty?, 'missing keep causes no API calls', failures)
+end
+
+puts '== non-interactive destructive runs never delete =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-old' }, { 'id' => 'wb-live' }])
+  calls = []
+  code, _out, err = run_cleanup(
+    dir,
+    args: ['--keep', 'wb-live'],
+    input: StringIO.new("wb-old\n"),
+    requester: ->(*parts) { calls << parts }
+  )
+  check(code == 2, 'non-interactive invocation exits 2', failures)
+  check(err.include?('requires an interactive terminal'), 'refusal names interactive requirement', failures)
+  check(calls.empty?, 'non-interactive invocation makes no API calls', failures)
+end
+
+puts '== live metadata must match the kept workbook context =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-other-folder' }, { 'id' => 'wb-live' }])
+  records = {
+    'wb-live' => { workbook: workbook('wb-live'), file: file_record('wb-live') },
+    'wb-other-folder' => {
+      workbook: workbook('wb-other-folder'),
+      file: file_record('wb-other-folder', parent: 'folder-2')
+    }
+  }
+  calls = []
+  code, _out, err = run_cleanup(
+    dir,
+    args: ['--keep', 'wb-live'],
+    input: TtyInput.new("wb-other-folder\n"),
+    requester: requester_for(records, calls)
+  )
+  check(code == 1, 'context mismatch exits 1', failures)
+  check(err.include?('folder, owner, or creator differs'), 'context mismatch is reported', failures)
+  check(calls.none? { |method, _path| method == :delete }, 'context mismatch causes no DELETE', failures)
+  marker = JSON.parse(File.read(File.join(dir, 'cleanup-marker.json')))
+  check(marker['failed'].first['id'] == 'wb-other-folder', 'refused id is recorded in marker', failures)
+end
+
+puts '== deletion requires typing each exact candidate id =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-old' }, { 'id' => 'wb-live' }])
+  records = {
+    'wb-live' => { workbook: workbook('wb-live'), file: file_record('wb-live') },
+    'wb-old' => { workbook: workbook('wb-old'), file: file_record('wb-old') }
+  }
+  calls = []
+  code, out, err = run_cleanup(
+    dir,
+    args: ['--keep', 'wb-live'],
+    input: TtyInput.new("wb-old\n"),
+    requester: requester_for(records, calls)
+  )
+  check(code.zero?, 'exact confirmation succeeds', failures)
+  check(err.empty?, 'successful cleanup has no stderr', failures)
+  check(out.include?('Type the full workbook ID'), 'operator receives an explicit prompt', failures)
+  deletes = calls.select { |method, _path| method == :delete }
+  check(deletes == [[:delete, '/v2/files/wb-old']], 'only the confirmed candidate is deleted', failures)
+  check(calls.none? { |method, path| method == :delete && path.include?('wb-live') },
+        'the explicit keep id is never deleted', failures)
+end
+
+puts '== declined candidates remain and make cleanup incomplete =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-old' }, { 'id' => 'wb-live' }])
+  records = {
+    'wb-live' => { workbook: workbook('wb-live'), file: file_record('wb-live') },
+    'wb-old' => { workbook: workbook('wb-old'), file: file_record('wb-old') }
+  }
+  calls = []
+  code, out, _err = run_cleanup(
+    dir,
+    args: ['--keep', 'wb-live'],
+    input: TtyInput.new("\n"),
+    requester: requester_for(records, calls)
+  )
+  check(code == 1, 'declining a candidate exits 1', failures)
+  check(out.include?('[KEPT] wb-old'), 'declined candidate is reported as kept', failures)
+  check(calls.none? { |method, _path| method == :delete }, 'declining causes no DELETE', failures)
+  marker = JSON.parse(File.read(File.join(dir, 'cleanup-marker.json')))
+  check(marker['skipped'].first['id'] == 'wb-old', 'declined id is recorded in marker', failures)
+end
+
+puts '== dry-run validates metadata without prompting or deleting =='
+Dir.mktmpdir do |dir|
+  write_ledger(dir, [{ 'id' => 'wb-old' }, { 'id' => 'wb-live' }])
+  records = {
+    'wb-live' => { workbook: workbook('wb-live'), file: file_record('wb-live') },
+    'wb-old' => { workbook: workbook('wb-old'), file: file_record('wb-old') }
+  }
+  calls = []
+  code, out, err = run_cleanup(
+    dir,
+    args: ['--keep', 'wb-live', '--dry-run'],
+    requester: requester_for(records, calls)
+  )
+  check(code.zero?, 'dry-run exits 0', failures)
+  check(err.empty?, 'valid dry-run has no stderr', failures)
+  check(out.include?('[DRY-RUN] validated'), 'dry-run reports validated candidate', failures)
+  check(calls.none? { |method, _path| method == :delete }, 'dry-run makes no DELETE calls', failures)
+  marker = JSON.parse(File.read(File.join(dir, 'cleanup-marker.json')))
+  check(marker['dry_run'] == true && marker['would_delete'].first['id'] == 'wb-old',
+        'dry-run marker records proposed candidate', failures)
+end
+
+abort "#{failures.length} cleanup safety test(s) failed" unless failures.empty?
+puts "\nAll cleanup safety tests passed."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The orphan cleanup script trusted append-only ledger order, kept the last ID, and deleted every earlier ID without validating live metadata or obtaining user confirmation. Reused workdirs could therefore target workbooks from earlier runs. This change makes deletion fail closed and interactive.

## Scope

- Plugin(s) touched: shared cleanup and completion-gate scripts, vendored to all registered converter targets
- [x] This PR is an isolated shared-infrastructure change

## Safety changes

- Require an explicit `--keep` ID when the ledger contains multiple workbooks
- Reject malformed ledgers and non-interactive destructive runs
- Read back both workbook and file metadata before offering a candidate
- Require matching workbook type, ID, URL ID, folder, owner, and creator context
- Display live name, path, and timestamps, then require typing each full workbook ID
- Provide no `--yes` or unattended deletion bypass
- Make the completion gate reject stale, partial, dry-run, failed, or user-declined cleanup markers

## Verification

- [x] Cleanup safety tests pass, including exact-ID confirmation and zero-delete refusal paths
- [x] Completion-gate regression suite passes
- [x] `ruby tools/check-shared.rb` — green (828 copies)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green (31/31)
- [x] Full governance suite — green
- [x] Plugin version-bump gate — green for all 11 affected plugins
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes included
- [x] Edited canonical files under `shared/` and ran `tools/sync-shared.rb`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b609ba5d-b913-4ce4-9cb6-70349d2a1dbd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b609ba5d-b913-4ce4-9cb6-70349d2a1dbd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

