### PR TITLE
Fix Streamlit shared PNG exporter drift

### DIFF
--- a/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/sigma-export-png.py
@@ -28,6 +28,23 @@ interaction verdict never depends on it).
 """
 import argparse, os, sys, time, requests
 
+def credentials():
+    base = os.environ.get("SIGMA_BASE_URL")
+    token = os.environ.get("SIGMA_API_TOKEN")
+    if base and token:
+        return base, token
+    # Shell-neutral no-Ruby path: mint from client credentials or the neutral
+    # env file using the co-located stdlib helper. Never print the token.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    try:
+        from get_token import mint_token
+        return mint_token()
+    except (ImportError, SystemExit) as exc:
+        raise SystemExit(
+            "Sigma token unavailable: set SIGMA_API_TOKEN or provide "
+            "SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET/SIGMA_BASE_URL"
+        ) from exc
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--workbook", required=True)
@@ -37,7 +54,7 @@ def main():
     ap.add_argument("--param", action="append", default=[],
                     metavar="CID=VALUE", help="control value for the render (repeatable)")
     a = ap.parse_args()
-    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    base, tok = credentials()
     h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
     fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
     body = {"format": fmt}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sync the Streamlit plugin's vendored `sigma-export-png.py` with the canonical shared script updated by #770. This fixes the post-merge shared-library drift failure from #755.

## Scope

- Plugin touched: `streamlit-to-sigma`
- [x] This PR touches exactly one plugin

## Checklist

- [x] `ruby tools/check-shared.rb` — green (872 copies match)
- [x] `ruby tools/lint-skills.rb` — green
- [x] `./corpus/run-corpus.sh --check streamlit` — 2/2 green
- [x] Full local governance hook — green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes included
- [x] `Skip-Version-Bump` trailer added for the non-user-facing vendored sync

## Shared synchronization

- [x] Canonical copy was already updated on `main`; ran `ruby tools/sync-shared.rb`
- [x] Standalone follow-up PR
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ac275a3-8589-44ab-bcef-681eb2522a40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ac275a3-8589-44ab-bcef-681eb2522a40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

