### PR TITLE
Recommend proven Streamlit redesign paths

### DIFF
--- a/plugins/streamlit-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/streamlit-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "streamlit-to-sigma",
   "displayName": "Streamlit → Sigma",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Migrate Streamlit projects to Sigma with static analysis, architecture dispositions, complexity readouts, controls/charts/layout conversion, parity gates, and read-only assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/streamlit-to-sigma/skills/streamlit-assessment/SKILL.md
+++ b/plugins/streamlit-to-sigma/skills/streamlit-assessment/SKILL.md
@@ -69,8 +69,8 @@ Each project receives:
   `blocked`
 - `resolvedPatterns` and `unresolvedGapCount` — preserve source findings while
   keeping successfully lowered patterns out of readiness/complexity penalties
-- `recommendation` — explicit `Migrate now`, `Redesign, then migrate`,
-  `Architecture review`, or `Defer until unblocked` decision
+- `recommendation` — explicit `Migrate now`, `Migrate with redesign`,
+  `Validate design, then migrate`, or `Resolve blockers, then migrate` path
 - `recommendation.technicalFitScore`, `wave`, `reason`, `nextAction`, and
   `blockers` — explain rank and make the shortlist actionable
 

--- a/plugins/streamlit-to-sigma/skills/streamlit-assessment/refs/migration-readout.md
+++ b/plugins/streamlit-to-sigma/skills/streamlit-assessment/refs/migration-readout.md
@@ -18,9 +18,14 @@ Every source-backed project must receive one explicit decision:
 | Decision | Meaning |
 |---|---|
 | `Migrate now` | Direct path with no unresolved restructuring or blockers. |
-| `Redesign, then migrate` | A bounded Sigma-native or warehouse redesign is identified. |
-| `Architecture review` | Complex state, AI, plugin, or writeback behavior needs a target decision first. |
-| `Defer until unblocked` | Source ambiguity, access, security, or another blocking finding prevents migration. |
+| `Migrate with redesign` | State, Python, plugin, or writeback behavior needs an explicit Sigma architecture. |
+| `Validate design, then migrate` | A workbook-agent or warehouse-backed path exists but must pass capability/security gates. |
+| `Resolve blockers, then migrate` | Source ambiguity or access must be resolved before implementation starts. |
+
+`blocked` readiness means the current automatic conversion cannot proceed. It
+does not mean the app should stay on Streamlit. Known workbook-agent,
+input-table, warehouse-backed, and manual-finish paths remain positive migration
+recommendations with later waves and lower technical-fit scores.
 
 Rank by recommendation first, then technical-fit score, then complexity score.
 Always show the reason, blockers, and next action. Technical fit is not business

--- a/plugins/streamlit-to-sigma/skills/streamlit-assessment/scripts/assess-streamlit.py
+++ b/plugins/streamlit-to-sigma/skills/streamlit-assessment/scripts/assess-streamlit.py
@@ -164,9 +164,9 @@ def complexity_profile(ir, score: int, readiness: str) -> dict:
 
 RECOMMENDATION_ORDER = {
     "migrate-now": 0,
-    "redesign-then-migrate": 1,
-    "architecture-review": 2,
-    "defer-until-unblocked": 3,
+    "migrate-with-redesign": 1,
+    "validate-then-migrate": 2,
+    "resolve-then-migrate": 3,
 }
 
 
@@ -199,42 +199,54 @@ def migration_recommendation(project: dict) -> dict:
             "Run the converter, complete reuse/readback gates, then validate "
             "data, interactions, security, and rendered parity."
         )
-    elif readiness == "redesign" and complexity != "complex":
-        decision = "redesign-then-migrate"
-        label = "Redesign, then migrate"
-        wave = "Wave 2"
-        fit_score = 65
-        reason = (
-            "Sigma can cover the app, but unresolved behavior requires a "
-            "bounded native or warehouse-backed redesign."
-        )
-        next_action = (
-            "Approve the listed migration disposition and redesign, then run "
-            "conversion with explicit manual-finish gates."
-        )
     elif readiness == "redesign":
-        decision = "architecture-review"
-        label = "Architecture review"
-        wave = "Wave 3"
-        fit_score = 40
+        decision = "migrate-with-redesign"
+        label = "Migrate with redesign"
+        wave = "Wave 2" if complexity == "medium" else "Wave 3"
+        fit_score = 65 if complexity == "medium" else 50
         reason = (
-            "Complex state, Python, AI, plugin, or writeback behavior prevents "
-            "a responsible converter-first recommendation."
+            "The app is a migration candidate, but state, Python, AI, plugin, "
+            "or writeback behavior requires an explicit Sigma architecture."
         )
         next_action = (
-            "Choose the target architecture and validate capability hosts "
-            "before committing this app to a migration wave."
+            "Choose and validate the listed Sigma-native, workbook-agent, "
+            "plugin, or warehouse-backed design, then migrate with parity gates."
         )
     else:
-        decision = "defer-until-unblocked"
-        label = "Defer until unblocked"
-        wave = "Hold"
-        fit_score = max(5, 25 - min(len(blockers), 5) * 3)
+        known_redesign = bool(
+            {
+                "warehouse-backed",
+                "workbook-agent-candidate",
+                "python-element-candidate",
+                "manual-ui-finish",
+                "redesign",
+            }
+            & set(dispositions)
+        )
+        decision = (
+            "validate-then-migrate"
+            if known_redesign
+            else "resolve-then-migrate"
+        )
+        label = (
+            "Validate design, then migrate"
+            if known_redesign
+            else "Resolve blockers, then migrate"
+        )
+        wave = "Wave 3" if known_redesign else "Unblock"
+        fit_score = (
+            40
+            if known_redesign
+            else max(15, 35 - min(len(blockers), 5) * 3)
+        )
         blocker_text = ", ".join(blockers) if blockers else "blocking findings"
-        reason = f"Migration cannot proceed reliably while {blocker_text} remains."
+        reason = (
+            "The app remains a migration candidate, but implementation cannot "
+            f"start reliably while {blocker_text} remains."
+        )
         next_action = (
             "Resolve source ambiguity, access, security, or writeback blockers "
-            "and rerun the assessment."
+            "and rerun the assessment before conversion."
         )
 
     if "workbook-agent-candidate" in dispositions:
@@ -242,7 +254,7 @@ def migration_recommendation(project: dict) -> dict:
             "Map the observed AI runtime to a governed workbook agent, attach "
             "proven grounding sources, and validate representative answers."
         )
-    elif "warehouse-backed" in dispositions and readiness != "blocked":
+    elif "warehouse-backed" in dispositions:
         next_action = (
             "Approve the warehouse/input-table writeback design and security "
             "model before conversion."
@@ -251,8 +263,7 @@ def migration_recommendation(project: dict) -> dict:
     return {
         "decision": decision,
         "label": label,
-        "recommended": decision
-        in {"migrate-now", "redesign-then-migrate"},
+        "recommended": True,
         "wave": wave,
         "technicalFitScore": fit_score,
         "reason": reason,
@@ -275,6 +286,16 @@ def prioritize_projects(projects: list[dict]) -> list[dict]:
     )
     for rank, project in enumerate(projects, start=1):
         project["priorityRank"] = rank
+    name_counts = {
+        name: sum(project["project"] == name for project in projects)
+        for name in {project["project"] for project in projects}
+    }
+    for project in projects:
+        project["displayName"] = (
+            f"{project['project']} — {Path(project['path']).name}"
+            if name_counts[project["project"]] > 1
+            else project["project"]
+        )
     return projects
 
 
@@ -363,7 +384,7 @@ def markdown_report(report: dict) -> str:
     for project in report["projects"]:
         recommendation = project["recommendation"]
         lines.append(
-            f"| {project['priorityRank']} | {project['project']} | "
+            f"| {project['priorityRank']} | {project['displayName']} | "
             f"**{recommendation['label']}** | {recommendation['wave']} | "
             f"{recommendation['technicalFitScore']}/100 | "
             f"{recommendation['reason']} | {recommendation['nextAction']} |"
@@ -379,7 +400,7 @@ def markdown_report(report: dict) -> str:
     )
     for project in report["projects"]:
         lines.append(
-            f"| {project['project']} | {project['readiness']} | "
+            f"| {project['displayName']} | {project['readiness']} | "
             f"{project['complexity']['class']} | "
             f"{project['complexity']['deliveryClass']} | "
             f"{project['migrationDisposition']} |"
@@ -387,7 +408,7 @@ def markdown_report(report: dict) -> str:
     lines.extend(["", "### Complexity drivers", ""])
     for project in report["projects"]:
         lines.append(
-            f"- **{project['project']}:** "
+            f"- **{project['displayName']}:** "
             + "; ".join(project["complexity"]["drivers"])
             + "."
         )
@@ -419,7 +440,7 @@ def html_report(report: dict) -> str:
         rows.append(
             "<tr>"
             f"<td>{project['priorityRank']}</td>"
-            f"<td><strong>{esc(project['project'])}</strong></td>"
+            f"<td><strong>{esc(project['displayName'])}</strong></td>"
             f"<td><span class=\"decision {esc(recommendation['decision'])}\">"
             f"{esc(recommendation['label'])}</span></td>"
             f"<td>{esc(recommendation['wave'])}</td>"
@@ -464,9 +485,9 @@ def html_report(report: dict) -> str:
     .decision {{ border-radius: 999px; padding: 3px 8px; white-space: nowrap;
       font-weight: 650; }}
     .migrate-now {{ background: #dcfce7; color: #166534; }}
-    .redesign-then-migrate {{ background: #dbeafe; color: #1e40af; }}
-    .architecture-review {{ background: #fef3c7; color: #92400e; }}
-    .defer-until-unblocked {{ background: #fee2e2; color: #991b1b; }}
+    .migrate-with-redesign {{ background: #dbeafe; color: #1e40af; }}
+    .validate-then-migrate {{ background: #fef3c7; color: #92400e; }}
+    .resolve-then-migrate {{ background: #fee2e2; color: #991b1b; }}
   </style>
 </head>
 <body>
@@ -478,8 +499,8 @@ def html_report(report: dict) -> str:
   <div class="summary">
     <div class="card"><div class="value">{counts['total']}</div>Total apps</div>
     <div class="card"><div class="value">{counts['migrateNow']}</div>Migrate now</div>
-    <div class="card"><div class="value">{counts['redesignThenMigrate']}</div>Redesign then migrate</div>
-    <div class="card"><div class="value">{counts['deferOrReview']}</div>Review / defer</div>
+    <div class="card"><div class="value">{counts['migrateWithRedesign']}</div>Migrate with redesign</div>
+    <div class="card"><div class="value">{counts['validateOrUnblock']}</div>Validate / unblock</div>
   </div>
   <h2>Recommended migration order</h2>
   <div class="table-wrap"><table>
@@ -541,19 +562,20 @@ def main() -> int:
         "recommendationSummary": {
             "total": len(projects),
             "migrateNow": recommendation_counts["migrate-now"],
-            "redesignThenMigrate": recommendation_counts[
-                "redesign-then-migrate"
+            "migrateWithRedesign": recommendation_counts[
+                "migrate-with-redesign"
             ],
-            "deferOrReview": (
-                recommendation_counts["architecture-review"]
-                + recommendation_counts["defer-until-unblocked"]
+            "validateOrUnblock": (
+                recommendation_counts["validate-then-migrate"]
+                + recommendation_counts["resolve-then-migrate"]
             ),
         },
         "projects": projects,
         "shortlist": [
             {
                 "rank": item["priorityRank"],
-                "project": item["project"],
+                "project": item["displayName"],
+                "sourceProject": item["project"],
                 "readiness": item["readiness"],
                 "complexityScore": item["complexityScore"],
                 "complexity": item["complexity"]["class"],

--- a/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/tests/test_safety_gates.py
+++ b/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/tests/test_safety_gates.py
@@ -99,9 +99,9 @@ class SafetyGateTest(unittest.TestCase):
             self.assertIn("blocked", project["migrationDispositions"])
             self.assertEqual(
                 project["recommendation"]["decision"],
-                "defer-until-unblocked",
+                "validate-then-migrate",
             )
-            self.assertFalse(project["recommendation"]["recommended"])
+            self.assertTrue(project["recommendation"]["recommended"])
             self.assertIn(
                 "warehouse-write",
                 project["recommendation"]["blockers"],
@@ -206,6 +206,11 @@ class SafetyGateTest(unittest.TestCase):
                 project["migrationDispositions"],
             )
             self.assertEqual(project["complexity"]["class"], "complex")
+            self.assertEqual(
+                project["recommendation"]["decision"],
+                "migrate-with-redesign",
+            )
+            self.assertTrue(project["recommendation"]["recommended"])
 
     def test_assessment_shortlist_ranks_migration_decisions(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -254,7 +259,7 @@ class SafetyGateTest(unittest.TestCase):
                     item["recommendation"]["decision"]
                     for item in report["shortlist"]
                 ],
-                ["migrate-now", "defer-until-unblocked"],
+                ["migrate-now", "resolve-then-migrate"],
             )
             self.assertEqual(
                 [item["rank"] for item in report["shortlist"]],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

The ranked assessment introduced in #779 still treated blocked automatic conversion as a recommendation not to migrate. That contradicts proven migrations for data editors, workbook agents, warehouse-backed writes, and complex session-state apps. This follow-up separates converter readiness from migration candidacy and keeps recommendations positive when a Sigma redesign path exists.

## Scope

- Plugin touched: `streamlit-to-sigma`
- [x] This PR touches exactly one plugin

## Changes

- Replace negative `Architecture review` / `Defer` labels with `Migrate with redesign`, `Validate design, then migrate`, and `Resolve blockers, then migrate`
- Keep all source-backed apps as migration candidates while sequencing harder ones into later waves
- Reserve `source-required` behavior for apps without source evidence
- Disambiguate duplicate project names using their source directory
- Bump plugin version to `0.1.23`

## Validation

- [x] 38 Streamlit unit/regression tests pass
- [x] Streamlit corpus passes 2/2
- [x] Shared drift and plugin-version gates pass
- [x] Full local governance passes
- [x] Browser walkthrough confirms all four paths remain positive and reasons/next actions render cleanly
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ac275a3-8589-44ab-bcef-681eb2522a40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ac275a3-8589-44ab-bcef-681eb2522a40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

