### PR TITLE
Add Metabase migration plugin and assessment

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -176,6 +176,13 @@
       "description": "Streamlit → Sigma static converter and assessment — SQL/dataframe lineage, controls, charts, pages, layout, gaps, and parity.",
       "category": "migration",
       "keywords": ["streamlit", "migration", "bi"]
+    },
+    {
+      "name": "metabase-to-sigma",
+      "source": "./plugins/metabase-to-sigma",
+      "description": "Metabase models, questions, and dashboards → Sigma data models + workbooks, with MBQL/pMBQL translation, native-SQL remodeling, controls, exact-grid layout, and parity verification. Bundles metabase-to-sigma + the read-only metabase-assessment.",
+      "category": "migration",
+      "keywords": ["metabase", "mbql", "migration", "bi"]
     }
   ]
 }

--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -60,6 +60,27 @@ jobs:
         # vendored bundle and only uses a local build via an explicit env/flag.
         run: ./corpus/converter-default-test.sh
 
+  metabase-typescript:
+    name: Metabase converter fixtures (TypeScript)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: plugins/metabase-to-sigma/skills/metabase-to-sigma/converter
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/package-lock.json
+      - name: Install locked converter tooling
+        run: npm ci
+      - name: Run Metabase fixture and contract suite
+        run: npm test
+      - name: Reject vulnerable converter dependencies
+        run: npm audit --audit-level=low
+
   ruby-free-runtime:
     name: Tableau Python runtime (Ruby absent)
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,8 @@ Maturity labels (`gold` / `live` / `foundation` / `scaffold`) are defined in
 | Author / repair Sigma data models (canonical spec) | `sigma-data-models` | live | `plugins/sigma-authoring/skills/sigma-data-models/` |
 | Convert a Streamlit source project → Sigma | `streamlit-to-sigma` | gold | `plugins/streamlit-to-sigma/skills/streamlit-to-sigma/` |
 | Scope/assess a Streamlit instance | `streamlit-assessment` | scaffold | `plugins/streamlit-to-sigma/skills/streamlit-assessment/` |
+| Convert Metabase models/questions/dashboards → Sigma | `metabase-to-sigma` | live | `plugins/metabase-to-sigma/skills/metabase-to-sigma/` |
+| Scope/assess a Metabase instance | `metabase-assessment` | live | `plugins/metabase-to-sigma/skills/metabase-assessment/` |
 
 Assessments are read-only (never write to the source or post to Sigma); run one
 to pick what to convert, then hand off to the matching converter.

--- a/corpus/README.md
+++ b/corpus/README.md
@@ -43,6 +43,7 @@ corpus/
 | sisense/ecommerce-smoke | existing Sample ECommerce model + dashboard fixtures | DM + workbook + structured gap report (checks.sh also verifies layout) |
 | streamlit/simple-retail | synthetic Streamlit-in-Workspaces Python project | static IR conversion → DM + wrapped workbook, byte-stable reconversion |
 | streamlit/retail-fulfillment-control-tower | synthetic four-page Streamlit-in-Workspaces project | deferred filters/actions, navigation, KPI/chart/table semantics, and byte-stable DM/workbook |
+| metabase/orders-overview | synthetic Metabase model + dashboard REST JSON | MBQL model + wrapped workbook with controls, native funnel, and authoritative layout |
 
 ## Runner
 

--- a/corpus/lib/corpus_check.py
+++ b/corpus/lib/corpus_check.py
@@ -66,17 +66,8 @@ def _apply_mapping(node, mapping):
         return {k: _apply_mapping(v, mapping) for k, v in node.items()}
     if isinstance(node, list):
         return [_apply_mapping(v, mapping) for v in node]
-    if isinstance(node, str):
-        if node in mapping:
-            return mapping[node]
-        # Workbook code representation embeds page/element ids inside the
-        # authoritative layout XML string. Rewrite those occurrences too or a
-        # normalized wrapped-workbook golden still changes on every conversion.
-        out = node
-        for old, new in mapping.items():
-            if old in out:
-                out = out.replace(old, new)
-        return out
+    if isinstance(node, str) and node in mapping:
+        return mapping[node]
     return node
 
 

--- a/corpus/lib/corpus_check.py
+++ b/corpus/lib/corpus_check.py
@@ -66,8 +66,17 @@ def _apply_mapping(node, mapping):
         return {k: _apply_mapping(v, mapping) for k, v in node.items()}
     if isinstance(node, list):
         return [_apply_mapping(v, mapping) for v in node]
-    if isinstance(node, str) and node in mapping:
-        return mapping[node]
+    if isinstance(node, str):
+        if node in mapping:
+            return mapping[node]
+        # Workbook code representation embeds page/element ids inside the
+        # authoritative layout XML string. Rewrite those occurrences too or a
+        # normalized wrapped-workbook golden still changes on every conversion.
+        out = node
+        for old, new in mapping.items():
+            if old in out:
+                out = out.replace(old, new)
+        return out
     return node
 
 

--- a/corpus/metabase/orders-overview/MANIFEST.md
+++ b/corpus/metabase/orders-overview/MANIFEST.md
@@ -10,11 +10,11 @@ the released wrapped/flat workbook code representation.
 ```bash
 cd plugins/metabase-to-sigma/skills/metabase-to-sigma/converter
 npm ci
-node --import tsx/esm cli.ts ../fixtures/orders-model.card.json \
+SIGMA_DETERMINISTIC_IDS=1 node --import tsx/esm cli.ts ../fixtures/orders-model.card.json \
   --metadata ../fixtures/metadata.json \
   --connection PLACEHOLDER-CONNECTION-ID --database DEMO_DB --schema DEMO \
   --envelope > /tmp/metabase-dm.json
-node --import tsx/esm cli.ts ../fixtures/exec-overview.dashboard.json \
+SIGMA_DETERMINISTIC_IDS=1 node --import tsx/esm cli.ts ../fixtures/exec-overview.dashboard.json \
   --metadata ../fixtures/metadata.json --dm PLACEHOLDER-DM-ID \
   --envelope > /tmp/metabase-workbook.json
 cd ../../../../..

--- a/corpus/metabase/orders-overview/MANIFEST.md
+++ b/corpus/metabase/orders-overview/MANIFEST.md
@@ -1,0 +1,71 @@
+# metabase / orders-overview
+
+Synthetic Metabase model and dashboard fixtures from the plugin. The case
+exercises MBQL joins, expressions, metrics, FK relationships, dashboard tabs,
+controls, exact 24-column layout, KPI/cartesian/pie/pivot/funnel elements, and
+the released wrapped/flat workbook code representation.
+
+## Converter
+
+```bash
+cd plugins/metabase-to-sigma/skills/metabase-to-sigma/converter
+npm ci
+node --import tsx/esm cli.ts ../fixtures/orders-model.card.json \
+  --metadata ../fixtures/metadata.json \
+  --connection PLACEHOLDER-CONNECTION-ID --database DEMO_DB --schema DEMO \
+  --envelope > /tmp/metabase-dm.json
+node --import tsx/esm cli.ts ../fixtures/exec-overview.dashboard.json \
+  --metadata ../fixtures/metadata.json --dm PLACEHOLDER-DM-ID \
+  --envelope > /tmp/metabase-workbook.json
+cd ../../../../..
+python3 corpus/lib/corpus_check.py normalize /tmp/metabase-dm.json \
+  corpus/metabase/orders-overview/golden/data-model.json
+python3 corpus/lib/corpus_check.py normalize /tmp/metabase-workbook.json \
+  corpus/metabase/orders-overview/golden/workbook.json
+```
+
+## Features exercised
+
+- A curated model with a warehouse-table join, calculated columns, metric, FK
+  relationship, and derived relationship view.
+- A wrapped workbook with metadata-only pages, flat elements, hidden Data
+  page, and authoritative canonical `<Page>`/`<Element>` layout.
+- Current `columnId` pointers for KPI, pie, pivot shelves, and funnel channels.
+- Two controls wired through hidden base tables, ordered after their targets.
+- Unsupported behavior remains explicit: click behavior and a relative
+  date-range default warn instead of being guessed.
+
+## Expectations
+
+```json
+{
+  "artifacts": [
+    {"path": "../../../plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/orders-model.card.json", "format": "json"},
+    {"path": "../../../plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/exec-overview.dashboard.json", "format": "json"},
+    {"path": "../../../plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/metadata.json", "format": "json"},
+    {"path": "checks.sh", "format": "text"},
+    {"path": "check_workbook.py", "format": "text"}
+  ],
+  "goldens": {
+    "data-model.json": {
+      "pages": 1,
+      "elements": 4,
+      "columns": 36,
+      "metrics": 1,
+      "relationships": 1,
+      "warnings": 0,
+      "element_names": ["Order Fact", "Customer Dim", "Orders Model", "Order Fact View"],
+      "metric_names": ["Total Revenue"],
+      "relationship_names": ["CUSTOMER_DIM"]
+    },
+    "workbook.json": {
+      "pages": 3,
+      "elements": 13,
+      "columns": 22,
+      "metrics": 0,
+      "relationships": 0,
+      "warnings": 3
+    }
+  }
+}
+```

--- a/corpus/metabase/orders-overview/check_workbook.py
+++ b/corpus/metabase/orders-overview/check_workbook.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Behavioral pins for the Metabase workbook corpus golden."""
+
+import json
+import pathlib
+import re
+
+HERE = pathlib.Path(__file__).resolve().parent
+raw = json.loads((HERE / "golden" / "workbook.json").read_text(encoding="utf-8"))
+workbook = raw["workbook"]
+doc = workbook["document"]
+elements = doc["elements"]
+
+assert doc["kind"] == "workbook"
+assert all("elements" not in page for page in doc["pages"])
+assert any(page.get("name") == "Data" and page.get("visibility") == "hidden"
+           for page in doc["pages"])
+
+layout = doc["layout"]
+assert "<Page " in layout and "<Element " in layout
+assert "<LayoutElement" not in layout and "<GridContainer" not in layout
+positioned = re.findall(r'<Element\b[^>]*\belementId="([^"]+)"', layout)
+declared = [element["id"] for element in elements]
+assert sorted(positioned) == sorted(declared)
+assert len(positioned) == len(set(positioned))
+
+by_kind = {}
+for element in elements:
+    by_kind.setdefault(element["kind"], []).append(element)
+
+pie = by_kind["pie-chart"][0]
+assert set(pie["value"]) == {"columnId"}
+assert set(pie["color"]) >= {"columnId"}
+
+pivot = by_kind["pivot-table"][0]
+assert pivot["rowsBy"] and pivot["columnsBy"]
+assert all(set(item) >= {"columnId"} and "id" not in item
+           for item in pivot["rowsBy"] + pivot["columnsBy"])
+assert all(isinstance(value, str) for value in pivot["values"])
+
+funnel = by_kind["funnel-chart"][0]
+assert set(funnel["stage"]) == {"columnId"}
+assert set(funnel["series"]) == {"columnId"}
+
+index = {element["id"]: i for i, element in enumerate(elements)}
+for control in by_kind["control"]:
+    for target in control.get("filters", []):
+        assert index[target["source"]["elementId"]] < index[control["id"]]
+
+print("metabase workbook code-representation checks: PASS")

--- a/corpus/metabase/orders-overview/check_workbook.py
+++ b/corpus/metabase/orders-overview/check_workbook.py
@@ -21,7 +21,7 @@ assert "<Page " in layout and "<Element " in layout
 assert "<LayoutElement" not in layout and "<GridContainer" not in layout
 positioned = re.findall(r'<Element\b[^>]*\belementId="([^"]+)"', layout)
 declared = [element["id"] for element in elements]
-assert sorted(positioned) == sorted(declared)
+assert len(positioned) == len(declared)
 assert len(positioned) == len(set(positioned))
 
 by_kind = {}

--- a/corpus/metabase/orders-overview/checks.sh
+++ b/corpus/metabase/orders-overview/checks.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+python3 check_workbook.py

--- a/corpus/metabase/orders-overview/golden/data-model.json
+++ b/corpus/metabase/orders-overview/golden/data-model.json
@@ -1,0 +1,324 @@
+{
+  "dataModel": {
+    "name": "DEMO_DB Snowflake",
+    "schemaVersion": 1,
+    "pages": [
+      {
+        "id": "id0001",
+        "name": "Page 1",
+        "elements": [
+          {
+            "id": "id0002",
+            "kind": "table",
+            "name": "Order Fact",
+            "source": {
+              "connectionId": "PLACEHOLDER-CONNECTION-ID",
+              "kind": "warehouse-table",
+              "path": [
+                "DEMO_DB",
+                "DEMO",
+                "ORDER_FACT"
+              ]
+            },
+            "columns": [
+              {
+                "id": "inode-NORM0003/ORDER_NUMBER",
+                "formula": "[ORDER_FACT/Order Number]"
+              },
+              {
+                "id": "inode-NORM0004/ORDER_DATE",
+                "formula": "[ORDER_FACT/Order Date]"
+              },
+              {
+                "id": "inode-NORM0005/SALES_AMOUNT",
+                "formula": "[ORDER_FACT/Sales Amount]"
+              },
+              {
+                "id": "inode-NORM0006/QUANTITY",
+                "formula": "[ORDER_FACT/Quantity]"
+              },
+              {
+                "id": "inode-NORM0007/DISCOUNT_AMOUNT",
+                "formula": "[ORDER_FACT/Discount Amount]"
+              },
+              {
+                "id": "inode-NORM0008/CUSTOMER_KEY",
+                "formula": "[ORDER_FACT/Customer Key]"
+              },
+              {
+                "id": "inode-NORM0009/ORDER_STORE_KEY",
+                "formula": "[ORDER_FACT/Order Store Key]"
+              }
+            ],
+            "order": [
+              "inode-NORM0003/ORDER_NUMBER",
+              "inode-NORM0004/ORDER_DATE",
+              "inode-NORM0005/SALES_AMOUNT",
+              "inode-NORM0006/QUANTITY",
+              "inode-NORM0007/DISCOUNT_AMOUNT",
+              "inode-NORM0008/CUSTOMER_KEY",
+              "inode-NORM0009/ORDER_STORE_KEY"
+            ],
+            "relationships": [
+              {
+                "id": "id0010",
+                "name": "CUSTOMER_DIM",
+                "targetElementId": "id0011",
+                "keys": [
+                  {
+                    "sourceColumnId": "inode-NORM0008/CUSTOMER_KEY",
+                    "targetColumnId": "inode-NORM0012/CUSTOMER_KEY"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "id0011",
+            "kind": "table",
+            "name": "Customer Dim",
+            "source": {
+              "connectionId": "PLACEHOLDER-CONNECTION-ID",
+              "kind": "warehouse-table",
+              "path": [
+                "DEMO_DB",
+                "DEMO",
+                "CUSTOMER_DIM"
+              ]
+            },
+            "columns": [
+              {
+                "id": "inode-NORM0012/CUSTOMER_KEY",
+                "formula": "[CUSTOMER_DIM/Customer Key]"
+              },
+              {
+                "id": "inode-NORM0013/FIRST_NAME",
+                "formula": "[CUSTOMER_DIM/First Name]"
+              },
+              {
+                "id": "inode-NORM0014/LAST_NAME",
+                "formula": "[CUSTOMER_DIM/Last Name]"
+              },
+              {
+                "id": "inode-NORM0015/LOYALTY_TIER",
+                "formula": "[CUSTOMER_DIM/Loyalty Tier]"
+              },
+              {
+                "id": "inode-NORM0016/REGION",
+                "formula": "[CUSTOMER_DIM/Region]"
+              }
+            ],
+            "order": [
+              "inode-NORM0012/CUSTOMER_KEY",
+              "inode-NORM0013/FIRST_NAME",
+              "inode-NORM0014/LAST_NAME",
+              "inode-NORM0015/LOYALTY_TIER",
+              "inode-NORM0016/REGION"
+            ]
+          },
+          {
+            "id": "id0017",
+            "kind": "table",
+            "name": "Orders Model",
+            "source": {
+              "kind": "join",
+              "name": "ORDER_FACT",
+              "connectionId": "PLACEHOLDER-CONNECTION-ID",
+              "joins": [
+                {
+                  "left": {
+                    "kind": "warehouse-table",
+                    "connectionId": "PLACEHOLDER-CONNECTION-ID",
+                    "path": [
+                      "DEMO_DB",
+                      "DEMO",
+                      "ORDER_FACT"
+                    ]
+                  },
+                  "right": {
+                    "kind": "warehouse-table",
+                    "connectionId": "PLACEHOLDER-CONNECTION-ID",
+                    "path": [
+                      "DEMO_DB",
+                      "DEMO",
+                      "CUSTOMER_DIM"
+                    ]
+                  },
+                  "joinType": "left-outer",
+                  "columns": [
+                    {
+                      "left": "[Customer Key]",
+                      "right": "[Customer Key]"
+                    }
+                  ],
+                  "name": "CUSTOMER_DIM"
+                }
+              ]
+            },
+            "columns": [
+              {
+                "id": "inode-NORM0018/ORDER_NUMBER",
+                "formula": "[ORDER_FACT/Order Number]"
+              },
+              {
+                "id": "inode-NORM0019/ORDER_DATE",
+                "formula": "[ORDER_FACT/Order Date]"
+              },
+              {
+                "id": "inode-NORM0020/SALES_AMOUNT",
+                "formula": "[ORDER_FACT/Sales Amount]"
+              },
+              {
+                "id": "inode-NORM0021/QUANTITY",
+                "formula": "[ORDER_FACT/Quantity]"
+              },
+              {
+                "id": "inode-NORM0022/DISCOUNT_AMOUNT",
+                "formula": "[ORDER_FACT/Discount Amount]"
+              },
+              {
+                "id": "inode-NORM0023/CUSTOMER_KEY",
+                "formula": "[ORDER_FACT/Customer Key]"
+              },
+              {
+                "id": "inode-NORM0024/ORDER_STORE_KEY",
+                "formula": "[ORDER_FACT/Order Store Key]"
+              },
+              {
+                "id": "inode-NORM0025/FIRST_NAME",
+                "formula": "[CUSTOMER_DIM/First Name]"
+              },
+              {
+                "id": "inode-NORM0026/LAST_NAME",
+                "formula": "[CUSTOMER_DIM/Last Name]"
+              },
+              {
+                "id": "inode-NORM0027/LOYALTY_TIER",
+                "formula": "[CUSTOMER_DIM/Loyalty Tier]"
+              },
+              {
+                "id": "inode-NORM0028/REGION",
+                "formula": "[CUSTOMER_DIM/Region]"
+              },
+              {
+                "id": "id0029",
+                "name": "Net Amount",
+                "formula": "([Sales Amount] - [Discount Amount])"
+              },
+              {
+                "id": "id0030",
+                "name": "Tier Bucket",
+                "formula": "If(([Loyalty Tier] = \"GOLD\" or [Loyalty Tier] = \"PLATINUM\"), \"Premium\", \"Standard\")"
+              }
+            ],
+            "order": [
+              "inode-NORM0018/ORDER_NUMBER",
+              "inode-NORM0019/ORDER_DATE",
+              "inode-NORM0020/SALES_AMOUNT",
+              "inode-NORM0021/QUANTITY",
+              "inode-NORM0022/DISCOUNT_AMOUNT",
+              "inode-NORM0023/CUSTOMER_KEY",
+              "inode-NORM0024/ORDER_STORE_KEY",
+              "inode-NORM0025/FIRST_NAME",
+              "inode-NORM0026/LAST_NAME",
+              "inode-NORM0027/LOYALTY_TIER",
+              "inode-NORM0028/REGION",
+              "id0029",
+              "id0030"
+            ],
+            "metrics": [
+              {
+                "id": "id0031",
+                "name": "Total Revenue",
+                "formula": "Sum([Sales Amount])",
+                "format": {
+                  "kind": "number",
+                  "formatString": "$,.2f",
+                  "currencySymbol": "$"
+                }
+              }
+            ]
+          },
+          {
+            "id": "id0032",
+            "kind": "table",
+            "name": "Order Fact View",
+            "source": {
+              "kind": "table",
+              "elementId": "id0002"
+            },
+            "columns": [
+              {
+                "id": "id0033",
+                "formula": "[Order Fact/Order Number]"
+              },
+              {
+                "id": "id0034",
+                "formula": "[Order Fact/Order Date]"
+              },
+              {
+                "id": "id0035",
+                "formula": "[Order Fact/Sales Amount]"
+              },
+              {
+                "id": "id0036",
+                "formula": "[Order Fact/Quantity]"
+              },
+              {
+                "id": "id0037",
+                "formula": "[Order Fact/Discount Amount]"
+              },
+              {
+                "id": "id0038",
+                "formula": "[Order Fact/Customer Key]"
+              },
+              {
+                "id": "id0039",
+                "formula": "[Order Fact/Order Store Key]"
+              },
+              {
+                "id": "id0040",
+                "formula": "[Order Fact/CUSTOMER_DIM/First Name]"
+              },
+              {
+                "id": "id0041",
+                "formula": "[Order Fact/CUSTOMER_DIM/Last Name]"
+              },
+              {
+                "id": "id0042",
+                "formula": "[Order Fact/CUSTOMER_DIM/Loyalty Tier]"
+              },
+              {
+                "id": "id0043",
+                "formula": "[Order Fact/CUSTOMER_DIM/Region]"
+              }
+            ],
+            "order": [
+              "id0033",
+              "id0034",
+              "id0035",
+              "id0036",
+              "id0037",
+              "id0038",
+              "id0039",
+              "id0040",
+              "id0041",
+              "id0042",
+              "id0043"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "warnings": [],
+  "stats": {
+    "cards": 1,
+    "elements": 4,
+    "sqlElements": 0,
+    "controls": 0,
+    "columns": 36,
+    "metrics": 1,
+    "relationships": 1
+  }
+}

--- a/corpus/metabase/orders-overview/golden/workbook.json
+++ b/corpus/metabase/orders-overview/golden/workbook.json
@@ -1,0 +1,424 @@
+{
+  "workbook": {
+    "name": "Exec Overview",
+    "document": {
+      "schemaVersion": 1,
+      "kind": "workbook",
+      "pages": [
+        {
+          "id": "id0001",
+          "name": "Overview"
+        },
+        {
+          "id": "id0002",
+          "name": "Detail"
+        },
+        {
+          "id": "id0003",
+          "name": "Data",
+          "visibility": "hidden"
+        }
+      ],
+      "elements": [
+        {
+          "id": "id0004",
+          "kind": "text",
+          "name": "Text",
+          "body": "## Executive Overview\nKey order metrics for DEMO_DB. Filters apply across the page."
+        },
+        {
+          "id": "id0005",
+          "kind": "kpi-chart",
+          "name": "Total Revenue",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0006",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0008",
+              "name": "Sum of Sales Amount",
+              "formula": "Sum([id0006/Sales Amount])",
+              "format": {
+                "kind": "number",
+                "formatString": "$,.0f",
+                "currencySymbol": "$"
+              }
+            }
+          ],
+          "order": [
+            "id0008"
+          ],
+          "value": {
+            "columnId": "id0008"
+          }
+        },
+        {
+          "id": "id0009",
+          "kind": "line-chart",
+          "name": "Revenue Trend",
+          "source": {
+            "kind": "table",
+            "elementId": "id0010"
+          },
+          "columns": [
+            {
+              "id": "id0011",
+              "name": "Order Date",
+              "formula": "DateTrunc(\"month\", [Revenue Trend Base/Order Date])"
+            },
+            {
+              "id": "id0012",
+              "name": "Sum of Sales Amount",
+              "formula": "Sum([Revenue Trend Base/Sales Amount])"
+            }
+          ],
+          "order": [
+            "id0011",
+            "id0012"
+          ],
+          "xAxis": {
+            "columnId": "id0011"
+          },
+          "yAxis": {
+            "columnIds": [
+              "id0012"
+            ]
+          }
+        },
+        {
+          "id": "id0013",
+          "kind": "bar-chart",
+          "name": "Customers by Region",
+          "source": {
+            "kind": "table",
+            "elementId": "id0014"
+          },
+          "columns": [
+            {
+              "id": "id0015",
+              "name": "Region",
+              "formula": "[Customers by Region Base/Region]"
+            },
+            {
+              "id": "id0016",
+              "name": "Count",
+              "formula": "Count()"
+            }
+          ],
+          "order": [
+            "id0015",
+            "id0016"
+          ],
+          "xAxis": {
+            "columnId": "id0015"
+          },
+          "yAxis": {
+            "columnIds": [
+              "id0016"
+            ]
+          }
+        },
+        {
+          "id": "id0017",
+          "kind": "bar-chart",
+          "name": "Customers by Loyalty Tier",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0018",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0019",
+              "name": "Loyalty Tier",
+              "formula": "[id0018/Loyalty Tier]"
+            },
+            {
+              "id": "id0020",
+              "name": "Count",
+              "formula": "Count()"
+            }
+          ],
+          "order": [
+            "id0019",
+            "id0020"
+          ],
+          "xAxis": {
+            "columnId": "id0019"
+          },
+          "yAxis": {
+            "columnIds": [
+              "id0020"
+            ]
+          },
+          "orientation": "horizontal"
+        },
+        {
+          "id": "id0021",
+          "kind": "pie-chart",
+          "name": "Stores by State",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0022",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0023",
+              "name": "State",
+              "formula": "[id0022/State]"
+            },
+            {
+              "id": "id0024",
+              "name": "Count",
+              "formula": "Count()"
+            }
+          ],
+          "order": [
+            "id0023",
+            "id0024"
+          ],
+          "color": {
+            "columnId": "id0023"
+          },
+          "value": {
+            "columnId": "id0024"
+          }
+        },
+        {
+          "id": "id0025",
+          "kind": "pivot-table",
+          "name": "id0026",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0026",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0027",
+              "name": "Region",
+              "formula": "[id0026/Region]"
+            },
+            {
+              "id": "id0028",
+              "name": "Loyalty Tier",
+              "formula": "[id0026/Loyalty Tier]"
+            },
+            {
+              "id": "id0029",
+              "name": "Sum of Sales Amount",
+              "formula": "Sum([id0026/Sales Amount])"
+            }
+          ],
+          "order": [
+            "id0027",
+            "id0028",
+            "id0029"
+          ],
+          "rowsBy": [
+            {
+              "columnId": "id0027"
+            }
+          ],
+          "columnsBy": [
+            {
+              "columnId": "id0028"
+            }
+          ],
+          "values": [
+            "id0029"
+          ]
+        },
+        {
+          "id": "id0030",
+          "kind": "funnel-chart",
+          "name": "Tier Funnel",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0018",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0031",
+              "name": "Loyalty Tier",
+              "formula": "[id0018/Loyalty Tier]"
+            },
+            {
+              "id": "id0032",
+              "name": "Count",
+              "formula": "Count()"
+            }
+          ],
+          "order": [
+            "id0031",
+            "id0032"
+          ],
+          "stage": {
+            "columnId": "id0031"
+          },
+          "series": {
+            "columnId": "id0032"
+          }
+        },
+        {
+          "id": "id0033",
+          "kind": "table",
+          "name": "id0034",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0034",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0035",
+              "name": "Order Number",
+              "formula": "[id0034/Order Number]"
+            },
+            {
+              "id": "id0036",
+              "name": "Sales Amount",
+              "formula": "[id0034/Sales Amount]"
+            },
+            {
+              "id": "id0037",
+              "name": "Net Amount",
+              "formula": "[id0034/Net Amount]"
+            },
+            {
+              "id": "id0038",
+              "name": "Tier Bucket",
+              "formula": "[id0034/Tier Bucket]"
+            },
+            {
+              "id": "id0039",
+              "name": "Filter: id0034",
+              "formula": "[id0034/Tier Bucket] = \"Premium\"",
+              "hidden": true
+            }
+          ],
+          "order": [
+            "id0035",
+            "id0036",
+            "id0037",
+            "id0038"
+          ],
+          "filters": [
+            {
+              "id": "id0040",
+              "columnId": "id0039",
+              "kind": "list",
+              "mode": "include",
+              "values": [
+                true
+              ]
+            }
+          ]
+        },
+        {
+          "id": "id0010",
+          "kind": "table",
+          "name": "Revenue Trend Base",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0006",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0041",
+              "name": "Order Date",
+              "formula": "[id0006/Order Date]"
+            },
+            {
+              "id": "id0042",
+              "name": "Sales Amount",
+              "formula": "[id0006/Sales Amount]"
+            }
+          ],
+          "order": [
+            "id0041",
+            "id0042"
+          ]
+        },
+        {
+          "id": "id0014",
+          "kind": "table",
+          "name": "Customers by Region Base",
+          "source": {
+            "kind": "data-model",
+            "elementId": "id0018",
+            "dataModelId": "id0007"
+          },
+          "columns": [
+            {
+              "id": "id0043",
+              "name": "Region",
+              "formula": "[id0018/Region]"
+            }
+          ],
+          "order": [
+            "id0043"
+          ]
+        },
+        {
+          "id": "id0044",
+          "kind": "control",
+          "controlId": "date_range",
+          "name": "Date",
+          "controlType": "date-range",
+          "mode": "between",
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "id0010"
+              },
+              "columnId": "id0041"
+            }
+          ]
+        },
+        {
+          "id": "id0045",
+          "kind": "control",
+          "controlId": "region",
+          "name": "Region",
+          "controlType": "list",
+          "filters": [
+            {
+              "source": {
+                "kind": "table",
+                "elementId": "id0014"
+              },
+              "columnId": "id0043"
+            }
+          ]
+        }
+      ],
+      "layout": "<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0001\">\n  <Element elementId=\"id0044\" gridColumn=\"1 / 13\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"id0045\" gridColumn=\"13 / 25\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"id0004\" gridColumn=\"1 / 25\" gridRow=\"3 / 7\"/>\n  <Element elementId=\"id0005\" gridColumn=\"1 / 6\" gridRow=\"7 / 15\"/>\n  <Element elementId=\"id0009\" gridColumn=\"6 / 16\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"id0013\" gridColumn=\"16 / 25\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"id0017\" gridColumn=\"1 / 13\" gridRow=\"19 / 31\"/>\n  <Element elementId=\"id0021\" gridColumn=\"13 / 25\" gridRow=\"19 / 31\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0002\">\n  <Element elementId=\"id0025\" gridColumn=\"1 / 15\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"id0030\" gridColumn=\"15 / 25\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"id0033\" gridColumn=\"1 / 25\" gridRow=\"17 / 33\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0003\">\n  <Element elementId=\"id0010\" gridColumn=\"1 / 25\" gridRow=\"1 / 13\"/>\n  <Element elementId=\"id0014\" gridColumn=\"1 / 25\" gridRow=\"13 / 25\"/>\n</Page>"
+    }
+  },
+  "warnings": [
+    "parameter \"Date\": range default \"past30days\" has no verified Sigma spec shape — control emitted WITHOUT a default; set it in the UI.",
+    "card \"Customers by Region\": click_behavior (cross-filter / link) is not converted — re-create as a Sigma action.",
+    "card \"id0034\" sources nested card 100 — no card-name mapping; sourced its OWN DM element by card name (the DM converter creates one per nested card). Pass cardNameById to source the parent model instead."
+  ],
+  "stats": {
+    "dashcards": 9,
+    "pages": 3,
+    "tables": 1,
+    "pivots": 1,
+    "kpis": 1,
+    "charts": 5,
+    "maps": 0,
+    "texts": 1,
+    "columns": 19,
+    "filters": 1,
+    "controls": 2,
+    "baseTables": 2
+  }
+}

--- a/corpus/metabase/orders-overview/golden/workbook.json
+++ b/corpus/metabase/orders-overview/golden/workbook.json
@@ -39,7 +39,7 @@
             {
               "id": "id0008",
               "name": "Sum of Sales Amount",
-              "formula": "Sum([id0006/Sales Amount])",
+              "formula": "Sum([Order Fact/Sales Amount])",
               "format": {
                 "kind": "number",
                 "formatString": "$,.0f",
@@ -133,7 +133,7 @@
             {
               "id": "id0019",
               "name": "Loyalty Tier",
-              "formula": "[id0018/Loyalty Tier]"
+              "formula": "[Customer Dim/Loyalty Tier]"
             },
             {
               "id": "id0020",
@@ -168,7 +168,7 @@
             {
               "id": "id0023",
               "name": "State",
-              "formula": "[id0022/State]"
+              "formula": "[Store Dim/State]"
             },
             {
               "id": "id0024",
@@ -200,17 +200,17 @@
             {
               "id": "id0027",
               "name": "Region",
-              "formula": "[id0026/Region]"
+              "formula": "[Revenue by Region and Tier/Region]"
             },
             {
               "id": "id0028",
               "name": "Loyalty Tier",
-              "formula": "[id0026/Loyalty Tier]"
+              "formula": "[Revenue by Region and Tier/Loyalty Tier]"
             },
             {
               "id": "id0029",
               "name": "Sum of Sales Amount",
-              "formula": "Sum([id0026/Sales Amount])"
+              "formula": "Sum([Revenue by Region and Tier/Sales Amount])"
             }
           ],
           "order": [
@@ -245,7 +245,7 @@
             {
               "id": "id0031",
               "name": "Loyalty Tier",
-              "formula": "[id0018/Loyalty Tier]"
+              "formula": "[Customer Dim/Loyalty Tier]"
             },
             {
               "id": "id0032",
@@ -277,27 +277,27 @@
             {
               "id": "id0035",
               "name": "Order Number",
-              "formula": "[id0034/Order Number]"
+              "formula": "[Premium Orders/Order Number]"
             },
             {
               "id": "id0036",
               "name": "Sales Amount",
-              "formula": "[id0034/Sales Amount]"
+              "formula": "[Premium Orders/Sales Amount]"
             },
             {
               "id": "id0037",
               "name": "Net Amount",
-              "formula": "[id0034/Net Amount]"
+              "formula": "[Premium Orders/Net Amount]"
             },
             {
               "id": "id0038",
               "name": "Tier Bucket",
-              "formula": "[id0034/Tier Bucket]"
+              "formula": "[Premium Orders/Tier Bucket]"
             },
             {
               "id": "id0039",
-              "name": "Filter: id0034",
-              "formula": "[id0034/Tier Bucket] = \"Premium\"",
+              "name": "Filter: Premium Orders",
+              "formula": "[Premium Orders/Tier Bucket] = \"Premium\"",
               "hidden": true
             }
           ],
@@ -332,12 +332,12 @@
             {
               "id": "id0041",
               "name": "Order Date",
-              "formula": "[id0006/Order Date]"
+              "formula": "[Order Fact/Order Date]"
             },
             {
               "id": "id0042",
               "name": "Sales Amount",
-              "formula": "[id0006/Sales Amount]"
+              "formula": "[Order Fact/Sales Amount]"
             }
           ],
           "order": [
@@ -358,7 +358,7 @@
             {
               "id": "id0043",
               "name": "Region",
-              "formula": "[id0018/Region]"
+              "formula": "[Customer Dim/Region]"
             }
           ],
           "order": [
@@ -399,13 +399,13 @@
           ]
         }
       ],
-      "layout": "<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0001\">\n  <Element elementId=\"id0044\" gridColumn=\"1 / 13\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"id0045\" gridColumn=\"13 / 25\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"id0004\" gridColumn=\"1 / 25\" gridRow=\"3 / 7\"/>\n  <Element elementId=\"id0005\" gridColumn=\"1 / 6\" gridRow=\"7 / 15\"/>\n  <Element elementId=\"id0009\" gridColumn=\"6 / 16\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"id0013\" gridColumn=\"16 / 25\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"id0017\" gridColumn=\"1 / 13\" gridRow=\"19 / 31\"/>\n  <Element elementId=\"id0021\" gridColumn=\"13 / 25\" gridRow=\"19 / 31\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0002\">\n  <Element elementId=\"id0025\" gridColumn=\"1 / 15\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"id0030\" gridColumn=\"15 / 25\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"id0033\" gridColumn=\"1 / 25\" gridRow=\"17 / 33\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"id0003\">\n  <Element elementId=\"id0010\" gridColumn=\"1 / 25\" gridRow=\"1 / 13\"/>\n  <Element elementId=\"id0014\" gridColumn=\"1 / 25\" gridRow=\"13 / 25\"/>\n</Page>"
+      "layout": "<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"M000000011\">\n  <Element elementId=\"M000000001\" gridColumn=\"1 / 13\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"M000000002\" gridColumn=\"13 / 25\" gridRow=\"1 / 3\"/>\n  <Element elementId=\"M000000003\" gridColumn=\"1 / 25\" gridRow=\"3 / 7\"/>\n  <Element elementId=\"M000000005\" gridColumn=\"1 / 6\" gridRow=\"7 / 15\"/>\n  <Element elementId=\"M000000008\" gridColumn=\"6 / 16\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"M00000000e\" gridColumn=\"16 / 25\" gridRow=\"7 / 19\"/>\n  <Element elementId=\"M00000000j\" gridColumn=\"1 / 13\" gridRow=\"19 / 31\"/>\n  <Element elementId=\"M00000000m\" gridColumn=\"13 / 25\" gridRow=\"19 / 31\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"M000000012\">\n  <Element elementId=\"M00000000q\" gridColumn=\"1 / 15\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"M00000000t\" gridColumn=\"15 / 25\" gridRow=\"1 / 17\"/>\n  <Element elementId=\"M00000000y\" gridColumn=\"1 / 25\" gridRow=\"17 / 33\"/>\n</Page>\n<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"dataM000000013\">\n  <Element elementId=\"M00000000b\" gridColumn=\"1 / 25\" gridRow=\"1 / 13\"/>\n  <Element elementId=\"M00000000g\" gridColumn=\"1 / 25\" gridRow=\"13 / 25\"/>\n</Page>"
     }
   },
   "warnings": [
     "parameter \"Date\": range default \"past30days\" has no verified Sigma spec shape — control emitted WITHOUT a default; set it in the UI.",
     "card \"Customers by Region\": click_behavior (cross-filter / link) is not converted — re-create as a Sigma action.",
-    "card \"id0034\" sources nested card 100 — no card-name mapping; sourced its OWN DM element by card name (the DM converter creates one per nested card). Pass cardNameById to source the parent model instead."
+    "card \"Premium Orders\" sources nested card 100 — no card-name mapping; sourced its OWN DM element by card name (the DM converter creates one per nested card). Pass cardNameById to source the parent model instead."
   ],
   "stats": {
     "dashcards": 9,

--- a/docs/phase-schema.md
+++ b/docs/phase-schema.md
@@ -207,3 +207,20 @@ Streamlit uses local phase numbering aligned directly to the canonical arc:
 | C8 Parity hard gate | Phase 6 — warehouse/Sigma values, control flips, page/overlay PNGs, `assert-phase6-ran.rb` |
 | C9 Security/RLS | Security section — static detection always, acknowledge/apply explicitly |
 | C10 Enhance | — foundation release defers shared Phase E wiring |
+
+### metabase-to-sigma
+
+Metabase keeps the standalone skill's established local numbering:
+
+| Canonical | metabase-to-sigma |
+|---|---|
+| C1 Assess | `metabase-assessment` skill (read-only inventory, coverage scoring, and shortlist) |
+| C2 Discover | Phase 0 — Metabase REST discovery (cards/models, dashboards, database metadata, and sandbox policies) |
+| C3 Reuse-check | Phase 1.5 — DM signature + `find-or-pick-dm.rb` before creating a new model |
+| C4 Convert | Phase 1 — MBQL/pMBQL cards and models → Sigma data-model spec |
+| C5 Post-DM gate | Phase 2 — POST the data model, read back real element/column ids, and fail on error-typed columns |
+| C6 Build workbook | Phase 3 — dashboard → wrapped workbook document wired to read-back DM ids |
+| C7 Layout | within Phase 3 — complete 24-column layout on create; `apply-layout.mjs` preserves the full document as the LAST write |
+| C8 Parity hard gate | Phase 4 — live Metabase values vs Sigma/warehouse, control flip test, visual check, and `assert-phase6-ran.rb` |
+| C9 Security/RLS | Security section — detect Metabase sandboxing always; port to Sigma user attributes only after explicit review |
+| C10 Enhance | — shared Phase E is not wired in this release |

--- a/plugins/metabase-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/metabase-to-sigma/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "metabase-to-sigma",
+  "displayName": "Metabase → Sigma",
+  "version": "0.1.0",
+  "description": "Migrate Metabase models, questions, and dashboards to Sigma data models and workbooks. Translates MBQL/pMBQL, remodels compatible native SQL, preserves controls and grid layout, verifies parity, and bundles a read-only estate assessment.",
+  "author": {
+    "name": "Thomas Wells"
+  },
+  "license": "MIT",
+  "keywords": [
+    "metabase",
+    "mbql",
+    "sigma",
+    "migration",
+    "bi",
+    "converter"
+  ],
+  "skills": "./skills/"
+}

--- a/plugins/metabase-to-sigma/.claude-plugin/plugin.json
+++ b/plugins/metabase-to-sigma/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "metabase-to-sigma",
   "displayName": "Metabase → Sigma",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Migrate Metabase models, questions, and dashboards to Sigma data models and workbooks. Translates MBQL/pMBQL, remodels compatible native SQL, preserves controls and grid layout, verifies parity, and bundles a read-only estate assessment.",
   "author": {
     "name": "Thomas Wells"

--- a/plugins/metabase-to-sigma/.gitignore
+++ b/plugins/metabase-to-sigma/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+*.log
+.DS_Store
+__pycache__/
+workdir-*/
+**/workdir-*/
+probe-artifacts.jsonl
+posted-workbooks.jsonl
+offramps.jsonl

--- a/plugins/metabase-to-sigma/README.md
+++ b/plugins/metabase-to-sigma/README.md
@@ -1,0 +1,77 @@
+# metabase-to-sigma
+
+Migration plugin for moving **Metabase** (open source or Pro/EE) to
+**Sigma**, in the same format and phase structure as the
+[sigma-migration-skills](https://github.com/twells89/sigma-migration-skills)
+converters (Tableau, Power BI, Qlik, ThoughtSpot, QuickSight, Looker, Cognos).
+Graduated from the standalone `metabase-to-sigma` repository at source commit
+`43df3fd`; this monorepo plugin is now the maintained marketplace copy.
+
+## Status: live-validated converter and assessment
+
+Discovery, extraction, and coverage scoring were validated against a large
+Metabase Cloud estate. The build path was validated end to end against a local
+Metabase instance and a live Sigma organization with exact query parity across
+models, nested questions, charts, controls, and layout.
+
+The imported converter now emits Sigma's released workbook code representation
+(`document` wrapper, flat elements, metadata-only pages, authoritative layout,
+and `columnId` channel pointers). That updated payload is covered by offline
+tests and corpus goldens; run the mandatory live POST/readback/parity/PNG gates
+for each migration.
+
+**The self-serve validation loop (no vendor gating — Metabase is OSS):**
+
+```bash
+# 1. Run Metabase locally, pointed at a Sigma-reachable warehouse (e.g. Snowflake)
+docker run -d -p 3000:3000 --name metabase metabase/metabase
+# → Admin → add the warehouse database; build a model + dashboard on real tables
+
+# 2. Extract → convert → post → parity (Phases 0–4 in the skill)
+# 3. Diff real API payloads against refs/mbql-shapes.md; fix drift in refs first,
+#    then converter; add a fixture reproducing every discrepancy found.
+```
+
+## What's in the box
+
+| Skill | What it does |
+|---|---|
+| [`skills/metabase-to-sigma`](skills/metabase-to-sigma/SKILL.md) | The converter: MBQL questions/models → Sigma data model; dashboards → wrapped Sigma workbooks. Phased (Discover → Convert → DM-reuse check → POST+readback gate → workbook wiring/layout → parity gate), with RLS (sandboxing) port flow and a gap-scout loop for unmapped expressions. |
+| [`skills/metabase-assessment`](skills/metabase-assessment/SKILL.md) | Read-only estate inventory + migration-readiness readout: bulk-fetches every card/dashboard definition via REST (7k-card estate in ~1 minute), scores each against the converter's exact coverage (auto/hint/manual/unhandled), renders a branded HTML report with an effort/wave plan. |
+
+## Quick start
+
+```bash
+# Auth (API key preferred — Metabase v49+, Admin → Settings → Authentication → API keys)
+export MB_BASE="https://<your-metabase>" MB_KEY="mb_…"
+eval "$(skills/metabase-to-sigma/scripts/get-metabase-session.sh)"
+
+# Assess the estate (read-only)
+bash skills/metabase-assessment/scripts/discover-metabase.sh --out /tmp/mb-assess
+node skills/metabase-assessment/scripts/score-coverage.mjs --in /tmp/mb-assess/specs --out /tmp/mb-assess
+node skills/metabase-assessment/scripts/render-report.mjs --out /tmp/mb-assess   # → readout.html
+
+# Migrate (see skills/metabase-to-sigma/SKILL.md for the full phase walkthrough)
+```
+
+Install the marketplace plugin or open the skill from a full repo clone, then
+ask: *"migrate my Metabase dashboard to Sigma"* / *"assess my Metabase estate."*
+
+## Design contract
+
+The conversion surface is specified in `skills/metabase-to-sigma/refs/`:
+
+- `rest-api.md` — endpoints (incl. the bulk fast path), auth (`x-api-key`), version gotchas (`dashcards` vs `ordered_cards`, …)
+- `mbql-shapes.md` — card/dashboard JSON + MBQL structures the converter parses, incl. the **pMBQL** ("lib/") format modern instances actually return
+- `expression-dsl.md` — the MBQL-op → Sigma-formula mapping table (translated vs flagged)
+- `template-tags.md` — native `{{tags}}` → Sigma controls (Sigma custom SQL uses the same `{{}}` syntax)
+- `design-notes.md` — architecture decisions + §9 first-production-contact findings + the honesty ledger of still-unverified Sigma POST shapes
+
+Core principle (shared with every sibling): **flag, never fake.** Anything
+without a clean Sigma analog (cum-sum/offset windows, segment refs, progress
+viz, object detail views, multi-stage queries, click behaviors) is surfaced as
+a loud warning with a readable placeholder — never silently wrong numbers.
+
+## License
+
+MIT

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/PRIVACY.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/PRIVACY.md
@@ -1,0 +1,58 @@
+# Metabase Assessment — privacy disclosure
+
+Share this with the customer's privacy / security reviewer before running the
+skill against a live Metabase instance.
+
+## What this skill does
+
+It issues **read-only `GET` requests** to the Metabase REST API (`/api`) to
+inventory the collection tree and fetch the definitions of models, questions
+(cards), and dashboards, then scores them locally for migration readiness and
+renders an HTML report. It **never** POSTs, modifies, runs, or deletes
+anything in Metabase — it never executes a query against the warehouse
+(`/api/card/{id}/query` and `/api/dataset` are never called) — and it never
+touches Sigma.
+
+## What enters the agent model context
+
+When a coding agent reads the fetched artifacts, their content is sent to that
+agent provider's model so the assessment can be produced:
+
+| Crosses the API | Stays in Metabase / local only |
+|---|---|
+| Aggregate counts (model / question / dashboard / collection counts) | Warehouse rows — never queried |
+| Object names, collection paths, types, `view_count` (v50+) | Database credentials (the endpoints used never return them) |
+| Card JSON: MBQL trees, **native SQL text**, custom-expression trees, viz settings | The customer's actual query *results* / result sets |
+| Dashboard JSON: grid layout, parameter definitions, click behaviors | Per-user activity history (not fetched) |
+| Database **schema** metadata: table/field names + ids (required to resolve MBQL field refs) | — |
+
+MBQL filters and **native SQL text** (which can embed business logic and
+sometimes literal threshold values, e.g. `WHERE tier = 'enterprise'`) are part
+of the definitions and do cross the API. They do not include row-level
+warehouse data.
+
+## Where outputs go
+
+The skill writes to a local directory (`/tmp/metabase-assessment-<env>/` by
+default): `inventory.json`, the fetched definitions under `specs/`, schema
+metadata under `metadata/`, `coverage.json`, and `readout.html` (plus
+`sandboxes.json` on Pro/EE instances with sandboxing policies). Nothing is
+uploaded anywhere. Sharing the readout with a Sigma rep is a deliberate action
+by the user, not automatic.
+
+## Auth handling
+
+The skill reads an API key (`MB_KEY`, sent as `x-api-key`) or a session token
+(`MB_SESSION`, sent as `X-Metabase-Session`) from environment variables the
+user sets. They are used only as request headers, are not stored, and are not
+written to any output file.
+
+## How to run it more privately
+
+- Run in **offline mode** against card/dashboard JSON files already exported
+  to disk — no live Metabase connection is made at all.
+- Personal collections are **skipped by default** (only `--include-personal`
+  pulls them in).
+- Use a session token scoped to a low-privilege account if the assessment
+  should only see a subset of collections — Metabase's own permission model
+  bounds what the walk can read.

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/README.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/README.md
@@ -1,0 +1,55 @@
+# metabase-assessment
+
+Read-only migration-readiness assessment for a Metabase instance → Sigma.
+Mirrors the `tableau-assessment` pattern: inventory the collection tree, score
+each model / question / dashboard against the **exact** coverage of the
+`metabase-to-sigma` converter, roll up an estate auto-migration %, name every
+gap, and render a branded HTML readout.
+
+```
+SKILL.md                      phased workflow (Connect → Discover → Score → Effort → Render)
+PRIVACY.md                    customer-facing data-handling disclosure
+scripts/
+  discover-metabase.sh        bulk fast path: GET /api/card (one response) + parallel dashboard GETs + db metadata → inventory.json (read-only; --walk = legacy per-collection walk)
+  mb-bulk-split.py            local splitter for the bulk card payload (stdlib-only, never networks)
+  pmbql-normalize.mjs         pMBQL ("lib/" MBQL) → legacy normalizer (synced copy of the converter's)
+  score-coverage.mjs          classify auto/hint/manual/unhandled vs. converter gaps; per-artifact + roll-up (zero-dep)
+  render-report.mjs           branded standalone readout.html (zero-dep)
+refs/
+  mb-rest.md                  endpoints + the two auth shapes used + the fast path
+  scoring-rubric.md           every gap signal → bucket → remediation + production calibration (7k-card estate)
+  usage-telemetry.md          honest take on Metabase usage stats (view_count v50+ is thin; rich audit is Pro/EE)
+fixtures/
+  101.card.json               all-auto MBQL question
+  102.card.json               cum-sum question (unhandled)
+  103.card.json               native-SQL model with a field-filter tag (hint)
+  104.card.json               pMBQL (modern "lib/" format) native question with every tag kind
+  201.dashboard.json          native funnel dashcard + click behavior (manual) + view_count
+  202.dashboard.json          pMBQL dashboard: tag-targeting parameters + object detail card
+```
+
+Discovery + scoring are **production-validated**: a 7,023-card / 1,548-dashboard
+Metabase Cloud estate (v1.61.4, 100% pMBQL) discovered in ~1 minute and scored
+97% auto-migratable. See `refs/scoring-rubric.md` § Production calibration.
+
+## Quick start (offline, against the bundled fixtures)
+
+```bash
+node scripts/score-coverage.mjs --in fixtures --out /tmp/metabase-assessment-sample
+node scripts/render-report.mjs  --out /tmp/metabase-assessment-sample
+open /tmp/metabase-assessment-sample/readout.html
+```
+
+## Live
+
+```bash
+export MB_BASE="https://<host>"        # no trailing /api
+export MB_KEY="mb_..."                 # or: export MB_SESSION="<token>"
+bash scripts/discover-metabase.sh --probe
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env>
+node scripts/score-coverage.mjs --in /tmp/metabase-assessment-<env>/specs --out /tmp/metabase-assessment-<env>
+node scripts/render-report.mjs  --out /tmp/metabase-assessment-<env>
+```
+
+Read-only and all-free. Tableau is the reference point. Not a replacement for
+a deeper hands-on engagement.

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/SKILL.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: metabase-assessment
+description: Take inventory of a Metabase instance and produce a migration-readiness readout — collection-tree counts, per-artifact conversion complexity (scored against the Metabase→Sigma converter's exact coverage), an estate-wide auto-migration percentage, a named gap analysis, and an effort/wave plan. Use when a user wants to scope a Metabase→Sigma migration, audit Metabase sprawl, or pick which models / questions / dashboards to convert first. Read-only, all-free, ~Tableau-assessment-style pre-scoping that complements (does not replace) a deeper paid engagement.
+user-invocable: true
+---
+
+# Metabase Assessment
+
+Surveys a Metabase instance (open source or Pro/EE, v46+) via its first-class
+REST API (`/api`) and produces a branded, share-friendly HTML readout plus a
+JSON inventory. The differentiator versus a generic BI audit is
+**converter-coverage scoring**: every model, question (card), and dashboard is
+classified auto-convert vs. flagged using the *same* rules the
+`metabase-to-sigma` converter (`converter/metabase.ts`, `translateMbqlExpr`)
+actually applies — so the readout's auto-migration % reflects what the tool
+will really do, not a hand-wave.
+
+> **Read-only.** This skill only issues `GET`s against the Metabase API. It
+> never POSTs, modifies, runs, or schedules anything in Metabase — and it never
+> touches Sigma. It can also run fully offline against card/dashboard JSON
+> files already on disk.
+
+> **All free.** Everything here — inventory, scoring, the HTML readout — is part
+> of the open migration tooling. There is no paid tier to upsell. For a deeper
+> hands-on engagement (permissions audit, sandboxing/RLS port, live parity
+> testing), point the customer at a Sigma SE.
+
+> **Tableau is the reference point.** This skill mirrors the structure and tone
+> of the `tableau-assessment` skill (environment counts → coverage → effort →
+> readout). If you've run that, this will feel familiar; the Metabase-specific
+> work is all in the coverage scorer.
+
+---
+
+## Privacy posture (READ FIRST, surface to the customer)
+
+**This skill reads content metadata and definitions, not warehouse data.**
+
+| Crosses the LLM API | Stays in Metabase / local |
+|---|---|
+| Aggregate counts (model / question / dashboard / collection counts) | Warehouse rows (this skill never runs a query) |
+| Object names, collection path, type, `view_count` (v50+) | Database credentials (Metabase never exposes them via these endpoints anyway) |
+| Card JSON (MBQL trees, **native SQL text**, expressions, viz settings) | The customer's actual query *results* |
+| Dashboard JSON (grid layout, parameters, click behaviors) | User PII beyond creator ids on objects |
+| Database **schema** metadata (table/field names + ids — required to resolve MBQL field refs) | — |
+
+When an agent reads these artifacts, their contents enter that agent provider's
+model context. Tell the user this before running. Outputs are written to a local
+`/tmp/metabase-assessment-<env>/` directory and uploaded nowhere — sharing is a
+deliberate action, not automatic. See `PRIVACY.md` for the full disclosure.
+
+---
+
+## When to use this skill
+
+- A Metabase customer wants a fast scoping view before committing to a migration.
+- A Sigma SE preparing for a discovery call wants a pre-built conversion shortlist.
+- A customer is deciding which Metabase questions/dashboards to retire vs. migrate.
+- A `metabase-to-sigma` conversion needs a Phase 0 inventory of the source estate.
+
+**Not for**: running live Metabase questions, extracting warehouse data, or
+making any change to the Metabase instance.
+
+---
+
+## Modes
+
+| Mode | Setup | Use when |
+|---|---|---|
+| **Live (REST)** | `MB_BASE` + (`MB_KEY` or `MB_SESSION`) env (see below) | Real estate scan against a running Metabase (OSS or Pro/EE) |
+| **Offline (files)** | A directory of `*.card.json` + `*.dashboard.json` already on disk | No live access; scoring a sample set or an export the customer mailed you |
+
+Both modes feed the same scorer + renderer. The bundled `fixtures/` let you
+validate the whole pipeline offline.
+
+---
+
+## Phase 0 — Connect / probe access
+
+Live mode needs one of two auth shapes (both are plain request headers):
+
+```bash
+export MB_BASE="https://<host>"            # no trailing /api — the script adds it
+
+# Option A (preferred, v49+): an API key from Admin → Settings → Authentication → API keys
+export MB_KEY="mb_..."                     # sent as `x-api-key`
+
+# Option B: a session token from POST /api/session {"username","password"}
+export MB_SESSION="<token>"                # sent as `X-Metabase-Session`
+
+# Cheap probe — prints the instance version, no auth strictly required:
+bash scripts/discover-metabase.sh --probe
+```
+
+If an authenticated request 401s, the session expired (sessions default to 14
+days, sooner with SSO) — re-login and re-export `MB_SESSION`, or switch to an
+API key. If an API-key request 403s, the key's **group** lacks read access to
+the collections — ask the admin for a key in a group with view rights
+(Administrators for a full scan). The discovery script surfaces a clear
+token-expiry note rather than dumping a stack trace.
+
+Offline mode needs no auth — skip straight to Phase 2 pointing the scorer at
+the file directory.
+
+---
+
+## Phase 1 — Discover the estate (live mode)
+
+```bash
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env>
+# include per-user personal collections too (skipped by default):
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env> --include-personal
+# useful caps / knobs: --concurrency 16  --max-dashboards N  --skip-cards  --walk
+```
+
+`discover-metabase.sh` uses the **bulk fast path** (production-validated: a
+7,023-card / 1,548-dashboard Metabase Cloud estate in ~1 minute — the old
+per-item walk took >1 hour on the same estate):
+
+1. `GET /api/collection` → collection names + personal flags
+2. **`GET /api/card`** — EVERY card with its full definition in ONE response
+   (~110MB for 7k cards), streamed to disk and split locally by
+   `scripts/mb-bulk-split.py` → `<out>/specs/<id>.card.json`
+3. `GET /api/dashboard` (shallow list) + **parallel** `GET /api/dashboard/{id}`
+   (default 16 concurrent, resumable) → `<out>/specs/<id>.dashboard.json`
+4. each **referenced database**, once → `GET /api/database/{id}/metadata`
+   → `<out>/metadata/<db>.metadata.json` (the integer-field-id → column map the
+   converter requires). A **403 on a scoped key is recorded, not fatal** —
+   field resolution falls back to card `result_metadata`, then
+   `GET /api/field/{id}` (works even for restricted DBs).
+
+It emits `<out>/inventory.json` =
+`{ environment: {...counts}, artifacts: [ {id,type,name,collection,view_count,specFile} ] }`.
+
+Notes baked into the script:
+- **Fallback walk** — `--walk` (or automatically when bulk `GET /api/card`
+  isn't available) uses the old paginated per-collection item walk; default
+  page size 100.
+- **Personal collections** — skipped by default (`personal_owner_id != null`);
+  `--include-personal` overrides. Personal sandboxes are usually retire-not-
+  migrate content and they dominate raw counts.
+- **Token expiry** — on a 401 it writes a `token_expired: true` flag into
+  `inventory.json` and stops gracefully so you can re-auth and re-run (already
+  fetched specs on disk are skipped — resumable).
+- **`view_count`** — recorded when the instance exposes it on card/dashboard
+  responses (**v50+**). Pre-v50 OSS exposes essentially no usage data via REST
+  (see `refs/usage-telemetry.md`); treat usage as a known gap and request the
+  Pro/EE Usage analytics export from the admin.
+- **Sandboxing (EE)** — probes `GET /api/mt/gtap` once; on Pro/EE with
+  sandboxes defined it saves `sandboxes.json` (surfaced as a needs-review
+  item); on OSS the 404 is silently ignored.
+
+---
+
+## Phase 2 — Score converter coverage (THE differentiator)
+
+```bash
+node scripts/score-coverage.mjs --in /tmp/metabase-assessment-<env>/specs --out /tmp/metabase-assessment-<env>
+# offline against the bundled fixtures:
+node scripts/score-coverage.mjs --in fixtures --out /tmp/metabase-assessment-<env>
+```
+
+For every `*.card.json` and `*.dashboard.json`, the scorer classifies features
+into four buckets — **auto / hint / manual / unhandled** — by detecting the
+*exact* gap signals the converter flags. It does NOT re-implement the
+converter; MBQL is plain JSON, so it recurses the `dataset_query` trees and
+matches op names against `translateMbqlExpr`'s translated-vs-flagged tables
+(`refs/expression-dsl.md` in the sibling converter skill). Each detected gap is
+recorded with a count **and** the specific reason + remediation.
+
+### Card signals (mirror `metabase.ts` / `expression-dsl.md`)
+
+| Bucket | Signal | Why |
+|---|---|---|
+| `auto` | MBQL table source, breakouts, translated aggregations (`count/sum/avg/min/max/median/distinct/stddev/var/percentile/count-where/sum-where/share`), translated expression & filter ops (arithmetic, `case`, `coalesce`, string fns, date fns, casts, `in`/`not-in`, comparison/`between`/`time-interval`…); native-SQL cards (→ DM `sql` element) with plain `text`/`number`/`date`/`boolean` template tags (same `{{}}` syntax in Sigma); single-rule conditional formatting; displays `table/bar/row/line/area/combo/scatter/pie/scalar/smartscalar/pivot/map/funnel/gauge/waterfall/sankey` | translated cleanly by the converter (pMBQL is normalized at intake) |
+| `hint` | nested-card source (`source-table: "card__N"`); `dimension`-type **field-filter** template tags; `{{#card}}` tags; optional `[[…]]` SQL blocks; explicit MBQL `joins` | convert fine, but review (source ordering, control wiring, join fan-out) |
+| `manual` | `binning` opts on a breakout (numeric histogram); `["segment", id]` / legacy `["metric", id]` refs (definitions live in other objects — inline needed); `click_behavior`; `snippet` template tags; gradient/range conditional formatting; `object` detail views; multi-stage queries | converter passes through + warns; brief re-creation in Sigma |
+| `unhandled` | `cum-sum` / `cum-count` / `offset` aggregations (window scope lives on the consuming element); `progress` display; sandboxing policies (EE); any unmapped MBQL op | converter emits a flagged placeholder + loud warning |
+
+### Dashboard signals
+
+| Bucket | Signal | Why |
+|---|---|---|
+| `auto` | dashcards whose card `display` is supported (24-col grid maps 1:1 to Sigma); text/heading virtual cards (markdown passes through); `parameters` → Sigma controls; `tabs` → workbook pages | converter emits clean elements |
+| `manual` | `click_behavior` on a dashcard (cross-filter / drill link) | re-implement as a Sigma action |
+| `unhandled` | dashcards whose card `display` is `progress` | data preserved as a flagged table; choose an approved replacement |
+
+### Output
+
+`<out>/coverage.json` — per artifact:
+`{ id, type, name, n_features, n_auto, n_hint, n_manual, n_unhandled, complexity, gaps:[{signal,count,bucket,reason,remediation}], view_count, uses_cards, value, cost, score, tag }`
+plus an estate roll-up: `{ pct_auto_migratable, gap_histogram, by_complexity, by_tag, totals, usage_available }`.
+
+Scoring (same framework as every `*-assessment` skill):
+`cost = 10·n_unhandled + 3·n_manual + 1·n_hint`;
+`value = 10 × view_count` when the instance exposes `view_count` on
+cards/dashboards (v50+), else `10 × n_features` (proxy — see usage-telemetry ref);
+`score = value / (1 + cost)`.
+Complexity: `n_unhandled>0 → high`; else `n_manual>0 → medium`; else `low`.
+Tags: `n_unhandled≥1 → needs-review`; `(manual+unhandled)==0 → migrate-first`;
+`score≥10 → easy-win`; else `moderate`.
+
+---
+
+## Phase 3 — Effort / wave plan
+
+The scorer's roll-up feeds a simple wave plan (computed in `render-report.mjs`):
+
+- **Wave 1 — migrate-first / easy-win.** Low-complexity models + questions +
+  dashboards, no unhandled features. These are the pilot.
+- **Wave 2 — moderate.** Medium complexity (manual setup, no unhandled) —
+  convert with light review.
+- **Wave 3 — needs-review.** Any artifact with an unhandled feature: a
+  cumulative/offset calc, a progress viz, a sandboxing
+  policy. Each needs a human decision before conversion.
+
+**Models migrate before the dashboards (and questions) that use them** — a
+question sourced from `card__N` and a dashboard's dashcards both point at the
+migrated model's DM element. The dependency is detectable from each card's
+`dataset_query.source-table` (`card__N` refs) and each dashboard's dashcard
+`card_id`s; the scorer records it as `uses_cards` and the renderer sequences
+models ahead of dependents within each wave.
+
+---
+
+## Phase 4 — Render the HTML readout
+
+```bash
+node scripts/render-report.mjs --out /tmp/metabase-assessment-<env>
+# → writes /tmp/metabase-assessment-<env>/readout.html
+```
+
+Reads `inventory.json` (if present) + `coverage.json` and emits a standalone,
+brand-styled `readout.html` (~6 sections, Sigma palette, print-friendly):
+
+1. **Executive summary** — estate size, auto-migration %, headline finding.
+2. **Estate inventory** — counts by type, artifact table (with views when v50+).
+3. **Coverage & auto-migration** — auto/hint/manual/unhandled breakdown, % auto.
+4. **Gap analysis** — named artifacts + the specific gap + why + remediation.
+5. **Effort / wave plan** — the 3 waves, models sequenced before dependents.
+6. **Next steps** — pilot recommendation, what to request from the admin.
+
+All-free framing throughout; no paid upsell.
+
+---
+
+## Phase 5 — Hand off (optional)
+
+After the readout, you can hand the shortlist to the `metabase-to-sigma`
+converter skill for the migrate-first artifacts. The coverage JSON's
+per-artifact `specFile` points the converter straight at the card/dashboard
+JSON it already fetched — and `metadata/<db>.metadata.json` is exactly the
+`--metadata` file the converter requires for field-id resolution. No
+re-discovery.
+
+> Do not auto-convert. Surface the shortlist and let the user choose.
+
+---
+
+## Scripts overview
+
+| Script | Purpose |
+|---|---|
+| `scripts/discover-metabase.sh` | Bulk fast path: `GET /api/card` (all definitions in one response, split locally) + `GET /api/dashboard` list + parallel per-dashboard GETs + per-database schema metadata, emit `inventory.json`. Production-validated: 7k-card estate in ~1 minute. Auth via `MB_KEY` (x-api-key) or `MB_SESSION`. Read-only, resumable, token-expiry aware, skips personal collections by default; `--walk` = legacy per-collection walk. |
+| `scripts/mb-bulk-split.py` | Local companion (stdlib-only): splits the bulk card payload into per-card specs, builds artifact records + `databases.txt`, filters dashboard fetch lists (resumable). Never talks to the network. |
+| `scripts/pmbql-normalize.mjs` | pMBQL ("lib/" MBQL) → legacy MBQL normalizer (byte-identical copy of the converter's — the converter test suite guards the sync). |
+| `scripts/score-coverage.mjs` | Classify every card/dashboard auto/hint/manual/unhandled against the converter's exact gap signals by walking the (normalized) MBQL JSON trees; per-artifact complexity + estate roll-up. Production-validated on 8,571 artifacts. |
+| `scripts/render-report.mjs` | Emit the branded standalone `readout.html`. Zero-dependency. |
+
+## Refs
+
+| Ref | Contents |
+|---|---|
+| `refs/mb-rest.md` | The Metabase REST endpoints this skill uses + the two auth shapes. |
+| `refs/scoring-rubric.md` | Every gap signal, what it means, which bucket, and the remediation text shown in the readout. |
+| `refs/usage-telemetry.md` | Honest investigation of Metabase usage stats: `view_count` (v50+) and `/api/activity/recents` are thin; rich audit is Pro/EE "Usage analytics"; pre-v50 OSS has essentially nothing. |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `discover-metabase.sh --probe` fails | `MB_BASE` wrong / instance unreachable | Probe hits `GET /api/session/properties` — verify the base URL (no trailing `/api`) |
+| Authenticated requests 401 | `MB_SESSION` expired (14-day default, sooner with SSO) | Re-login (`POST /api/session`) and re-export, or switch to an API key (`MB_KEY`) |
+| API-key requests 403 | The key's **group** lacks collection read permissions | Ask the admin for a key in a group with view access (Administrators for a full scan) |
+| `inventory.json` has `token_expired: true` | Auth died mid-walk | Re-auth, re-run — on-disk specs are skipped (resumable) |
+| `score-coverage.mjs` finds 0 artifacts | `--in` points at the wrong dir | Point at the `specs/` dir (live) or `fixtures/` (offline) |
+| Dashboard scores 0 dashcards | Pre-v48 instance returns `ordered_cards` (with `sizeX/sizeY`), not `dashcards` | The scorer handles both shapes — if counts still look wrong, check the raw JSON for a third variant |
+| `view_count` all blank / value falls back to feature counts | Instance is pre-v50 (OSS exposes no view counts before that) | Expected — see `refs/usage-telemetry.md`; request the Pro/EE Usage analytics export from the admin |
+| Personal-collection content missing from the inventory | Skipped by default | Re-run with `--include-personal` |

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/101.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/101.card.json
@@ -1,0 +1,32 @@
+{
+  "id": 101,
+  "name": "Revenue by Month",
+  "description": "Clean MBQL question — everything translates automatically.",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": 45,
+  "type": "question",
+  "display": "line",
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "aggregation": [
+        ["sum", ["field", 72, null]],
+        ["count"]
+      ],
+      "breakout": [["field", 80, { "temporal-unit": "month" }]],
+      "filter": ["=", ["field", 81, null], "Widget", "Gadget"]
+    }
+  },
+  "result_metadata": [
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, { "temporal-unit": "month" }] },
+    { "name": "sum", "display_name": "Sum of Total", "base_type": "type/Float" },
+    { "name": "count", "display_name": "Count", "base_type": "type/Integer" }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["CREATED_AT"],
+    "graph.metrics": ["sum", "count"]
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/102.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/102.card.json
@@ -1,0 +1,30 @@
+{
+  "id": 102,
+  "name": "Cumulative Revenue",
+  "description": "Uses cum-sum — the converter flags it (window scope lives on the consuming element).",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": 45,
+  "type": "question",
+  "display": "line",
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "expressions": {
+        "Profit": ["-", ["field", 72, null], ["field", 73, null]]
+      },
+      "aggregation": [["cum-sum", ["field", 72, null]]],
+      "breakout": [["field", 80, { "temporal-unit": "month" }]]
+    }
+  },
+  "result_metadata": [
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, { "temporal-unit": "month" }] },
+    { "name": "cum-sum", "display_name": "Cumulative sum of Total", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["CREATED_AT"],
+    "graph.metrics": ["cum-sum"]
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/103.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/103.card.json
@@ -1,0 +1,27 @@
+{
+  "id": 103,
+  "name": "Orders Cleaned (model)",
+  "description": "Native-SQL model with one plain text tag (auto) and one dimension field-filter tag (hint).",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": null,
+  "type": "model",
+  "display": "table",
+  "dataset_query": {
+    "type": "native",
+    "database": 2,
+    "native": {
+      "query": "SELECT * FROM ORDERS WHERE STATUS = {{status}} AND {{date_range}}",
+      "template-tags": {
+        "status": { "name": "status", "display-name": "Status", "type": "text", "default": "completed" },
+        "date_range": { "name": "date_range", "display-name": "Date Range", "type": "dimension", "widget-type": "date/range", "dimension": ["field", 80, null] }
+      }
+    }
+  },
+  "result_metadata": [
+    { "name": "ID", "display_name": "ID", "base_type": "type/BigInteger" },
+    { "name": "TOTAL", "display_name": "Total", "base_type": "type/Float" },
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime" }
+  ],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/104.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/104.card.json
@@ -1,0 +1,43 @@
+{
+  "id": 401,
+  "name": "Filtered Revenue (pMBQL Native + Tags)",
+  "description": "Modern-format native card with every template-tag kind: text + number variables, a dimension field filter (pMBQL field clause), a card ref, and an optional [[…]] block. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM DEMO_DB.DEMO.ORDER_FACT o\nJOIN DEMO_DB.DEMO.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}} AND o.QUANTITY >= {{min_qty}} [[AND c.LOYALTY_TIER = {{tier}}]]\n  AND o.ORDER_NUMBER IN (SELECT ORDER_NUMBER FROM {{#400-daily-revenue}})\nGROUP BY 1",
+        "template-tags": {
+          "region": {
+            "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+          },
+          "min_qty": {
+            "id": "tt2", "name": "min_qty", "display-name": "Min Quantity", "type": "number", "default": 1
+          },
+          "order_date": {
+            "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+            "widget-type": "date/range", "required": false,
+            "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]
+          },
+          "tier": {
+            "id": "tt4", "name": "tier", "display-name": "Loyalty Tier", "type": "text"
+          },
+          "#400-daily-revenue": {
+            "id": "tt5", "name": "#400-daily-revenue", "display-name": "#400 Daily Revenue", "type": "card", "card-id": 400
+          }
+        }
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/201.dashboard.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/201.dashboard.json
@@ -1,0 +1,42 @@
+{
+  "id": 201,
+  "name": "Executive Overview",
+  "description": "One supported line dashcard, one native funnel, a text card, a parameter, and a click behavior (manual).",
+  "collection_id": 5,
+  "view_count": 240,
+  "parameters": [
+    { "id": "abc123", "name": "Date", "slug": "date", "type": "date/range", "default": "past30days" }
+  ],
+  "tabs": [{ "id": 1, "name": "Overview" }],
+  "dashcards": [
+    {
+      "id": 1,
+      "card_id": 101,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "dashboard_tab_id": 1,
+      "card": { "id": 101, "name": "Revenue by Month", "display": "line" },
+      "parameter_mappings": [
+        { "parameter_id": "abc123", "card_id": 101, "target": ["dimension", ["field", 80, null]] }
+      ],
+      "visualization_settings": {}
+    },
+    {
+      "id": 2,
+      "card_id": 104,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "dashboard_tab_id": 1,
+      "card": { "id": 104, "name": "Order Funnel", "display": "funnel" },
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "click_behavior": { "type": "link", "linkType": "url", "linkTemplate": "https://example.com/orders/{{ID}}" }
+      }
+    },
+    {
+      "id": 3,
+      "card_id": null,
+      "row": 6, "col": 0, "size_x": 24, "size_y": 2,
+      "dashboard_tab_id": 1,
+      "visualization_settings": { "virtual_card": { "display": "text" }, "text": "## Orders KPIs" }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/202.dashboard.json
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/fixtures/202.dashboard.json
@@ -1,0 +1,131 @@
+{
+  "id": 500,
+  "name": "Regional Ops (pMBQL)",
+  "description": "Modern-format dashboard: parameters targeting native template tags (variable + field-filter), a pMBQL dimension target, conditional formatting, series_settings renames, and an object-detail card. Synthetic.",
+  "collection_id": 5,
+  "parameters": [
+    { "id": "p1", "name": "Region", "slug": "region_param", "type": "string/=", "default": "West" },
+    { "id": "p2", "name": "Order Window", "slug": "order_window", "type": "date/range" },
+    { "id": "p3", "name": "Order Date", "slug": "order_date_param", "type": "date/all-options" }
+  ],
+  "tabs": [],
+  "dashcards": [
+    {
+      "id": 9001,
+      "card_id": 401,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 401, "target": ["variable", ["template-tag", "region"]] },
+        { "parameter_id": "p3", "card_id": 401, "target": ["dimension", ["template-tag", "order_date"], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "table.column_formatting": [
+          { "columns": ["REVENUE"], "type": "single", "operator": ">", "value": 10000, "color": "#22c55e", "highlight_row": false },
+          { "columns": ["REVENUE"], "type": "range", "colors": ["#ffffff", "#509ee3"], "min_type": null, "max_type": null }
+        ]
+      },
+      "card": {
+        "id": 401,
+        "name": "Filtered Revenue (pMBQL Native + Tags)",
+        "display": "table",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/native",
+              "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE FROM DEMO_DB.DEMO.ORDER_FACT o JOIN DEMO_DB.DEMO.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY WHERE c.REGION = {{region}} AND {{order_date}} GROUP BY 1",
+              "template-tags": {
+                "region": { "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West" },
+                "order_date": {
+                  "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+                  "widget-type": "date/range",
+                  "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime" }, 71]
+                }
+              }
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+          { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9002,
+      "card_id": 402,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 402, "target": ["dimension", ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000d001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "series_settings": { "total_revenue": { "title": "Revenue ($)", "color": "#88BF4D" } }
+      },
+      "card": {
+        "id": 402,
+        "name": "Weekly Orders by Region (pMBQL)",
+        "display": "bar",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/mbql",
+              "source-table": 45,
+              "aggregation": [
+                ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+                ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+                  ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float" }, 72]]
+              ],
+              "breakout": [
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71]
+              ]
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+          { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9003,
+      "card_id": 406,
+      "row": 6, "col": 0, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {},
+      "card": {
+        "id": 406,
+        "name": "Order Record",
+        "display": "object",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 45 }]
+        },
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", 70, null] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9004,
+      "card_id": null,
+      "row": 6, "col": 8, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Ops Notes\nSynthetic markdown block."
+      }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/refs/mb-rest.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/refs/mb-rest.md
@@ -1,0 +1,45 @@
+# Metabase REST endpoints used by metabase-assessment
+
+All read-only `GET`s against the first-class public API (`<host>/api/...`) —
+works on open source and Pro/EE alike, v46+. Auth is one plain header, either:
+
+| Method | Header | Notes |
+|---|---|---|
+| **API key** (preferred, v49+) | `x-api-key: $MB_KEY` | Admin → Settings → Authentication → API keys. Durable. A 403 means the key's **group** lacks collection read perms — ask for a key in a group with view access (Administrators for a full scan). |
+| **Session token** | `X-Metabase-Session: $MB_SESSION` | From `POST /api/session {"username","password"}`. Expires (14-day default, sooner with SSO) — on 401 re-login and re-run (the walk is resumable). |
+
+## Fast path (default — production-validated, 7k-card estate in ~1 minute)
+
+The per-item collection walk took **>1 hour** on a 7,023-card / 1,548-dashboard
+Metabase Cloud estate. The rewritten `discover-metabase.sh` uses bulk endpoints:
+
+| Need | Endpoint | Notes |
+|---|---|---|
+| Probe / version | `GET /api/session/properties` | `version.tag` — works without auth; tells you whether `view_count` will exist (v50+) |
+| Collection tree | `GET /api/collection?archived=false` | flat list; `personal_owner_id != null` (or `is_personal`) = personal space — skipped by default → `<out>/collections.json` |
+| **ALL cards (bulk)** | `GET /api/card` | EVERY card **with its full definition** in one response (~110MB for 7k cards) — streamed to disk, split locally by `mb-bulk-split.py split-cards` into `<out>/specs/{id}.card.json` + `databases.txt`. Falls back to the legacy walk if unavailable |
+| Dashboard list | `GET /api/dashboard` | shallow list `{id, name, collection_id, archived}` → `<out>/dashboards.list.json` |
+| **Dashboard defs (parallel)** | `GET /api/dashboard/{id}` | ~16 concurrent, resumable (on-disk specs skipped), `--max-dashboards N` to cap; `dashcards[]` (⚠ pre-v48: `ordered_cards[]`) + `parameters[]` + `tabs[]` + `view_count` (v50+) → `<out>/specs/{id}.dashboard.json` |
+| **Schema metadata** | `GET /api/database/{id}/metadata` | once per referenced database → `<out>/metadata/{id}.metadata.json`. **403 on scoped keys is recorded, not fatal** — fallback chain below |
+| Field-id fallback | `GET /api/field/{id}` | when metadata 403s: card `result_metadata` first, then this endpoint (**worked even for restricted DBs on the reference estate**), then names from the SQL when native |
+| Sandboxing probe (EE) | `GET /api/mt/gtap` | Pro/EE only — 404 on OSS (silently ignored); non-empty array → `sandboxes.json`, surfaced as needs-review |
+| Recent views (thin) | `GET /api/activity/recents` | not used for ranking — see `usage-telemetry.md` |
+
+Legacy walk (`--walk`, or automatic fallback): `GET
+/api/collection/{id}/items?models=card&models=dashboard&models=dataset&limit=100&offset=N`
+per collection, then per-item GETs — keep for pre-bulk instances only.
+
+Format note: modern instances (Cloud v1.61+) return `dataset_query` in
+**pMBQL** (`{"lib/type":"mbql/query","stages":[…]}`); the scorer normalizes via
+`pmbql-normalize.mjs` at intake. Sniff the `lib/type` key per card — a list may
+mix formats across versions.
+
+## What is NOT available here
+
+- **Per-artifact usage history** (views over time, per-user reach) — `view_count`
+  (v50+) is a lifetime counter only; rich audit is the Pro/EE "Usage analytics"
+  collection. Pre-v50 OSS has essentially nothing. See `usage-telemetry.md`.
+- **Serialization export** (`/api/ee/serialization/export`, YAML bundles) is
+  Pro/EE-only — this skill never depends on it; the REST walk above works on OSS.
+- **Warehouse data** — this skill never calls `/api/card/{id}/query` or
+  `/api/dataset`; definitions only, never results.

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/refs/scoring-rubric.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/refs/scoring-rubric.md
@@ -1,0 +1,105 @@
+# Metabase→Sigma coverage scoring rubric
+
+`score-coverage.mjs` classifies every feature into one of four buckets by
+detecting the **exact** signals the `metabase-to-sigma` converter
+(`converter/metabase.ts`, `translateMbqlExpr`) acts on. It does not re-run the
+converter; it mirrors what the converter translates cleanly vs. flags. MBQL is
+already-parsed JSON, so the scorer recurses the `dataset_query` trees and
+matches op names — no regex DSL parsing. Each detected gap is recorded with a
+count, the reason, and the remediation shown in the readout.
+
+## Buckets
+
+| Bucket | Meaning | Converter behavior |
+|---|---|---|
+| **auto** | Converts cleanly, zero touch | emitted directly (table source, breakout, aggregation, expression, chart, control, sql element) |
+| **hint** | Converts, but review one thing (no logic rebuild) | converts; a sequencing/wiring/fan-out check (nested card, field filter, join) |
+| **manual** | Brief re-creation in Sigma | converter passes through + warns; you rebuild it by hand |
+| **unhandled** | No clean Sigma analog — needs a human design decision | converter emits a flagged placeholder + a loud warning (never silent, never guessed) |
+
+## Cost / value / tag (same framework as every `*-assessment` skill)
+
+- `cost  = 10·n_unhandled + 3·n_manual + 1·n_hint`
+- `value = 10 · view_count` when the instance exposes `view_count` on cards/dashboards (**v50+**); else `10 · n_features` *(proxy — see `usage-telemetry.md`)*
+- `score = value / (1 + cost)`
+- complexity: `n_unhandled>0 → high`; else `n_manual>0 → medium`; else `low`
+- tag: `n_unhandled≥1 → needs-review`; else `(manual+unhandled)==0 → migrate-first`; else `score≥10 → easy-win`; else `moderate`
+- `pct_auto_migratable = (n_auto + n_hint) / n_features` — hint is a review, not rework, so it counts as auto-migratable.
+
+## Card signals (from `metabase.ts` / the converter's `expression-dsl.md`)
+
+| Signal | Bucket | Reason | Remediation |
+|---|---|---|---|
+| table source (`source-table: <int>`) | auto | → the model/DM element for the warehouse table | — |
+| breakout (no binning) | auto | → Sigma grouping / chart axis (`temporal-unit` → `DateTrunc`) | — |
+| translated aggregation — `count/sum/avg/min/max/median/distinct/stddev/var/percentile/count-where/sum-where/share` (+ `aggregation-options` name wrapper) | auto | → `Sum/Avg/CountIf/SumIf/Percentile/…` via `translateMbqlExpr` | — |
+| translated expression/filter op — arithmetic, `case`, `coalesce`, `concat`, string fns (`substring/trim/upper/lower/length/replace/regex-match-first/split-part`), math (`round/floor/ceil/abs/sqrt/exp/power/log`), date fns (`datetime-add/-subtract/-diff`, `get-*`, `now`, `relative-datetime`), comparisons, `between`, `is-null/not-null/is-empty/not-empty`, `starts-with/ends-with/contains/does-not-contain`, `time-interval`, `inside` | auto | maps via `translateMbqlExpr` (multi-value `=` → `Or` chain — Sigma has no `IsIn`) | — |
+| native SQL card | auto | the SQL text → a Sigma Custom SQL (`sql`) element verbatim | — |
+| plain template tag (`type: text/number/date`) | auto | → a Sigma `=`-parameter control | — |
+| supported display — `table/bar/row/line/area/combo/scatter/pie/scalar/smartscalar/trend/pivot/map/funnel/gauge/waterfall/sankey` | auto | → native Sigma table/chart/pivot/KPI/map element | — (note: the `smartscalar`/`trend` auto "vs previous period" comparison line is a manual follow-up — the KPI value itself converts) |
+| nested-card source (`source-table: "card__N"`) | hint | built on another saved card (usually a model) | converts to an element sourced from card N's element — sequence the source card first; recorded in `uses_cards` for the wave plan |
+| field-filter template tag (`type: dimension`) | hint | the tag expands to a whole WHERE clause at runtime | becomes a Sigma control on the target column + an element filter — verify widget type + default |
+| nested-card template tag (`{{#N}}`, `type: card`) | hint | inlines another saved question as a sub-query | sequence the referenced card first |
+| explicit MBQL `joins` | hint | converts to a Sigma DM `join` source | review fan-out (row multiplication) before trusting aggregates — same risk as in Metabase |
+| `binning` opts on a breakout | manual | numeric histogram buckets | recreate with `BinFixed()`/`BinCount()` in the consuming workbook element |
+| `["segment", id]` ref | manual | definition lives in another object | inline the segment's MBQL filter (`GET /api/segment/{id}`) |
+| `["metric", id]` ref (legacy) | manual | definition lives in another object | inline the metric's aggregation (`GET /api/legacy-metric/{id}`) |
+| `click_behavior` (top-level or per-column) | manual | cross-filter / drill link | re-implement as a Sigma action |
+| snippet template tag (`type: snippet`) | manual | splices a shared SQL snippet | inline the snippet text into the Custom SQL |
+| optional `[[…]]` SQL block | hint | Metabase includes it only when the tag has a value; Sigma has no optional-clause syntax | field-filter/default-carrying blocks stay active; others are dropped (Metabase's empty-value behavior) with a loud warning — review each |
+| conditional formatting — `single` rule | auto | threshold rule → Sigma `conditionalFormats` entry | — |
+| conditional formatting — gradient/`range` scale | manual | backgroundScale spec shape not live-verified | recreate in the Sigma UI |
+| `object` display (record detail) | manual | single-record detail view | flagged table; recreate detail with element filters / drill |
+| multi-stage query (pMBQL `stages`>1 / `source-query`) | manual | a sub-query, not a flat card | rebuild as chained Sigma elements; converter flags + skips |
+| `cum-sum` / `cum-count` / `offset` | unhandled | running-total / lag window — the window scope lives on the consuming element | rebuild with `CumulativeSum` / `Lag` in the date-grouped workbook element (proven pattern); converter emits a flagged placeholder |
+| display `progress` | unhandled | no faithful native Sigma mapping is verified | data preserved as a flagged table; choose an explicitly approved replacement |
+| unmapped MBQL op | unhandled | no confirmed Sigma mapping | translate by hand; converter emits `/* unmapped: <op> */` + a loud warning |
+| sandboxing policy (EE, from `sandboxes.json`) | unhandled | GTAP row-level security per group | port to Sigma user attributes + DM filters via the shared RLS engine (`apply_sigma_rls.py`) — opt-in, reviewed per policy |
+
+## Dashboard signals
+
+| Signal | Bucket | Reason | Remediation |
+|---|---|---|---|
+| dashcard with a supported card display | auto | 24-col grid → Sigma's 24-col layout 1:1 | — |
+| text/heading card (`card_id: null` + `virtual_card`) | auto | markdown → Sigma text element | — |
+| `parameters[]` | auto | → Sigma controls (+ `parameter_mappings` → per-card filter targets) | — |
+| `tabs[]` | auto | → workbook pages | — |
+| `click_behavior` on a dashcard | manual | cross-filter / drill link | re-implement as a Sigma action |
+| dashcard with display `progress` | unhandled | no faithful native Sigma mapping is verified | flagged table; choose an approved replacement |
+
+Both `dashcards[]` (v48+, `size_x/size_y`) and legacy `ordered_cards[]`
+(`sizeX/sizeY`) shapes are accepted.
+
+## Production calibration (a 7k-card production estate, 2026-06)
+
+First production run of this scorer — Metabase Cloud v1.61.4, 7,023 cards /
+12 models / 1,548 dashboards (8,571 artifacts), 100% pMBQL. Results to sanity-
+check your own runs against:
+
+- The historical run reported **97% auto-migratable** under the June coverage
+  catalog. Funnel, gauge, waterfall, and sankey were then counted unhandled;
+  the current scorer correctly counts them as native/auto, so rescore the
+  source estate before quoting an exact current percentage.
+- tags: **migrate-first 8,039 · easy-win 272 · needs-review 183 · moderate 77**
+- display histogram (cards): table 2999 · bar 1604 · line 1176 · combo 449 ·
+  scalar 259 · pie 135 · row 130 · funnel 83 · area 67 · pivot 39 · object 37 ·
+  waterfall 15 · sankey 13 · gauge 11 · scatter 3 · progress 3. Current
+  coverage converts funnel/waterfall/sankey/gauge natively; progress remains
+  flagged and object remains a manual detail-table route.
+- 45% of cards carry template tags; 53% of dashboards carry parameters; 17%
+  use tabs; `view_count` available (usage-based value path exercised)
+
+## Calibrating against the bundled fixtures
+
+Running against `fixtures/` (4 cards + 2 dashboards) must produce all four buckets:
+
+- **Revenue by Month** (101) — all-auto MBQL (sum/count, month breakout, multi-value `=` filter, line) → `migrate-first`, low.
+- **Cumulative Revenue** (102) — `cum-sum` → `needs-review`, high (the `-` Profit expression still scores auto).
+- **Orders Cleaned (model)** (103) — native SQL model; `{{status}}` text tag auto, `{{date_range}}` dimension field filter → 1 **hint**; `migrate-first`, low.
+- **Executive Overview** (201) — funnel dashcard → **auto/native**; a
+  `click_behavior` → **manual**; parameter/tab/line/text → auto; `view_count:
+  240` exercises the usage-based value path.
+- **Filtered Revenue (pMBQL Native + Tags)** (104) — modern `lib/type` format: plain tags auto, field-filter + card tags + optional block → **hints**; `migrate-first`.
+- **Regional Ops (pMBQL)** (202) — pMBQL dashboard: parameters auto, object dashcard → **manual**.
+
+If those don't show up, the scorer regressed.

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/refs/usage-telemetry.md
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/refs/usage-telemetry.md
@@ -1,0 +1,55 @@
+# Usage telemetry on Metabase — an honest investigation
+
+The universal weak spot of every BI migration assessment is **usage**: which
+content is actually viewed, so you can rank a migration shortlist by audience
+value and confidently retire dead content. Here is what Metabase does — and
+does not — expose, and what to do about it.
+
+## What the OSS REST surface gives you (it's thin)
+
+1. **`view_count` (v50+).** Card and dashboard API responses carry a lifetime
+   `view_count` integer. This is the best free signal and the scorer uses it
+   directly: `value = 10 · view_count` when present. But it is a **lifetime
+   counter** — no time series, no per-user breakdown, no "viewed this quarter".
+   A dashboard viewed 5,000 times in 2022 and never since looks identical to a
+   daily driver.
+2. **`GET /api/activity/recents`.** The "recently viewed" list for the calling
+   user — a handful of items, no counts, no history. Useful as a sniff test
+   ("is anything here even touched?"), useless for ranking. The discovery
+   script does not rank on it.
+3. **Pre-v50 OSS: essentially nothing.** No `view_count`, no audit endpoints.
+   The scorer falls back to `value = 10 · n_features` (a size proxy), and the
+   readout says so plainly — the shortlist is ranked by conversion effort, not
+   popularity.
+
+## Where the rich usage data actually lives (Pro/EE)
+
+Metabase Pro/EE ships **"Usage analytics"** — an instance-level analytics
+collection (formerly "Audit tools") backed by the app DB's `view_log` /
+`audit_log`: views **over time**, **per-user** activity, dashboard/question
+usage rankings, unused-content reports. That is exactly the series a migration
+ranking wants. It is:
+
+- **Pro/EE only** — not available on OSS at any version.
+- Accessed in-product (the Usage analytics collection) — an admin can export
+  the relevant questions to CSV in a few clicks.
+- Backed by application-DB tables (`view_log`, `audit_log`) that a
+  self-hosting admin *can* query directly, but that's unsupported surface —
+  prefer the in-product export.
+
+## Recommendation (what the readout tells the user)
+
+> **v50+ instance:** the shortlist is already ranked by `view_count`. Still
+> ask the admin for the Pro/EE Usage analytics export (views over time,
+> per-user reach) before retiring anything — a lifetime counter can't
+> distinguish "popular once" from "popular now".
+>
+> **Pre-v50 / OSS without view counts:** request a usage export from the
+> Metabase admin — either the Pro/EE Usage analytics CSVs, or (self-hosted) a
+> read-only query against the app DB's `view_log`. Until then the shortlist is
+> ranked by conversion effort, not popularity, and the readout says so.
+
+If/when the admin provides a usage CSV (`item_id, item_type, views,
+distinct_users, last_viewed`), the scorer's `value` term can be upgraded to
+`views · sqrt(distinct_users)` — the same value formula the Tableau and Qlik
+assessments use — without changing anything else in the pipeline.

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/discover-metabase.sh
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/discover-metabase.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Metabase estate discovery — read-only inventory walk for the
+# metabase-assessment skill.
+#
+# Auth (one of):
+#   export MB_BASE="https://<host>"        # no trailing /api — added here
+#   export MB_KEY="mb_..."                 # API key (v49+)  → x-api-key header
+#   export MB_SESSION="<token>"            # session token   → X-Metabase-Session header
+#
+# Usage:
+#   discover-metabase.sh --probe
+#       Cheap check — GET /api/session/properties, prints the instance version.
+#   discover-metabase.sh --out <dir> [--include-personal] [--concurrency N]
+#                        [--max-dashboards N] [--skip-cards] [--walk] [--page N]
+#       FAST PATH (default — production-validated on a 7k-card / 1.5k-dashboard
+#       estate, ~1 minute vs >1 hour for the old per-item walk):
+#         1. GET /api/card        — ALL card definitions in ONE response
+#                                   (~110MB for 7k cards; streamed to disk, then
+#                                   split locally by mb-bulk-split.py)
+#         2. GET /api/dashboard   — the dashboard list, then PARALLEL
+#                                   per-dashboard GETs (default 16 concurrent,
+#                                   resumable: on-disk specs are skipped)
+#         3. GET /api/database/{id}/metadata once per referenced database
+#            (403 on scoped keys is recorded, not fatal — the converter falls
+#             back to card result_metadata, then GET /api/field/{id})
+#       --walk forces the legacy per-collection item walk (also the automatic
+#       fallback when the bulk card endpoint is unavailable).
+#
+# READ-ONLY: only ever issues GETs. Never POSTs / modifies / runs anything.
+# Resumable (already-downloaded specs are skipped), 401-aware (writes
+# token_expired:true into inventory.json and exits gracefully).
+# Personal collections are skipped by default (--include-personal to override).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+OUT=""
+PROBE=0
+PAGE=100
+INCLUDE_PERSONAL=0
+CONC=16
+MAX_DASH=""
+SKIP_CARDS=0
+WALK=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --probe) PROBE=1; shift ;;
+    --out)   OUT="$2"; shift 2 ;;
+    --page)  PAGE="$2"; shift 2 ;;
+    --concurrency) CONC="$2"; shift 2 ;;
+    --max-dashboards) MAX_DASH="$2"; shift 2 ;;
+    --skip-cards) SKIP_CARDS=1; shift ;;
+    --walk) WALK=1; shift ;;
+    --include-personal) INCLUDE_PERSONAL=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${MB_BASE:?set MB_BASE (e.g. https://metabase.example.com — no trailing /api)}"
+MB_BASE="${MB_BASE%/}"
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+
+# Pick the auth header: MB_KEY (x-api-key) wins, else MB_SESSION.
+AUTH_NAME=""; AUTH_VALUE=""
+if [ -n "${MB_KEY:-}" ]; then
+  AUTH_NAME="x-api-key"; AUTH_VALUE="$MB_KEY"
+elif [ -n "${MB_SESSION:-}" ]; then
+  AUTH_NAME="X-Metabase-Session"; AUTH_VALUE="$MB_SESSION"
+elif [ "$PROBE" = "0" ]; then
+  echo "set MB_KEY (API key) or MB_SESSION (session token)" >&2; exit 2
+fi
+
+# req <path-with-leading-slash> — body lands in $RESP, status in $HTTP_CODE.
+# NOT command-substituted (a subshell would lose HTTP_CODE); curl -o keeps the
+# body and the status code separate, so no fragile tail-line parsing either.
+RESP=$(mktemp); trap 'rm -f "$RESP"' EXIT
+HTTP_CODE=""
+TOKEN_EXPIRED=0
+req() {
+  : > "$RESP"
+  if [ -n "$AUTH_NAME" ]; then
+    HTTP_CODE=$(curl -s -o "$RESP" -w '%{http_code}' "$MB_BASE$1" \
+      -H 'Accept: application/json' -H "$AUTH_NAME: $AUTH_VALUE" || echo "000")
+  else
+    HTTP_CODE=$(curl -s -o "$RESP" -w '%{http_code}' "$MB_BASE$1" \
+      -H 'Accept: application/json' || echo "000")
+  fi
+  if [ "$HTTP_CODE" = "401" ]; then TOKEN_EXPIRED=1; fi
+}
+ok() { [ -n "$HTTP_CODE" ] && [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 400 ] 2>/dev/null; }
+
+# ---- probe ----
+if [ "$PROBE" = "1" ]; then
+  req "/api/session/properties"
+  if ! ok; then
+    echo "PROBE FAILED (HTTP ${HTTP_CODE:-?}) — check MB_BASE (no trailing /api) and that the instance is reachable." >&2
+    exit 1
+  fi
+  version=$(jq -r '.version.tag // "unknown"' "$RESP" 2>/dev/null || echo "unknown")
+  echo "PROBE OK (HTTP $HTTP_CODE). Metabase version: $version"
+  case "$version" in
+    v0.4[0-9].*|v1.4[0-9].*|v0.3*|v1.3*) echo "NOTE: pre-v50 — view_count is not exposed; usage ranking falls back to feature counts." ;;
+  esac
+  exit 0
+fi
+
+[ -n "$OUT" ] || { echo "--out <dir> required (unless --probe)" >&2; exit 2; }
+mkdir -p "$OUT/specs" "$OUT/metadata"
+ART="$OUT/.artifacts.jsonl"; : > "$ART"
+PFLAG=""
+[ "$INCLUDE_PERSONAL" = "1" ] && PFLAG="--include-personal"
+
+# instance version (best effort, for the inventory header)
+req "/api/session/properties"
+VERSION=$(jq -r '.version.tag // "unknown"' "$RESP" 2>/dev/null || echo "unknown")
+
+# ---- collection list (flat — needed by both paths for names + personal flags) ----
+req "/api/collection?archived=false"
+if ! ok; then
+  jq -n --arg base "$MB_BASE" --arg code "${HTTP_CODE:-?}" \
+    '{environment:{base:$base,error:("collection list failed (HTTP " + $code + ")")},artifacts:[],token_expired:true}' \
+    > "$OUT/inventory.json"
+  echo "AUTH FAILED (HTTP ${HTTP_CODE:-?}) listing collections — wrote token_expired flag; re-auth (MB_SESSION expired? MB_KEY group lacks perms?) and re-run." >&2
+  exit 0
+fi
+cp "$RESP" "$OUT/collections.json"
+N_COLLECTIONS=$(jq 'length' "$OUT/collections.json" 2>/dev/null || echo 0)
+
+# id + name per collection (legacy walk); skip personal collections unless asked.
+COLL_TSV=$(jq -r --argjson p "$INCLUDE_PERSONAL" '
+  [ .[] | select($p == 1 or ((.personal_owner_id // null) == null and ((.is_personal // false) | not))) ]
+  | .[] | "\(.id)\t\(.name)"' "$OUT/collections.json" 2>/dev/null || true)
+if ! printf '%s\n' "$COLL_TSV" | cut -f1 | grep -qx 'root'; then
+  COLL_TSV=$(printf 'root\tOur analytics\n%s' "$COLL_TSV")
+fi
+
+fetched_dbs=""  # space-separated db ids already fetched
+
+fetch_metadata() { # $1 = database id
+  local db="$1" f
+  [ -n "$db" ] && [ "$db" != "null" ] || return 0
+  case " $fetched_dbs " in *" $db "*) return 0 ;; esac
+  fetched_dbs="$fetched_dbs $db"
+  f="$OUT/metadata/$db.metadata.json"
+  [ -s "$f" ] && return 0
+  req "/api/database/$db/metadata"
+  if ok && [ -s "$RESP" ]; then
+    cp "$RESP" "$f"
+  elif [ "$HTTP_CODE" = "403" ]; then
+    # Scoped keys often can't read whole-database metadata. NOT fatal: the
+    # converter resolves field ids via card result_metadata, then
+    # GET /api/field/{id} (which works even for restricted DBs), then SQL names.
+    echo "database $db: metadata HTTP 403 — use the field-id fallback chain (result_metadata → GET /api/field/{id})" >> "$OUT/metadata/unavailable.txt"
+  fi
+}
+
+record_failed() { # $1=id $2=type $3=name $4=collection — definition fetch failed
+  jq -n --arg id "$1" --arg type "$2" --arg name "$3" --arg coll "$4" \
+    '{id:($id|tonumber? // $id),type:$type,name:$name,collection:$coll,specFile:null}' >> "$ART"
+}
+
+fetch_card() { # $1=id $2=name $3=collection — appends an artifact record (legacy walk)
+  local id="$1" name="$2" coll="$3" f="$OUT/specs/$1.card.json" db
+  if [ ! -s "$f" ]; then
+    req "/api/card/$id"
+    [ "$TOKEN_EXPIRED" = "1" ] && return 0
+    if ! ok || [ ! -s "$RESP" ]; then record_failed "$id" "card" "$name" "$coll"; return 0; fi
+    cp "$RESP" "$f"
+  fi
+  db=$(jq -r '.database_id // .dataset_query.database // empty' "$f" 2>/dev/null || true)
+  fetch_metadata "$db"
+  jq -c --arg coll "$coll" --arg sf "specs/$id.card.json" '
+    {id:.id, type:(if (.type=="model") or (.dataset==true) then "model" elif .type=="metric" then "metric" else "card" end),
+     name:.name, collection:$coll, view_count:(.view_count // null), specFile:$sf}' "$f" >> "$ART" 2>/dev/null || \
+    record_failed "$id" "card" "$name" "$coll"
+}
+
+fetch_dashboard() { # $1=id $2=name $3=collection (legacy walk)
+  local id="$1" name="$2" coll="$3" f="$OUT/specs/$1.dashboard.json"
+  if [ ! -s "$f" ]; then
+    req "/api/dashboard/$id"
+    [ "$TOKEN_EXPIRED" = "1" ] && return 0
+    if ! ok || [ ! -s "$RESP" ]; then record_failed "$id" "dashboard" "$name" "$coll"; return 0; fi
+    cp "$RESP" "$f"
+  fi
+  jq -c --arg coll "$coll" --arg sf "specs/$id.dashboard.json" \
+    '{id:.id, type:"dashboard", name:.name, collection:$coll, view_count:(.view_count // null), specFile:$sf}' \
+    "$f" >> "$ART" 2>/dev/null || record_failed "$id" "dashboard" "$name" "$coll"
+}
+
+# ============================================================================
+# FAST PATH (default): bulk card endpoint + parallel dashboard GETs
+# ============================================================================
+if [ "$WALK" = "0" ]; then
+  # ---- cards: one bulk GET, split locally ----
+  if [ "$SKIP_CARDS" = "0" ]; then
+    if ls "$OUT/specs/"*.card.json >/dev/null 2>&1 && [ -s "$OUT/databases.txt" ]; then
+      echo "cards already split on disk — rebuilding artifact records (re-delete specs/ to force a re-fetch)"
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" collect-cards --collections "$OUT/collections.json" --out "$OUT" $PFLAG
+    else
+      echo "bulk-fetching ALL card definitions (GET /api/card — ~15MB per 1k cards, streamed to disk) …"
+      BULK="$OUT/cards.bulk.json"
+      CODE=$(curl -s -o "$BULK" -w '%{http_code}' "$MB_BASE/api/card" \
+        -H 'Accept: application/json' -H "$AUTH_NAME: $AUTH_VALUE" || echo "000")
+      if [ "$CODE" = "200" ] && [ -s "$BULK" ]; then
+        python3 "$SCRIPT_DIR/mb-bulk-split.py" split-cards --bulk "$BULK" --collections "$OUT/collections.json" --out "$OUT" $PFLAG
+        rm -f "$BULK"
+      elif [ "$CODE" = "401" ]; then
+        TOKEN_EXPIRED=1
+      else
+        echo "bulk GET /api/card failed (HTTP $CODE) — falling back to the legacy per-collection walk." >&2
+        WALK=1
+      fi
+    fi
+  fi
+
+  # ---- dashboards: list once, fetch in parallel (resumable) ----
+  if [ "$WALK" = "0" ] && [ "$TOKEN_EXPIRED" = "0" ]; then
+    req "/api/dashboard"
+    if ok; then
+      cp "$RESP" "$OUT/dashboards.list.json"
+      DIDS="$OUT/.dash_ids"
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" list-dashboards --list "$OUT/dashboards.list.json" \
+        --collections "$OUT/collections.json" --out "$OUT" $PFLAG ${MAX_DASH:+--max "$MAX_DASH"} > "$DIDS"
+      N_TO_FETCH=$(grep -c . "$DIDS" || true)
+      if [ "${N_TO_FETCH:-0}" -gt 0 ]; then
+        echo "fetching $N_TO_FETCH dashboards ($CONC parallel, resumable) …"
+        export MB_BASE AUTH_NAME AUTH_VALUE OUT
+        xargs -P "$CONC" -n 1 sh -c '
+          id="$0"; f="$OUT/specs/$id.dashboard.json"
+          [ -s "$f" ] && exit 0
+          tmp="$f.tmp.$$"
+          code=$(curl -s -o "$tmp" -w "%{http_code}" "$MB_BASE/api/dashboard/$id" \
+            -H "Accept: application/json" -H "$AUTH_NAME: $AUTH_VALUE" || echo 000)
+          if [ "$code" = "200" ] && [ -s "$tmp" ]; then mv "$tmp" "$f"
+          else rm -f "$tmp"; echo "dashboard $id: HTTP $code" >&2; fi
+        ' < "$DIDS" || true
+      fi
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" collect-dashboards --collections "$OUT/collections.json" --out "$OUT"
+      rm -f "$DIDS"
+    elif [ "$HTTP_CODE" = "401" ]; then
+      TOKEN_EXPIRED=1
+    else
+      echo "GET /api/dashboard failed (HTTP $HTTP_CODE) — dashboards via the legacy walk." >&2
+      WALK=1
+    fi
+  fi
+
+  # ---- database metadata (once per referenced database; 403 = fallback chain) ----
+  if [ "$TOKEN_EXPIRED" = "0" ] && [ -s "$OUT/databases.txt" ]; then
+    while IFS= read -r db; do
+      [ -n "$db" ] && fetch_metadata "$db"
+    done < "$OUT/databases.txt"
+  fi
+fi
+
+# ============================================================================
+# LEGACY WALK (--walk, or automatic fallback): per-collection item pages
+# ============================================================================
+if [ "$WALK" = "1" ]; then
+  while IFS=$'\t' read -r cid cname; do
+    [ -n "$cid" ] || continue
+    [ "$TOKEN_EXPIRED" = "1" ] && break
+    offset=0
+    while :; do
+      [ "$TOKEN_EXPIRED" = "1" ] && break
+      req "/api/collection/$cid/items?models=card&models=dashboard&models=dataset&limit=$PAGE&offset=$offset"
+      [ "$TOKEN_EXPIRED" = "1" ] && break
+      ok || break
+      n=$(jq '.data | length' "$RESP" 2>/dev/null || echo 0)
+      [ "$n" -gt 0 ] 2>/dev/null || break
+      # snapshot the page before inner reqs reuse $RESP
+      items=$(jq -r '.data[] | "\(.model)\t\(.id)\t\(.name)"' "$RESP")
+      while IFS=$'\t' read -r model iid iname; do
+        [ -n "$iid" ] || continue
+        [ "$TOKEN_EXPIRED" = "1" ] && break
+        case "$model" in
+          card|dataset) fetch_card "$iid" "$iname" "$cname" ;;
+          dashboard)    fetch_dashboard "$iid" "$iname" "$cname" ;;
+        esac
+      done <<< "$items"
+      [ "$n" -lt "$PAGE" ] && break
+      offset=$((offset + PAGE))
+    done
+  done <<< "$COLL_TSV"
+fi
+
+# ---- sandboxing probe (Pro/EE only; 404 on OSS is fine) ----
+if [ "$TOKEN_EXPIRED" = "0" ]; then
+  req "/api/mt/gtap" || true
+  if ok && jq -e 'type=="array" and length>0' "$RESP" >/dev/null 2>&1; then
+    cp "$RESP" "$OUT/sandboxes.json"
+    echo "NOTE: $(jq 'length' "$OUT/sandboxes.json") sandboxing policies found (EE) -> $OUT/sandboxes.json"
+  fi
+fi
+
+# ---- assemble inventory.json ----
+jq -s --arg base "$MB_BASE" --arg version "$VERSION" --argjson ncoll "${N_COLLECTIONS:-0}" \
+   --argjson expired "$TOKEN_EXPIRED" '
+  . as $arts |
+  {environment:{
+     generated_at: (now | strftime("%Y-%m-%d")),
+     base: $base, version: $version,
+     n_collections: $ncoll,
+     by_type: (reduce $arts[] as $a ({}; .[$a.type] = ((.[$a.type] // 0) + 1))),
+     n_artifacts: ($arts | length),
+     n_cards: ([$arts[] | select(.type=="card" or .type=="metric")] | length),
+     n_models: ([$arts[] | select(.type=="model")] | length),
+     n_dashboards: ([$arts[] | select(.type=="dashboard")] | length)
+   },
+   artifacts: $arts}
+  + (if $expired == 1 then {token_expired:true} else {} end)
+' "$ART" > "$OUT/inventory.json"
+rm -f "$ART"
+
+n_total=$(jq '.environment.n_artifacts' "$OUT/inventory.json")
+n_models=$(jq '.environment.n_models' "$OUT/inventory.json")
+n_cards=$(jq '.environment.n_cards' "$OUT/inventory.json")
+n_dash=$(jq '.environment.n_dashboards' "$OUT/inventory.json")
+msg="discovered $n_total artifacts ($n_models models, $n_cards questions, $n_dash dashboards) -> $OUT/inventory.json"
+if [ "$TOKEN_EXPIRED" = "1" ]; then
+  msg="$msg  [WARNING: auth expired mid-walk (401) — re-auth and re-run to complete; on-disk specs are kept]"
+fi
+echo "$msg"

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/dup-dashboards.py
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/mb-bulk-split.py
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/mb-bulk-split.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""mb-bulk-split.py — companion to discover-metabase.sh's bulk fast path.
+
+Production finding (7k-card / 1.5k-dashboard Metabase Cloud estate): the old
+per-item sequential walk took >1 hour; `GET /api/card` returns EVERY card with
+its full definition in one response (~110MB for 7k cards). Stream that to disk,
+then split it locally — the whole discovery drops to ~1 minute.
+
+Subcommands (all local-file only; the shell script does the HTTP):
+  split-cards        --bulk cards.bulk.json --collections collections.json --out DIR
+                     [--include-personal]
+        → DIR/specs/{id}.card.json (skip-if-exists), appends DIR/.artifacts.jsonl,
+          writes DIR/databases.txt (distinct database ids, for metadata fetches)
+  list-dashboards    --list dashboards.list.json --collections collections.json --out DIR
+                     [--include-personal] [--max N]
+        → prints dashboard ids to fetch (one per line), already-downloaded ids skipped
+  collect-cards      --collections collections.json --out DIR [--include-personal]
+        → rebuilds artifact records + databases.txt from DIR/specs/*.card.json
+          (resume path — avoids re-downloading the bulk payload)
+  collect-dashboards --collections collections.json --out DIR
+        → appends artifact records for every DIR/specs/*.dashboard.json on disk
+
+Stdlib only. Read-only with respect to Metabase (never talks to the network).
+"""
+import argparse
+import json
+import os
+import sys
+from glob import glob
+
+
+def load_collections(path):
+    """collection id → name; plus the set of personal-collection ids."""
+    names = {None: 'Our analytics', 'root': 'Our analytics'}
+    personal = set()
+    try:
+        with open(path) as f:
+            colls = json.load(f)
+    except (OSError, ValueError):
+        return names, personal
+    for c in colls if isinstance(colls, list) else []:
+        cid = c.get('id')
+        names[cid] = c.get('name') or str(cid)
+        if c.get('personal_owner_id') is not None or c.get('is_personal'):
+            personal.add(cid)
+    return names, personal
+
+
+def artifact_type(card):
+    if card.get('type') == 'model' or card.get('dataset') is True:
+        return 'model'
+    if card.get('type') == 'metric':
+        return 'metric'
+    return 'card'
+
+
+def split_cards(args):
+    names, personal = load_collections(args.collections)
+    with open(args.bulk) as f:
+        cards = json.load(f)
+    if not isinstance(cards, list):
+        sys.exit('split-cards: bulk file is not a JSON array — is this really GET /api/card?')
+    specs = os.path.join(args.out, 'specs')
+    os.makedirs(specs, exist_ok=True)
+    dbs, n_written, n_skipped, n_personal = set(), 0, 0, 0
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    for c in cards:
+        cid = c.get('id')
+        if cid is None or c.get('archived'):
+            continue
+        coll_id = c.get('collection_id')
+        if coll_id in personal and not args.include_personal:
+            n_personal += 1
+            continue
+        path = os.path.join(specs, f'{cid}.card.json')
+        if os.path.exists(path) and os.path.getsize(path) > 0:
+            n_skipped += 1
+        else:
+            tmp = path + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump(c, f)
+            os.replace(tmp, path)
+            n_written += 1
+        db = c.get('database_id') or (c.get('dataset_query') or {}).get('database')
+        if db:
+            dbs.add(db)
+        art.write(json.dumps({
+            'id': cid, 'type': artifact_type(c), 'name': c.get('name'),
+            'collection': names.get(coll_id, str(coll_id)),
+            'view_count': c.get('view_count'),
+            'specFile': f'specs/{cid}.card.json',
+        }) + '\n')
+    art.close()
+    with open(os.path.join(args.out, 'databases.txt'), 'w') as f:
+        for db in sorted(dbs):
+            f.write(f'{db}\n')
+    print(f'split-cards: {n_written} written, {n_skipped} already on disk, '
+          f'{n_personal} personal-collection cards skipped, {len(dbs)} databases referenced',
+          file=sys.stderr)
+
+
+def list_dashboards(args):
+    _, personal = load_collections(args.collections)
+    with open(args.list) as f:
+        dashes = json.load(f)
+    if isinstance(dashes, dict):  # some versions wrap in {data:[…]}
+        dashes = dashes.get('data', [])
+    specs = os.path.join(args.out, 'specs')
+    out = []
+    for d in dashes if isinstance(dashes, list) else []:
+        did = d.get('id')
+        if did is None or d.get('archived'):
+            continue
+        if d.get('collection_id') in personal and not args.include_personal:
+            continue
+        p = os.path.join(specs, f'{did}.dashboard.json')
+        if os.path.exists(p) and os.path.getsize(p) > 0:
+            continue  # resumable: already downloaded
+        out.append(did)
+    if args.max is not None:
+        out = out[:args.max]
+    for did in out:
+        print(did)
+
+
+def collect_cards(args):
+    names, personal = load_collections(args.collections)
+    specs = os.path.join(args.out, 'specs')
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    dbs, n = set(), 0
+    for p in sorted(glob(os.path.join(specs, '*.card.json'))):
+        try:
+            with open(p) as f:
+                c = json.load(f)
+        except (OSError, ValueError):
+            continue
+        if c.get('collection_id') in personal and not args.include_personal:
+            continue
+        art.write(json.dumps({
+            'id': c.get('id'), 'type': artifact_type(c), 'name': c.get('name'),
+            'collection': names.get(c.get('collection_id'), str(c.get('collection_id'))),
+            'view_count': c.get('view_count'),
+            'specFile': f"specs/{os.path.basename(p)}",
+        }) + '\n')
+        db = c.get('database_id') or (c.get('dataset_query') or {}).get('database')
+        if db:
+            dbs.add(db)
+        n += 1
+    art.close()
+    with open(os.path.join(args.out, 'databases.txt'), 'w') as f:
+        for db in sorted(dbs):
+            f.write(f'{db}\n')
+    print(f'collect-cards: {n} cards recorded from disk', file=sys.stderr)
+
+
+def collect_dashboards(args):
+    names, _ = load_collections(args.collections)
+    specs = os.path.join(args.out, 'specs')
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    n = 0
+    for p in sorted(glob(os.path.join(specs, '*.dashboard.json'))):
+        try:
+            with open(p) as f:
+                d = json.load(f)
+        except (OSError, ValueError):
+            continue
+        art.write(json.dumps({
+            'id': d.get('id'), 'type': 'dashboard', 'name': d.get('name'),
+            'collection': names.get(d.get('collection_id'), str(d.get('collection_id'))),
+            'view_count': d.get('view_count'),
+            'specFile': f"specs/{os.path.basename(p)}",
+        }) + '\n')
+        n += 1
+    art.close()
+    print(f'collect-dashboards: {n} dashboards recorded', file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    s1 = sub.add_parser('split-cards')
+    s1.add_argument('--bulk', required=True)
+    s1.add_argument('--collections', required=True)
+    s1.add_argument('--out', required=True)
+    s1.add_argument('--include-personal', action='store_true')
+    s2 = sub.add_parser('list-dashboards')
+    s2.add_argument('--list', required=True)
+    s2.add_argument('--collections', required=True)
+    s2.add_argument('--out', required=True)
+    s2.add_argument('--include-personal', action='store_true')
+    s2.add_argument('--max', type=int, default=None)
+    s3 = sub.add_parser('collect-dashboards')
+    s3.add_argument('--collections', required=True)
+    s3.add_argument('--out', required=True)
+    s4 = sub.add_parser('collect-cards')
+    s4.add_argument('--collections', required=True)
+    s4.add_argument('--out', required=True)
+    s4.add_argument('--include-personal', action='store_true')
+    args = ap.parse_args()
+    {'split-cards': split_cards, 'list-dashboards': list_dashboards,
+     'collect-dashboards': collect_dashboards, 'collect-cards': collect_cards}[args.cmd](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/pmbql-normalize.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/pmbql-normalize.mjs
@@ -1,0 +1,228 @@
+/**
+ * pMBQL ("lib/" MBQL, Metabase Lib) → legacy MBQL normalizer.
+ *
+ * Modern Metabase instances (observed: Metabase Cloud v1.61.x; 100% of a
+ * 7k-card production estate) return `dataset_query` in pMBQL form:
+ *
+ *   { "lib/type": "mbql/query", "database": N, "stages": [ ... ] }
+ *
+ * instead of the legacy `{ "type": "native"|"query", ... }` the converter and
+ * scorer were built against. A single card-list response may contain EITHER
+ * format depending on instance version — sniff the `lib/type` key, never the
+ * version string.
+ *
+ * Shape differences handled here (all verified against production payloads):
+ *   query    {lib/type:"mbql/query", stages:[…]}     → {type, database, native|query}
+ *   stage    mbql.stage/native {native:"sql", template-tags} → {native:{query, template-tags}}
+ *   stage    mbql.stage/mbql   {aggregation, breakout, filters, joins, …}
+ *   clause   [op, {opts}, …args]                     → [op, …args] (opts map is ALWAYS
+ *            the 2nd element in pMBQL; legacy puts it last, or 3rd for "field")
+ *   field    ["field", {opts}, idOrName]             → ["field", idOrName, opts|null]
+ *   filters  array (implicit AND)                    → single `filter` (["and", …])
+ *   in/not-in                                        → multi-value "="/"!=" (the
+ *            converter renders those as Or/And chains — Sigma has no IsIn)
+ *   named aggregation (name/display-name in opts)    → ["aggregation-options", inner, {…}]
+ *   expressions list (lib/expression-name in opts)   → {name: clause} map
+ *   source-card N                                    → source-table "card__N"
+ *   joins {stages:[{source-table}], conditions:[…]}  → {source-table, condition, …}
+ *   multi-stage (rare but real: 14 of 7,023 cards)   → legacy source-query nesting
+ *   template-tags dimension clauses                  → legacy field refs
+ *
+ * `normalizeCard` prefers the server-provided `legacy_query` JSON string when
+ * present and parseable (the instance's own down-conversion — authoritative),
+ * falling back to this normalizer. Zero dependencies; usable from Node ≥18.
+ *
+ * NOTE: this file exists in two locations (converter + assessment scripts) so
+ * each skill stays self-contained. The converter test suite asserts the two
+ * copies are byte-identical — edit one, copy to the other.
+ */
+
+const isOptsMap = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+
+/** A pMBQL clause is [op:string, optsMap, ...args] — opts ALWAYS second. */
+const isPmbqlClause = (n) => Array.isArray(n) && typeof n[0] === 'string' && isOptsMap(n[1]);
+
+function cleanOpts(opts) {
+  const out = {};
+  for (const [k, v] of Object.entries(opts || {})) {
+    if (k.startsWith('lib/') || k === 'effective-type' || k === 'ident') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const STRING_MATCH_OPS = new Set(['starts-with', 'ends-with', 'contains', 'does-not-contain']);
+
+/** Recursively normalize a pMBQL clause tree into legacy MBQL. */
+export function normalizeClause(node) {
+  if (!Array.isArray(node)) return node;
+  if (!isPmbqlClause(node)) return node.map(normalizeClause); // e.g. case clause-pair lists
+  const op = node[0];
+  const opts = cleanOpts(node[1]);
+  const args = node.slice(2);
+  const hasOpts = Object.keys(opts).length > 0;
+
+  switch (op) {
+    case 'field':
+      // ["field", {opts}, idOrName] → ["field", idOrName, opts|null]
+      return ['field', args[0], hasOpts ? opts : null];
+    case 'expression':
+      return hasOpts ? ['expression', args[0], opts] : ['expression', args[0]];
+    case 'aggregation':
+      return ['aggregation', args[0]];
+    case 'template-tag':
+      return ['template-tag', args[0]];
+    case 'value':
+      return normalizeClause(args[0]); // literal wrapper — unwrap
+    case 'absolute-datetime':
+      return normalizeClause(args[0]); // legacy filters carry the bare ISO string
+    case 'case':
+    case 'if': {
+      // ["case", {opts}, [[pred, expr], …], default?] → ["case", [[…]], {default}?]
+      const pairs = (args[0] || []).map((p) =>
+        Array.isArray(p) ? [normalizeClause(p[0]), normalizeClause(p[1])] : p);
+      const out = ['case', pairs];
+      if (args.length > 1 && args[1] !== undefined) out.push({ default: normalizeClause(args[1]) });
+      return out;
+    }
+    case 'in':
+      return ['=', ...args.map(normalizeClause)];
+    case 'not-in':
+      return ['!=', ...args.map(normalizeClause)];
+    case 'time-interval':
+    case 'relative-time-interval': {
+      // ["time-interval", {opts}, field, n, unit] → ["time-interval", field, n, unit, opts?]
+      const rest = args.map(normalizeClause);
+      return hasOpts ? ['time-interval', ...rest, opts] : ['time-interval', ...rest];
+    }
+    case 'segment':
+    case 'metric':
+      return [op, args[0]];
+    default: {
+      const rest = args.map(normalizeClause);
+      // string-match ops carry case-sensitive in opts — legacy puts it last
+      if (STRING_MATCH_OPS.has(op) && hasOpts) return [op, ...rest, opts];
+      return [op, ...rest];
+    }
+  }
+}
+
+/** Aggregation clause — pMBQL names live in opts → legacy aggregation-options wrapper. */
+function normalizeAggregation(a) {
+  if (!isPmbqlClause(a)) return normalizeClause(a);
+  const o = a[1];
+  const norm = normalizeClause(a);
+  const nm = o['display-name'] || o.name;
+  if (!nm) return norm;
+  const wrap = {};
+  if (o.name) wrap.name = o.name;
+  if (o['display-name']) wrap['display-name'] = o['display-name'];
+  return ['aggregation-options', norm, wrap];
+}
+
+function normalizeJoin(j) {
+  const out = {};
+  const st0 = (j.stages && j.stages[0]) || {};
+  if (st0['source-card'] != null) out['source-table'] = `card__${st0['source-card']}`;
+  else if (st0['source-table'] != null) out['source-table'] = st0['source-table'];
+  else if (j['source-table'] != null) out['source-table'] = j['source-table'];
+  if (j.alias != null) out.alias = j.alias;
+  if (j.strategy != null) out.strategy = j.strategy;
+  if (Array.isArray(j.conditions)) {
+    const cs = j.conditions.map(normalizeClause);
+    out.condition = cs.length === 1 ? cs[0] : ['and', ...cs];
+  } else if (j.condition) {
+    out.condition = normalizeClause(j.condition);
+  }
+  if (j.fields != null) out.fields = Array.isArray(j.fields) ? j.fields.map(normalizeClause) : j.fields;
+  return out;
+}
+
+function normalizeTemplateTags(tags) {
+  if (!tags) return tags;
+  const out = {};
+  for (const [k, t] of Object.entries(tags)) {
+    out[k] = t && t.dimension ? { ...t, dimension: normalizeClause(t.dimension) } : t;
+  }
+  return out;
+}
+
+/** One pMBQL stage → legacy query object (native stages return {__native}). */
+function normalizeStage(stage, prev) {
+  if (stage['lib/type'] === 'mbql.stage/native') {
+    const native = { query: stage.native ?? stage.query ?? '' };
+    if (stage['template-tags']) native['template-tags'] = normalizeTemplateTags(stage['template-tags']);
+    if (stage.collection) native.collection = stage.collection; // MongoDB
+    return { __native: native };
+  }
+  const q = {};
+  if (prev) {
+    q['source-query'] = prev.__native
+      ? { native: prev.__native.query, 'template-tags': prev.__native['template-tags'] || {} }
+      : prev;
+  } else if (stage['source-card'] != null) {
+    q['source-table'] = `card__${stage['source-card']}`;
+  } else if (stage['source-table'] != null) {
+    q['source-table'] = stage['source-table'];
+  }
+  if (Array.isArray(stage.joins)) q.joins = stage.joins.map(normalizeJoin);
+  if (Array.isArray(stage.expressions)) {
+    q.expressions = {};
+    for (const e of stage.expressions) {
+      const nm = (isPmbqlClause(e) && e[1]['lib/expression-name']) || `expr_${Object.keys(q.expressions).length}`;
+      q.expressions[nm] = normalizeClause(e);
+    }
+  }
+  if (Array.isArray(stage.aggregation)) q.aggregation = stage.aggregation.map(normalizeAggregation);
+  if (Array.isArray(stage.breakout)) q.breakout = stage.breakout.map(normalizeClause);
+  if (Array.isArray(stage.filters) && stage.filters.length) {
+    const fs = stage.filters.map(normalizeClause);
+    q.filter = fs.length === 1 ? fs[0] : ['and', ...fs];
+  } else if (stage.filter) {
+    q.filter = normalizeClause(stage.filter);
+  }
+  if (Array.isArray(stage['order-by'])) {
+    q['order-by'] = stage['order-by'].map((o) =>
+      Array.isArray(o) && isOptsMap(o[1]) ? [o[0], normalizeClause(o[2])] : normalizeClause(o));
+  }
+  if (stage.limit != null) q.limit = stage.limit;
+  if (Array.isArray(stage.fields)) q.fields = stage.fields.map(normalizeClause);
+  return q;
+}
+
+export function isPmbqlQuery(dq) {
+  return !!dq && typeof dq === 'object' && dq['lib/type'] === 'mbql/query';
+}
+
+/**
+ * pMBQL dataset_query → legacy dataset_query. Legacy input passes through
+ * untouched (format-sniffing: a list endpoint may return either).
+ */
+export function normalizeDatasetQuery(dq) {
+  if (!isPmbqlQuery(dq)) return dq;
+  const stages = Array.isArray(dq.stages) ? dq.stages : [];
+  let acc = null;
+  for (const s of stages) acc = normalizeStage(s, acc);
+  if (acc && acc.__native) return { type: 'native', database: dq.database, native: acc.__native };
+  return { type: 'query', database: dq.database, query: acc || {} };
+}
+
+/**
+ * Normalize a full card object (non-mutating). Prefers the server-provided
+ * `legacy_query` (a JSON string — the instance's own down-conversion, present
+ * on ~70% of cards observed) and falls back to normalizeDatasetQuery.
+ */
+export function normalizeCard(card) {
+  if (!card || typeof card !== 'object') return card;
+  if (!isPmbqlQuery(card.dataset_query)) return card;
+  if (typeof card.legacy_query === 'string' && card.legacy_query.trim().startsWith('{')) {
+    try {
+      const lq = JSON.parse(card.legacy_query);
+      if (lq && (lq.type === 'native' || lq.type === 'query')) return { ...card, dataset_query: lq };
+    } catch { /* fall through to the normalizer */ }
+  }
+  if (isOptsMap(card.legacy_query) && (card.legacy_query.type === 'native' || card.legacy_query.type === 'query')) {
+    return { ...card, dataset_query: card.legacy_query };
+  }
+  return { ...card, dataset_query: normalizeDatasetQuery(card.dataset_query) };
+}

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/render-report.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/render-report.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * render-report.mjs — branded standalone HTML readout for the metabase-assessment skill.
+ *
+ *   node render-report.mjs --out <dir>            # reads <dir>/coverage.json (+ inventory.json if present)
+ *   node render-report.mjs --coverage <f> --out <f.html>
+ *
+ * Sigma-branded, print-friendly, ~6 sections, all-free framing. Zero deps.
+ * CSS/palette lifted from the tableau-assessment render-readout-html.rb.
+ */
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+let outDir = null, coveragePath = null, outFile = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--out') outDir = args[++i];
+  else if (args[i] === '--coverage') coveragePath = args[++i];
+}
+if (outDir && !coveragePath) coveragePath = join(outDir, 'coverage.json');
+if (outDir && outDir.endsWith('.html')) { outFile = outDir; outDir = null; }
+if (!coveragePath || !existsSync(coveragePath)) {
+  console.error('coverage.json not found — pass --out <dir> (containing coverage.json) or --coverage <file>');
+  process.exit(1);
+}
+if (!outFile) outFile = outDir ? join(outDir, 'readout.html') : 'readout.html';
+
+const cov = JSON.parse(readFileSync(coveragePath, 'utf8'));
+const invPath = outDir ? join(outDir, 'inventory.json') : null;
+const inv = invPath && existsSync(invPath) ? JSON.parse(readFileSync(invPath, 'utf8')) : null;
+
+const R = cov.rollup;
+const arts = cov.artifacts;
+const usage = !!R.usage_available;
+
+const h = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const num = (n) => Number(n || 0).toLocaleString('en-US');
+const fmtDate = (() => { try { return new Date(R.generated_at + 'T00:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); } catch { return R.generated_at; } })();
+
+const TAG_META = {
+  'migrate-first': ['tag-go', 'Migrate first'],
+  'easy-win': ['tag-blue', 'Easy win'],
+  'moderate': ['tag-gray', 'Standard'],
+  'needs-review': ['tag-warn', 'Needs review'],
+};
+const tagPill = (t) => { const [c, l] = TAG_META[t] || ['tag-gray', t]; return `<span class="tag ${c}">${h(l)}</span>`; };
+const bar = (v, max, color = 'bar-blue') => {
+  const pct = max ? Math.round((v / max) * 100) : 0;
+  return `<div class="bar-cell"><div class="bar-track"><div class="bar-fill ${color}" style="width:${pct}%"></div></div><div class="bar-num">${num(v)}</div></div>`;
+};
+
+// ---- waves (models sequenced before the questions/dashboards that use them) ----
+const TYPE_ORDER = { model: 0, card: 1, metric: 1, dashboard: 2 };
+const waveSort = (a, b) => (TYPE_ORDER[a.type] ?? 1) - (TYPE_ORDER[b.type] ?? 1) || b.score - a.score;
+const wave1 = arts.filter((a) => a.tag === 'migrate-first' || a.tag === 'easy-win').sort(waveSort);
+const wave2 = arts.filter((a) => a.tag === 'moderate').sort(waveSort);
+const wave3 = arts.filter((a) => a.tag === 'needs-review').sort(waveSort);
+
+// ---- hero finding ----
+const nReview = wave3.length;
+const heroFinding =
+  R.pct_auto_migratable >= 85
+    ? `Migration is largely automatic: ${R.pct_auto_migratable}% of detected features convert with the Metabase→Sigma tooling. ${nReview} of ${R.n_artifacts} artifact${nReview === 1 ? '' : 's'} contain a feature that warrants individual review.`
+    : `${R.pct_auto_migratable}% of detected features convert automatically. ${nReview} artifact${nReview === 1 ? '' : 's'} need individual review before conversion.`;
+
+// ---- KPI tiles ----
+const env = inv?.environment;
+const kpis = [
+  ['Artifacts', R.n_artifacts, env?.version ? `Metabase ${env.version}` : 'scored'],
+  ['Models', R.n_models, 'semantic layer'],
+  ['Questions', R.n_cards, 'MBQL + native SQL'],
+  ['Dashboards', R.n_dashboards, 'grids, tabs, filters'],
+  ['Auto-migratable', R.pct_auto_migratable + '%', 'of detected features'],
+  ['Needs review', nReview, 'human decision first'],
+].map(([l, v, s]) => `<div class="kpi"><div class="kpi-v">${h(v)}</div><div class="kpi-l">${h(l)}</div><div class="kpi-sub">${h(s)}</div></div>`).join('');
+
+// ---- inventory table ----
+const maxFeat = Math.max(1, ...arts.map((a) => a.n_features));
+const typeClass = (t) => t === 'model' ? 'ds-published' : t === 'dashboard' ? 'ds-dash' : 'ds-embedded';
+const invRows = arts.map((a) => `<tr>
+  <td>${h(a.name)}</td>
+  <td><span class="ds-bucket ${typeClass(a.type)}">${h(a.type)}</span></td>
+  <td>${bar(a.n_features, maxFeat)}</td>
+  ${usage ? `<td class="al-right num">${a.view_count != null ? num(a.view_count) : '<span class="muted">—</span>'}</td>` : ''}
+  <td><span class="risk-chip ${a.complexity === 'high' ? 'risk-red' : a.complexity === 'medium' ? 'risk-amber' : 'risk-clean'}"><span class="risk-dot"></span>${h(a.complexity)}</span></td>
+  <td>${tagPill(a.tag)}</td>
+</tr>`).join('');
+
+// ---- coverage breakdown ----
+const cb = R.totals;
+const coverageBars = [
+  ['Auto-convert', cb.n_auto, 'bar-blue', 'translated cleanly by the converter'],
+  ['Review, no rebuild', cb.n_hint, 'bar-blue', 'nested cards, field-filter tags, joins — sequencing/fan-out check'],
+  ['Manual setup', cb.n_manual, 'bar-blue', 'brief re-creation in Sigma (binning, segments/metrics, click behavior, snippets)'],
+  ['Needs review', cb.n_unhandled, 'bar-blue', 'no clean analog — human decision'],
+];
+const maxCov = Math.max(1, ...coverageBars.map((b) => b[1]));
+const coverageRows = coverageBars.map(([l, v, c, why]) => `<tr><td>${h(l)}</td><td>${bar(v, maxCov, c)}</td><td class="muted">${h(why)}</td></tr>`).join('');
+
+// ---- gap analysis ----
+const gapRows = R.gap_histogram.map((g) => {
+  const arr = [...new Set(g.artifacts)];
+  const named = arr.slice(0, 6).map((n) => `<code>${h(n)}</code>`).join(' ') + (arr.length > 6 ? ` +${arr.length - 6} more` : '');
+  return `<tr>
+    <td><span class="risk-chip ${g.bucket === 'unhandled' ? 'risk-red' : 'risk-amber'}"><span class="risk-dot"></span>${h(g.signal)}</span></td>
+    <td class="al-right num">${g.count}</td>
+    <td>${named}</td>
+    <td class="muted">${h(g.remediation)}</td>
+  </tr>`;
+}).join('');
+
+// ---- wave plan ----
+const waveBlock = (n, title, desc, members, cls) => {
+  if (!members.length) return '';
+  const list = members.slice(0, 20).map((a) => `<div class="cluster-member"><strong>${h(a.name)}</strong> <span class="muted">· ${h(a.type)} · ${h(a.complexity)}</span></div>`).join('');
+  return `<div class="stat ${cls}" style="grid-column: span 1;">
+    <div class="stat-l">Wave ${n} — ${h(title)}</div>
+    <div class="stat-v" style="font-size:24px;">${members.length}<span style="font-size:13px;color:var(--mute);font-weight:600;"> artifacts</span></div>
+    <div class="stat-sub" style="margin-bottom:10px;">${h(desc)}</div>
+    ${list}${members.length > 20 ? `<div class="muted" style="font-size:11px;margin-top:6px;">+${members.length - 20} more</div>` : ''}
+  </div>`;
+};
+
+const CSS = `
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); }
+  body { font-family:"DM Sans",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; font-size:14px; line-height:1.55; -webkit-font-smoothing:antialiased; }
+  main { max-width:1120px; margin:0 auto; padding:48px 48px 80px; }
+  .brand-bar { display:flex; align-items:center; gap:10px; margin-bottom:28px; }
+  .brand-mark { font-weight:700; font-size:21px; letter-spacing:-0.02em; color:var(--ink); }
+  .brand-dot { width:9px; height:9px; border-radius:2px; background:var(--blue); -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .brand-tag { font-size:12px; color:var(--mute); font-weight:500; text-transform:uppercase; letter-spacing:0.08em; }
+  .doc-header { margin-bottom:40px; }
+  .doc-eyebrow { font-size:11px; font-weight:600; color:var(--accent); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:8px; }
+  .doc-title { font-size:36px; font-weight:700; letter-spacing:-0.02em; margin:0 0 8px; line-height:1.1; }
+  .doc-meta { font-size:13px; color:var(--ink-2); }
+  .hero { background:var(--accent-soft); border:1px solid var(--line); border-left:4px solid var(--blue); border-radius:8px; padding:18px 22px; margin-bottom:40px; display:flex; align-items:center; gap:16px; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .hero-label { font-size:11px; font-weight:700; color:var(--accent); text-transform:uppercase; letter-spacing:0.08em; white-space:nowrap; padding-right:16px; border-right:1px solid var(--line); }
+  .hero-text { font-size:15px; color:var(--ink); font-weight:500; line-height:1.4; }
+  section { margin-bottom:56px; }
+  .section-head { display:flex; align-items:baseline; justify-content:space-between; margin-bottom:16px; padding-bottom:12px; border-bottom:1px solid var(--line); }
+  .section-num { font-size:12px; font-weight:600; color:var(--mute); letter-spacing:0.06em; }
+  .section-title { font-size:22px; font-weight:600; letter-spacing:-0.01em; margin:0; flex:1; padding-left:14px; }
+  .section-aside { font-size:12px; color:var(--mute); }
+  .section-lede { font-size:14px; color:var(--ink-2); margin:-4px 0 16px; }
+  .kpi-grid { display:grid; grid-template-columns:repeat(6,1fr); gap:12px; }
+  .kpi { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:18px 16px; }
+  .kpi-v { font-size:28px; font-weight:700; letter-spacing:-0.01em; line-height:1; }
+  .kpi-l { font-size:11px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; font-weight:600; margin-top:10px; }
+  .kpi-sub { font-size:11px; color:var(--mute); margin-top:4px; line-height:1.4; }
+  .stat-row { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin-bottom:24px; align-items:start; }
+  .stat { background:#fafafa; border:1px solid var(--line); border-left:3px solid var(--accent); border-radius:8px; padding:16px 18px; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .stat.stat-go { border-left-color:var(--go); background:var(--go-soft); }
+  .stat.stat-warn { border-left-color:var(--warn); background:var(--warn-soft); }
+  .stat.stat-blue { border-left-color:var(--blue); background:var(--blue-soft); }
+  .stat-l { font-size:10px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; font-weight:700; margin-bottom:6px; }
+  .stat-v { font-size:30px; font-weight:700; line-height:1; letter-spacing:-0.02em; }
+  .stat-v.go { color:var(--go); } .stat-v.warn { color:var(--warn); }
+  .stat-sub { font-size:12px; color:var(--mute); margin-top:6px; }
+  table.data { width:100%; border-collapse:collapse; background:var(--card); border:1px solid var(--line); border-radius:10px; overflow:hidden; font-size:13px; }
+  table.data th { font-weight:600; font-size:11px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; padding:12px 16px; background:#fafafa; border-bottom:1px solid var(--line); text-align:left; }
+  table.data td { padding:12px 16px; border-bottom:1px solid var(--line-soft); vertical-align:middle; }
+  table.data tbody tr:last-child td { border-bottom:0; }
+  table.data tbody tr:hover td { background:#fafafa; }
+  .al-right { text-align:right; }
+  table.data td.al-right, table.data th.al-right, table.data td:has(.bar-cell) { width:1%; white-space:nowrap; }
+  .num { font-variant-numeric:tabular-nums; } .muted { color:var(--mute); }
+  .tag { display:inline-block; padding:3px 10px; border-radius:99px; font-size:11px; font-weight:600; white-space:nowrap; }
+  .tag-go { background:var(--go-soft); color:var(--go); }
+  .tag-blue { background:var(--blue-soft); color:var(--blue); }
+  .tag-gray { background:#f5f5f5; color:var(--ink-2); }
+  .tag-warn { background:var(--warn-soft); color:var(--warn); }
+  .bar-cell { display:flex; align-items:center; gap:10px; }
+  .bar-track { flex:none; width:84px; height:6px; background:#f5f5f5; border-radius:4px; overflow:hidden; }
+  .bar-fill { height:100%; border-radius:4px; }
+  .bar-blue { background:linear-gradient(90deg,#4cec8c,#2fb874); }
+  .bar-num { font-variant-numeric:tabular-nums; font-weight:600; min-width:36px; text-align:right; }
+  .ds-bucket { display:inline-block; padding:3px 10px; border-radius:6px; font-size:11px; font-weight:600; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .ds-published { background:var(--blue-soft); color:var(--blue); }
+  .ds-embedded { background:#f5f5f5; color:var(--ink-2); }
+  .ds-dash { background:var(--go-soft); color:var(--go); }
+  .risk-chip { display:inline-flex; align-items:center; gap:6px; font-size:12px; font-variant-numeric:tabular-nums; }
+  .risk-dot { width:8px; height:8px; border-radius:50%; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .risk-clean .risk-dot { background:var(--go); } .risk-clean { color:var(--go); font-weight:600; }
+  .risk-amber .risk-dot { background:#f59e0b; } .risk-amber { color:#a16207; font-weight:600; }
+  .risk-red .risk-dot { background:var(--warn); } .risk-red { color:var(--warn); font-weight:700; }
+  .cluster-member { padding:2px 0; font-size:12px; line-height:1.4; }
+  .cluster-member + .cluster-member { border-top:1px dashed var(--line-soft); }
+  .note { font-size:12px; color:var(--mute); font-style:italic; margin:12px 0 0; }
+  .callout { background:var(--warn-soft); border-left:3px solid var(--warn); padding:12px 16px; border-radius:6px; margin-top:16px; font-size:13px; color:#7c2d12; }
+  code { font-family:"DM Mono",ui-monospace,"SF Mono",Menlo,monospace; font-size:12.5px; background:var(--line-soft); padding:1px 6px; border-radius:4px; }
+  ol.next-steps { margin:0; padding-left:0; counter-reset:step; list-style:none; }
+  ol.next-steps li { counter-increment:step; padding:14px 0 14px 44px; position:relative; border-bottom:1px solid var(--line-soft); font-size:14px; }
+  ol.next-steps li:last-child { border-bottom:0; }
+  ol.next-steps li::before { content:counter(step); position:absolute; left:0; top:14px; width:28px; height:28px; border-radius:50%; background:var(--accent-soft); color:var(--accent); display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; }
+  footer { color:var(--mute); font-size:11px; text-align:center; margin-top:56px; padding-top:20px; border-top:1px solid var(--line); }
+  @media print {
+    @page { margin:0.6in 0.5in; size:letter portrait; }
+    body { background:white; font-size:11.5px; } main { max-width:none; padding:0; }
+    .doc-title { font-size:26px; } section { margin-bottom:24px; }
+    .kpi-v { font-size:22px; } table.data { font-size:11px; } table.data thead { display:table-header-group; }
+    .hero,.kpi,.stat,table.data,table.data th,.ds-bucket,.tag,.bar-track,.bar-fill,.risk-dot,.callout,ol.next-steps li::before { -webkit-print-color-adjust:exact !important; print-color-adjust:exact !important; }
+    table.data tr { page-break-inside:avoid; } .section-head { page-break-after:avoid; }
+  }
+`;
+
+const usageStep = usage
+  ? `<li><strong>Confirm the usage ranking with the admin.</strong> This instance exposes <code>view_count</code> (v50+), so the shortlist is already ranked by real views. For richer signal — views over time, per-user reach — ask the admin for the Pro/EE <em>Usage analytics</em> collection export and merge it in before retiring anything.</li>`
+  : `<li><strong>Request usage telemetry from your Metabase admin.</strong> This instance does not expose <code>view_count</code> on cards/dashboards (pre-v50), so the shortlist is ranked by conversion effort, not popularity. Ask for the Pro/EE <em>Usage analytics</em> export (or upgrade and re-run) to confirm which artifacts are actually used — and which to retire.</li>`;
+
+const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Metabase Migration Assessment</title>
+<style>${CSS}</style></head>
+<body><main>
+
+<div class="brand-bar"><span class="brand-dot"></span><span class="brand-mark">sigma</span><span class="brand-tag">Migration Assessment</span></div>
+<div class="doc-header">
+  <div class="doc-eyebrow">Metabase → Sigma — Estate Readout</div>
+  <h1 class="doc-title">Metabase Migration Assessment</h1>
+  <div class="doc-meta">${env ? h(env.base) + ' · ' : ''}Generated ${h(fmtDate)} · ${R.n_artifacts} artifacts scored</div>
+</div>
+
+<div class="hero"><div class="hero-label">Headline finding</div><div class="hero-text">${h(heroFinding)}</div></div>
+
+<section>
+  <div class="section-head"><span class="section-num">01</span><h2 class="section-title">Executive summary</h2></div>
+  <p class="section-lede">A read-only scan of the Metabase instance, scored against the exact coverage of the Metabase→Sigma converter. Every model, question, and dashboard below was classified by walking its MBQL/native definition and detecting the specific features the converter translates cleanly versus the ones it flags for a human. This is a fast, no-cost pre-scoping pass — like the equivalent Tableau assessment — to size the migration and pick a pilot.</p>
+  <div class="kpi-grid">${kpis}</div>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">02</span><h2 class="section-title">Estate inventory</h2><span class="section-aside">${R.n_models} models · ${R.n_cards} questions · ${R.n_dashboards} dashboards</span></div>
+  <p class="section-lede">Every scored artifact with its detected feature count${usage ? ', views' : ''}, conversion complexity, and recommendation. Complexity is <strong>low</strong> (converts cleanly), <strong>medium</strong> (brief manual setup), or <strong>high</strong> (contains a feature with no clean Sigma analog).</p>
+  <table class="data"><thead><tr><th>Artifact</th><th>Type</th><th>Features</th>${usage ? '<th class="al-right">Views</th>' : ''}<th>Complexity</th><th>Recommendation</th></tr></thead><tbody>${invRows}</tbody></table>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">03</span><h2 class="section-title">Coverage &amp; auto-migration</h2><span class="section-aside">${R.pct_auto_migratable}% auto-migratable</span></div>
+  <p class="section-lede">Of the ${num(R.totals.n_features)} features detected across the estate, this is how the converter handles them. "Auto-migratable" combines clean auto-conversion with review-only items (nested-card sequencing, field-filter control wiring, join fan-out checks) — work that doesn't require rebuilding logic.</p>
+  <div class="stat-row">
+    <div class="stat stat-go"><div class="stat-l">Auto-migratable</div><div class="stat-v go">${R.pct_auto_migratable}%</div><div class="stat-sub">${num(cb.n_auto + cb.n_hint)} of ${num(R.totals.n_features)} features</div></div>
+    <div class="stat ${cb.n_manual ? 'stat-blue' : ''}"><div class="stat-l">Manual setup features</div><div class="stat-v">${num(cb.n_manual)}</div><div class="stat-sub">binning, segments/metrics, click behavior, snippets</div></div>
+    <div class="stat ${cb.n_unhandled ? 'stat-warn' : ''}"><div class="stat-l">Needs-review features</div><div class="stat-v ${cb.n_unhandled ? 'warn' : ''}">${num(cb.n_unhandled)}</div><div class="stat-sub">cumulative/offset calcs, progress, unknown MBQL</div></div>
+  </div>
+  <table class="data"><thead><tr><th>Bucket</th><th>Features</th><th>What it means</th></tr></thead><tbody>${coverageRows}</tbody></table>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">04</span><h2 class="section-title">Gap analysis</h2><span class="section-aside">${R.gap_histogram.length} distinct gap type${R.gap_histogram.length === 1 ? '' : 's'}</span></div>
+  <p class="section-lede">Every feature that needs a human — named to the artifact, with the specific reason and the remediation. Amber = brief manual setup in Sigma; red = no clean analog, needs a decision before conversion. Identifying these up front means no surprises mid-migration.</p>
+  ${R.gap_histogram.length ? `<table class="data"><thead><tr><th>Gap</th><th class="al-right">Count</th><th>Artifacts</th><th>Remediation</th></tr></thead><tbody>${gapRows}</tbody></table>` : '<p class="note">No manual or needs-review gaps detected — the entire estate converts cleanly.</p>'}
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">05</span><h2 class="section-title">Effort &amp; wave plan</h2><span class="section-aside">3 waves · models before dependent dashboards</span></div>
+  <p class="section-lede">A risk-minimizing migration sequence. Wave 1 is the low-risk pilot; Wave 3 holds anything with a needs-review feature, each requiring a human decision first. Within every wave, convert models ahead of the questions and dashboards that source them (dashcards and <code>card__N</code> refs point at the migrated model's element).</p>
+  <div class="stat-row">
+    ${waveBlock(1, 'pilot', 'migrate-first / easy-win — no needs-review features; models first, then their dashboards', wave1, 'stat-go')}
+    ${waveBlock(2, 'standard', 'medium complexity — convert with light review', wave2, 'stat-blue')}
+    ${waveBlock(3, 'review-first', 'contains a cumulative/offset calc, progress/unknown viz, or sandboxing policy', wave3, 'stat-warn')}
+  </div>
+  ${cb.n_unhandled || R.n_sandboxes ? `<div class="callout"><strong>${nReview} artifact${nReview === 1 ? '' : 's'}</strong> include a feature with no clean Sigma analog (cumulative/offset window calcs, progress viz, or unknown MBQL${R.n_sandboxes ? `, plus ${R.n_sandboxes} EE sandboxing polic${R.n_sandboxes === 1 ? 'y' : 'ies'} at the instance level` : ''}). Plan a short design decision for each before converting — the converter emits a flagged placeholder rather than guessing.</div>` : ''}
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">06</span><h2 class="section-title">Recommended next steps</h2></div>
+  <ol class="next-steps">
+    <li><strong>Pilot Wave 1 (${wave1.length} artifact${wave1.length === 1 ? '' : 's'}).</strong> These convert with no needs-review features — the lowest-risk way to demonstrate an end-to-end Metabase→Sigma migration. Convert the models first, then the dashboards (and questions) that source them.</li>
+    ${cb.n_unhandled || R.n_sandboxes ? `<li><strong>Hold a design review for the needs-review items.</strong> Decide the Sigma equivalent for each cumulative/offset calc, progress viz, or unknown MBQL construct${R.n_sandboxes ? ', and sandboxing policy (these port to Sigma user attributes via the RLS engine — reviewed per policy)' : ''} up front (see the gap analysis above).</li>` : ''}
+    ${usageStep}
+    <li><strong>Request a durable API key from the admin</strong> (Admin → Settings → Authentication → API keys, in a group with view access) so the conversion phase doesn't depend on a 14-day session token${R.n_sandboxes ? ' — and, since this is a Pro/EE instance, the Usage analytics audit export' : ''}.</li>
+    <li><strong>Hand the pilot to the <code>metabase-to-sigma</code> converter.</strong> The per-artifact card/dashboard JSON and the per-database <code>metadata/*.metadata.json</code> (the field-id map the converter requires) are already cached from this scan — the converter can skip re-discovery and go straight to building the Sigma data model + workbook.</li>
+  </ol>
+</section>
+
+<footer>Read-only assessment · generated ${h(fmtDate)} · supporting <code>coverage.json</code>${inv ? ' + <code>inventory.json</code>' : ''} alongside in the same folder · all-free migration tooling</footer>
+
+</main></body></html>`;
+
+writeFileSync(outFile, html);
+console.log(`wrote ${outFile} (${html.length} bytes)`);

--- a/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/score-coverage.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-assessment/scripts/score-coverage.mjs
@@ -1,0 +1,452 @@
+#!/usr/bin/env node
+/**
+ * score-coverage.mjs — converter-coverage scorer for the metabase-assessment skill.
+ *
+ * For every Metabase card JSON (*.card.json) and dashboard JSON
+ * (*.dashboard.json), classify features into auto / hint / manual / unhandled
+ * by detecting the EXACT gap signals the metabase-to-sigma converter
+ * (converter/metabase.ts, translateMbqlExpr) translates cleanly vs. flags.
+ * This does NOT re-run the converter — it detects the same patterns so the
+ * estate's auto-migration % matches what the tool will actually do.
+ *
+ * Zero external dependencies (Node built-ins only). MBQL arrives already
+ * parsed (nested JSON arrays like ["sum", ["field", 72, null]]), so the
+ * scorer simply recurses the dataset_query trees and matches op names against
+ * the converter's translated-vs-flagged tables — no regex DSL parsing at all.
+ *
+ *   node score-coverage.mjs --in <dir-of-specs> --out <dir>
+ *
+ * Reads --in for *.card.json + *.dashboard.json (recurses one level into
+ * specs/). If a sandboxes.json (EE GTAP export) sits next to the specs, its
+ * policies are surfaced as needs-review items. Writes <out>/coverage.json.
+ * Read-only.
+ */
+import { readFileSync, readdirSync, statSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+// pMBQL ("lib/" MBQL) → legacy — modern instances (Cloud v1.61+) return
+// dataset_query as {"lib/type":"mbql/query","stages":[…]} (100% of a 7k-card
+// production estate). Normalized at intake; a list may mix both formats.
+import { normalizeCard } from './pmbql-normalize.mjs';
+
+// ---- args ----
+const args = process.argv.slice(2);
+let inDir = null, outDir = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--in') inDir = args[++i];
+  else if (args[i] === '--out') outDir = args[++i];
+}
+if (!inDir || !outDir) {
+  console.error('usage: score-coverage.mjs --in <specs-dir> --out <dir>');
+  process.exit(2);
+}
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+// ---- collect spec files (the dir itself, and a specs/ subdir if present) ----
+function collect(dir) {
+  const out = [];
+  const tryDir = (d) => {
+    if (!existsSync(d)) return;
+    for (const f of readdirSync(d)) {
+      const p = join(d, f);
+      let st;
+      try { st = statSync(p); } catch { continue; }
+      if (st.isFile() && (f.endsWith('.card.json') || f.endsWith('.dashboard.json'))) out.push(p);
+    }
+  };
+  tryDir(dir);
+  tryDir(join(dir, 'specs'));
+  return [...new Set(out)];
+}
+
+// ============================================================================
+// GAP SIGNAL DEFINITIONS — each maps to a converter behavior.
+// See refs/scoring-rubric.md (this skill) + refs/expression-dsl.md (converter).
+// ============================================================================
+
+// Aggregations translateMbqlExpr maps cleanly (Sum/Avg/CountIf/SumIf/share…).
+const AUTO_AGGS = new Set(['count', 'sum', 'avg', 'min', 'max', 'median', 'distinct',
+  'stddev', 'var', 'percentile', 'count-where', 'sum-where', 'share']);
+
+// Cumulative / window aggregations the converter flags loudly — the window
+// scope lives on the consuming Sigma element, so they're never faked.
+const UNHANDLED_AGGS = new Set(['cum-sum', 'cum-count', 'offset']);
+
+// Expression / filter ops in expression-dsl.md's translated table.
+const AUTO_OPS = new Set([
+  '+', '-', '*', '/', 'case', 'coalesce', 'concat', 'substring',
+  'trim', 'ltrim', 'rtrim', 'upper', 'lower', 'length', 'replace',
+  'regex-match-first', 'split-part',
+  'round', 'floor', 'ceil', 'abs', 'sqrt', 'exp', 'power', 'log',
+  'datetime-add', 'datetime-subtract', 'datetime-diff',
+  'get-year', 'get-quarter', 'get-month', 'get-week', 'get-day',
+  'get-day-of-week', 'get-hour', 'get-minute', 'get-second',
+  'now', 'relative-datetime',
+  'text', 'integer', 'float', 'date',          // casts → Text/Int/Number/DateTrunc
+  '=', '!=', 'in', 'not-in', '<', '<=', '>', '>=', 'between',
+  'is-null', 'not-null', 'is-empty', 'not-empty',
+  'starts-with', 'ends-with', 'contains', 'does-not-contain',
+  'time-interval', 'inside',
+]);
+
+// Structural tokens — handled elsewhere or free; never counted as features.
+const IGNORE_OPS = new Set(['field', 'expression', 'aggregation', 'value',
+  'aggregation-options', 'and', 'or', 'not', 'asc', 'desc', 'datetime', 'interval']);
+
+// Card displays the converter builds natively (chart/table/pivot/KPI/map).
+// Production histogram (7k-card estate): table 2999 · bar 1604 · line 1176 ·
+// combo 449 · scalar 259 · pie 135 · row 130 · area 67 · pivot 39 · scatter 3
+// all convert natively — see refs/scoring-rubric.md.
+const AUTO_DISPLAYS = new Set(['table', 'bar', 'row', 'line', 'area', 'combo',
+  'scatter', 'pie', 'scalar', 'smartscalar', 'trend', 'pivot', 'map',
+  'funnel', 'gauge', 'waterfall', 'sankey']);
+// Progress has no faithful native mapping; the converter preserves its data in
+// a flagged table. Funnel/gauge/waterfall/sankey are native Sigma kinds.
+const UNHANDLED_DISPLAYS = new Set(['progress']);
+
+function makeAdd(state) {
+  return (signal, bucket, reason, remediation) => {
+    let g = state.gaps.find((x) => x.signal === signal);
+    if (!g) { g = { signal, bucket, count: 0, reason, remediation }; state.gaps.push(g); }
+    g.count++;
+    if (bucket === 'auto') state.nAuto++; else if (bucket === 'hint') state.nHint++;
+    else if (bucket === 'manual') state.nManual++; else state.nUnhandled++;
+  };
+}
+
+// ---- MBQL tree walker — classifies every op the way translateMbqlExpr would.
+function walkExpr(node, where, add) {
+  if (!Array.isArray(node)) return;
+  const op = typeof node[0] === 'string' ? node[0].toLowerCase() : null;
+  if (op === 'value') return; // literal wrapper — unwraps transparently
+  if (op === 'field') {
+    const opts = node[2];
+    if (opts && typeof opts === 'object' && opts.binning) {
+      add('binning breakout (numeric histogram)', 'manual', `"${where}" bins a numeric field (${JSON.stringify(opts.binning)})`,
+        'The converter passes binning through with a warning. Recreate the buckets with BinFixed()/BinCount() in the consuming Sigma workbook element.');
+    }
+    return;
+  }
+  if (op === 'segment') {
+    add('segment ref (["segment", id])', 'manual', `"${where}" references a saved segment — its definition lives in another object`,
+      'Inline the segment\'s own MBQL filter (GET /api/segment/{id}) into the Sigma element filter; the converter flags the ref instead of guessing.');
+    return;
+  }
+  if (op === 'metric') {
+    add('legacy metric ref (["metric", id])', 'manual', `"${where}" references a saved legacy metric`,
+      'Inline the metric\'s own MBQL aggregation (GET /api/legacy-metric/{id}) as a Sigma metric; the converter flags the ref instead of guessing.');
+    return;
+  }
+  if (op) {
+    if (UNHANDLED_AGGS.has(op)) {
+      add(`${op} (cumulative/offset window calc)`, 'unhandled', `"${where}" uses MBQL ${op}`,
+        'Running totals / lag need a window scope Sigma defines on the consuming element. Rebuild with CumulativeSum / Lag in the date-grouped workbook element (proven pattern); the converter emits a flagged placeholder.');
+    } else if (AUTO_AGGS.has(op)) {
+      add('translated aggregation', 'auto', `"${where}" uses ${op} — maps via translateMbqlExpr`, '—');
+    } else if (AUTO_OPS.has(op)) {
+      add('translated expression/filter op', 'auto', `"${where}" uses ${op} — maps via translateMbqlExpr`, '—');
+    } else if (op === 'aggregation-options') {
+      // wrapper supplies the metric's name — score the inner aggregation only
+      walkExpr(node[1], where, add);
+      return;
+    } else if (!IGNORE_OPS.has(op)) {
+      add(`unmapped MBQL op ${op}`, 'unhandled', `"${where}" uses ${op} — no confirmed Sigma mapping`,
+        'Review and translate by hand; the converter emits a /* unmapped */ placeholder + a loud warning — never silent, never guessed.');
+    }
+  }
+  for (const child of node.slice(op ? 1 : 0)) walkExpr(child, where, add);
+}
+
+// ---- MBQL query (structural pass + expression trees) ----
+function scoreMbqlQuery(q, where, add, deps) {
+  if (!q || typeof q !== 'object') return;
+  if (q['source-query']) {
+    // pMBQL stages>1 / legacy nested source-query — converter flags + skips
+    // (rare but real: 14 of 7,023 on the reference production estate)
+    add('multi-stage query (nested source-query)', 'manual', `"${where}" aggregates over an inner query stage`,
+      'Rebuild as a chain of Sigma elements (inner stage → element, outer stage → child element) or a custom-SQL element; the converter flags it, never mistranslates.');
+  }
+  const st = q['source-table'];
+  if (typeof st === 'string' && st.startsWith('card__')) {
+    const dep = Number(st.slice(6));
+    if (!Number.isNaN(dep)) deps.push(dep);
+    add('nested-card source (card__N)', 'hint', `"${where}" is built on saved card ${st.slice(6)}`,
+      'Converts to an element sourced from that card\'s element — sequence the source card (usually a model) first; the converter wires it when both are in the input set.');
+  } else if (st != null) {
+    add('table source', 'auto', 'maps to the model/DM element for the warehouse table', '—');
+  }
+  if (q['source-query']) scoreMbqlQuery(q['source-query'], `${where} (inner query)`, add, deps);
+
+  for (const j of q.joins || []) {
+    add('explicit MBQL join', 'hint', `"${where}" joins ${typeof j['source-table'] === 'string' ? j['source-table'] : 'table ' + j['source-table']} (${j.strategy || 'left-join'})`,
+      'Converts to a Sigma DM join source — review for fan-out (row multiplication) before trusting aggregates, exactly as you would in Metabase.');
+    if (typeof j['source-table'] === 'string' && j['source-table'].startsWith('card__')) {
+      const dep = Number(j['source-table'].slice(6));
+      if (!Number.isNaN(dep)) deps.push(dep);
+    }
+    walkExpr(j.condition, `${where} join condition`, add);
+  }
+  for (const [name, expr] of Object.entries(q.expressions || {})) {
+    walkExpr(expr, `${where} expression "${name}"`, add);
+  }
+  for (const agg of q.aggregation || []) walkExpr(agg, `${where} aggregation`, add);
+  for (const b of q.breakout || []) {
+    const opts = Array.isArray(b) && b[0] === 'field' ? b[2] : null;
+    if (opts && typeof opts === 'object' && opts.binning) {
+      walkExpr(b, `${where} breakout`, add); // emits the binning manual signal
+    } else {
+      add('breakout (group-by)', 'auto', 'maps to a Sigma grouping / chart axis', '—');
+    }
+  }
+  walkExpr(q.filter, `${where} filter`, add);
+  // order-by / limit / fields are free — the converter carries them silently.
+}
+
+function classifyDisplay(display, where, add) {
+  const d = String(display || 'table').toLowerCase();
+  if (AUTO_DISPLAYS.has(d)) {
+    add(`${d} display → Sigma element`, 'auto', `${d} maps to a native Sigma chart/table/pivot/KPI/map element`, '—');
+  } else if (d === 'object') {
+    add('object display (record detail view)', 'manual', `"${where}" is a single-record detail view`,
+      'The converter emits the data as a flagged table; recreate the detail experience with element filters / drill in Sigma.');
+  } else if (UNHANDLED_DISPLAYS.has(d)) {
+    add(`${d} display (no faithful Sigma mapping)`, 'unhandled', `"${where}" renders as a ${d} — no faithful native Sigma mapping is verified`,
+      'Data is preserved as a flagged table; choose an explicitly approved replacement in the workbook.');
+  } else {
+    add(`${d} display (no converter mapping)`, 'unhandled', `"${where}" uses display "${d}"`,
+      'Review and pick the closest Sigma element by hand; the converter emits a flagged table.');
+  }
+}
+
+function countClickBehaviors(vs) {
+  // click_behavior can sit at the top level or under column_settings.* — count keys anywhere.
+  let n = 0;
+  const walk = (o) => {
+    if (!o || typeof o !== 'object') return;
+    if (Array.isArray(o)) { for (const c of o) walk(c); return; }
+    for (const [k, v] of Object.entries(o)) {
+      if (k === 'click_behavior' && v) n++;
+      walk(v);
+    }
+  };
+  walk(vs);
+  return n;
+}
+
+// ---- card scorer (mirrors metabase.ts) ----
+function scoreCard(text, name) {
+  let card;
+  try { card = JSON.parse(text); } catch { return null; }
+  try { card = normalizeCard(card); } catch { /* score the raw card — never crash the walk */ }
+  const type = (card.type === 'model' || card.dataset === true) ? 'model'
+    : card.type === 'metric' ? 'metric' : 'card';
+  const state = { gaps: [], nAuto: 0, nHint: 0, nManual: 0, nUnhandled: 0 };
+  const add = makeAdd(state);
+  const deps = [];
+  const dispName = card.name || name;
+
+  const dq = card.dataset_query || {};
+  if (dq.type === 'native') {
+    add('native SQL card → DM sql element', 'auto', 'the SQL text becomes a Sigma Custom SQL element verbatim', '—');
+    const tags = (dq.native && dq.native['template-tags']) || {};
+    for (const [tname, tag] of Object.entries(tags)) {
+      const ttype = String(tag?.type || '').toLowerCase();
+      if (ttype === 'dimension') {
+        add('field-filter template tag (type: dimension)', 'hint', `tag {{${tname}}} expands to a whole WHERE clause at runtime`,
+          'Converts to a Sigma control on the target column + an element filter (not a plain =-parameter) — verify the widget type and default after conversion.');
+      } else if (ttype === 'card') {
+        add('nested-card template tag ({{#N}})', 'hint', `tag {{${tname}}} inlines another saved question as a sub-query`,
+          'Sequence the referenced card first; the converter wires it when both are in the input set.');
+      } else if (ttype === 'snippet') {
+        add('snippet template tag', 'manual', `tag {{${tname}}} splices a shared SQL snippet`,
+          'Inline the snippet text (GET /api/native-query-snippet) into the Sigma Custom SQL by hand; Sigma has no snippet library.');
+      } else {
+        add('plain template tag → control (text/number/date/boolean)', 'auto', `tag {{${tname}}} (${ttype || 'text'}) maps to a Sigma control — Sigma custom SQL uses the SAME {{control-id}} parameter syntax, so the statement converts near-verbatim`, '—');
+      }
+    }
+    if (/\[\[/.test(dq.native?.query || '')) {
+      add('optional [[…]] SQL block', 'hint', `"${dispName}" uses Metabase optional-clause syntax`,
+        'Sigma has no optional-clause syntax: blocks whose tags are field filters or have defaults stay active; others are dropped (matching Metabase\'s empty-value behavior) with a loud warning. Review each.');
+    }
+  } else {
+    scoreMbqlQuery(dq.query, dispName, add, deps);
+  }
+
+  classifyDisplay(card.display, dispName, add);
+
+  // table.column_formatting — single rules convert to Sigma conditionalFormats;
+  // gradient/range scales are flagged (spec shape not yet live-verified).
+  for (const r of card.visualization_settings?.['table.column_formatting'] || []) {
+    if (r?.type === 'single') {
+      add('conditional formatting (single rule) → conditionalFormats', 'auto',
+        `"${dispName}" has a threshold formatting rule — converts to a Sigma conditionalFormats entry`, '—');
+    } else {
+      add('conditional formatting (gradient/range scale)', 'manual',
+        `"${dispName}" has a "${r?.type}" formatting scale`,
+        'Recreate as a Sigma backgroundScale conditional format in the UI; the converter flags it.');
+    }
+  }
+
+  const clicks = countClickBehaviors(card.visualization_settings);
+  for (let i = 0; i < clicks; i++) {
+    add('click_behavior (cross-filter / link)', 'manual', `"${dispName}" defines a click behavior`,
+      'Re-implement as a Sigma action (cross-element filter / open-link); the converter flags it, never fakes it.');
+  }
+
+  return finalize({
+    type, name: dispName, gaps: state.gaps,
+    nAuto: state.nAuto, nHint: state.nHint, nManual: state.nManual, nUnhandled: state.nUnhandled,
+    viewCount: typeof card.view_count === 'number' ? card.view_count : null,
+    usesCards: [...new Set(deps)],
+  });
+}
+
+// ---- dashboard scorer ----
+function scoreDashboard(text, name) {
+  let d;
+  try { d = JSON.parse(text); } catch { return null; }
+  const state = { gaps: [], nAuto: 0, nHint: 0, nManual: 0, nUnhandled: 0 };
+  const add = makeAdd(state);
+  const deps = [];
+  const dispName = d.name || name;
+
+  // v48+ uses dashcards[].size_x; pre-v48 uses ordered_cards[].sizeX — accept both.
+  const dashcards = d.dashcards || d.ordered_cards || [];
+
+  for (const p of d.parameters || []) {
+    add('dashboard parameter → control', 'auto', `parameter "${p.name || p.slug}" maps to a Sigma control (+ per-card targets from parameter_mappings)`, '—');
+  }
+  for (const t of d.tabs || []) {
+    add('dashboard tab → workbook page', 'auto', `tab "${t.name}" maps to a Sigma workbook page`, '—');
+  }
+
+  for (const dc of dashcards) {
+    const vs = dc.visualization_settings || {};
+    if ((dc.card_id == null || dc.card_id === undefined) && vs.virtual_card) {
+      add('text/heading card → text element', 'auto', 'markdown passes through to a Sigma text element', '—');
+    } else {
+      if (dc.card_id != null) deps.push(dc.card_id);
+      const cardDisplay = dc.card?.display || vs?.virtual_card?.display;
+      classifyDisplay(cardDisplay, `${dispName} / card ${dc.card_id ?? '?'}`, add);
+    }
+    const clicks = countClickBehaviors(vs);
+    for (let i = 0; i < clicks; i++) {
+      add('click_behavior (cross-filter / link)', 'manual', `a dashcard on "${dispName}" defines a click behavior`,
+        'Re-implement as a Sigma action (cross-element filter / open-link); the converter flags it, never fakes it.');
+    }
+  }
+
+  return finalize({
+    type: 'dashboard', name: dispName, gaps: state.gaps,
+    nAuto: state.nAuto, nHint: state.nHint, nManual: state.nManual, nUnhandled: state.nUnhandled,
+    viewCount: typeof d.view_count === 'number' ? d.view_count : null,
+    usesCards: [...new Set(deps)],
+  });
+}
+
+function finalize(r) {
+  const nFeatures = r.nAuto + r.nHint + r.nManual + r.nUnhandled;
+  const cost = 10 * r.nUnhandled + 3 * r.nManual + 1 * r.nHint;
+  // value = 10·view_count when the instance exposes it (v50+), else 10·n_features.
+  const usageBased = r.viewCount != null;
+  const value = usageBased ? 10 * r.viewCount : 10 * nFeatures;
+  const score = Math.round((value / (1 + cost)) * 100) / 100;
+  const complexity = r.nUnhandled > 0 ? 'high' : r.nManual > 0 ? 'medium' : 'low';
+  let tag;
+  if (r.nUnhandled >= 1) tag = 'needs-review';
+  else if (r.nManual + r.nUnhandled === 0) tag = 'migrate-first';
+  else if (score >= 10) tag = 'easy-win';
+  else tag = 'moderate';
+  return {
+    id: r.name, type: r.type, name: r.name,
+    n_features: nFeatures, n_auto: r.nAuto, n_hint: r.nHint, n_manual: r.nManual, n_unhandled: r.nUnhandled,
+    complexity, gaps: r.gaps,
+    view_count: r.viewCount, uses_cards: r.usesCards || [],
+    value, cost, score, tag,
+  };
+}
+
+// ============================================================================
+// main
+// ============================================================================
+const files = collect(inDir);
+if (!files.length) {
+  console.error(`no *.card.json / *.dashboard.json found under ${inDir}`);
+  process.exit(1);
+}
+
+const artifacts = [];
+for (const f of files) {
+  const text = readFileSync(f, 'utf8');
+  const name = basename(f).replace(/\.(card\.json|dashboard\.json)$/, '');
+  const res = f.endsWith('.card.json') ? scoreCard(text, name) : scoreDashboard(text, name);
+  if (res) { res.specFile = f; artifacts.push(res); }
+}
+artifacts.sort((a, b) => b.score - a.score);
+
+// estate roll-up
+const totals = artifacts.reduce((t, a) => {
+  t.n_auto += a.n_auto; t.n_hint += a.n_hint; t.n_manual += a.n_manual; t.n_unhandled += a.n_unhandled;
+  t.n_features += a.n_features;
+  return t;
+}, { n_auto: 0, n_hint: 0, n_manual: 0, n_unhandled: 0, n_features: 0 });
+
+// % auto-migratable = features that convert with no manual/unhandled work.
+// (auto + hint count as auto-migratable; hint is a review, not rework.)
+const autoMigratable = totals.n_auto + totals.n_hint;
+const pctAuto = totals.n_features ? Math.round((autoMigratable / totals.n_features) * 100) : 0;
+
+// gap histogram = manual + unhandled signals aggregated by signal name
+const histo = {};
+for (const a of artifacts) {
+  for (const g of a.gaps) {
+    if (g.bucket === 'manual' || g.bucket === 'unhandled') {
+      const k = g.signal;
+      histo[k] = histo[k] || { signal: g.signal, bucket: g.bucket, count: 0, artifacts: [], reason: g.reason, remediation: g.remediation };
+      histo[k].count += g.count;
+      histo[k].artifacts.push(a.name);
+    }
+  }
+}
+
+// EE sandboxing (GTAP export saved by discovery) — estate-level needs-review item.
+let nSandboxes = 0;
+for (const cand of [join(inDir, 'sandboxes.json'), join(dirname(inDir), 'sandboxes.json'), outDir ? join(outDir, 'sandboxes.json') : null]) {
+  if (cand && existsSync(cand)) {
+    try {
+      const sb = JSON.parse(readFileSync(cand, 'utf8'));
+      if (Array.isArray(sb)) { nSandboxes = sb.length; break; }
+    } catch { /* ignore */ }
+  }
+}
+if (nSandboxes > 0) {
+  histo['sandboxing policy (EE row-level security)'] = {
+    signal: 'sandboxing policy (EE row-level security)', bucket: 'unhandled', count: nSandboxes,
+    artifacts: ['(instance-level — sandboxes.json)'],
+    reason: `${nSandboxes} GTAP sandboxing polic${nSandboxes === 1 ? 'y' : 'ies'} restrict data per group`,
+    remediation: 'Port to Sigma user attributes + data-model filters with the metabase-to-sigma RLS engine (apply_sigma_rls.py) after the DM is posted — opt-in, reviewed per policy, never silent.',
+  };
+}
+const gapHistogram = Object.values(histo).sort((a, b) => (b.bucket === 'unhandled' ? 1 : 0) - (a.bucket === 'unhandled' ? 1 : 0) || b.count - a.count);
+
+const byComplexity = { low: 0, medium: 0, high: 0 };
+const byTag = {};
+for (const a of artifacts) { byComplexity[a.complexity]++; byTag[a.tag] = (byTag[a.tag] || 0) + 1; }
+
+const rollup = {
+  generated_at: new Date().toISOString().slice(0, 10),
+  n_artifacts: artifacts.length,
+  n_models: artifacts.filter((a) => a.type === 'model').length,
+  n_cards: artifacts.filter((a) => a.type === 'card' || a.type === 'metric').length,
+  n_dashboards: artifacts.filter((a) => a.type === 'dashboard').length,
+  totals,
+  pct_auto_migratable: pctAuto,
+  gap_histogram: gapHistogram,
+  by_complexity: byComplexity,
+  by_tag: byTag,
+  usage_available: artifacts.some((a) => a.view_count != null),
+  n_sandboxes: nSandboxes,
+};
+
+const out = { rollup, artifacts };
+writeFileSync(join(outDir, 'coverage.json'), JSON.stringify(out, null, 2));
+console.log(`scored ${artifacts.length} artifacts (${rollup.n_models} models, ${rollup.n_cards} questions, ${rollup.n_dashboards} dashboards) — ${pctAuto}% auto-migratable -> ${join(outDir, 'coverage.json')}`);

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/QUICKSTART.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/QUICKSTART.md
@@ -1,0 +1,87 @@
+author: Sigma Computing
+summary: Migrating from Metabase made easy — convert Metabase models and dashboards to Sigma with Claude Code
+id: developers_migrating_from_metabase_made_easy
+categories: Developers, Migration, AI
+environments: Web
+status: Draft
+feedback link: https://github.com/twells89/metabase-to-sigma/issues
+
+# Migrating from Metabase to Sigma made easy
+
+## Introduction & why it matters
+Duration: 2
+
+Rebuilding Metabase content in a new BI tool by hand means re-deriving every model,
+re-typing every custom expression, and hoping the numbers still tie out.
+
+This quickstart automates the path with **your coding agent** (Claude Code, Cursor,
+Cortex Code, …) + the Metabase→Sigma skills: discover content over the Metabase REST
+API, translate MBQL to Sigma formulas, build a Sigma data model and matching workbook,
+and **verify data parity** against the same warehouse.
+
+positive
+: **Validation status:** discovery, extraction, scoring, and the conversion
+semantics were live-validated end to end. The released wrapped/flat workbook
+payload is covered offline; use the POST/readback, parity, and PNG gates on
+every migration before calling it complete.
+
+positive
+: Metabase is open source — you can rehearse the entire migration on a local
+`docker run metabase/metabase` pointed at the same warehouse Sigma reads.
+
+## Who this is for
+Duration: 1
+
+- Sigma SEs and technical CSMs
+- Migration partners
+- Metabase admins evaluating a move to Sigma
+
+## Prerequisites
+Duration: 2
+
+- **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, etc.
+- **Metabase REST access** — an API key (v49+: Admin → Settings → Authentication →
+  API keys) or username/password. Open-source Metabase is fully sufficient.
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`).
+- **The same warehouse on both sides** — Sigma's connection must reach the database
+  Metabase queries (the bundled H2 Sample Database is not reachable from Sigma).
+
+## Assess the estate (optional, ~minutes)
+Duration: 5
+
+```bash
+export MB_BASE="https://<your-metabase>" MB_KEY="mb_…"
+eval "$(skills/metabase-to-sigma/scripts/get-metabase-session.sh)"
+bash skills/metabase-assessment/scripts/discover-metabase.sh --out /tmp/mb-assess
+node skills/metabase-assessment/scripts/score-coverage.mjs --in /tmp/mb-assess/specs --out /tmp/mb-assess
+node skills/metabase-assessment/scripts/render-report.mjs --out /tmp/mb-assess
+open /tmp/mb-assess/readout.html
+```
+
+The readout scores every card/dashboard against the converter's exact coverage and
+hands you a wave plan: migrate-first, moderate, needs-review.
+
+## Migrate a dashboard
+Duration: 15
+
+Ask your agent:
+
+> Migrate my Metabase dashboard "Exec Overview" to Sigma.
+
+The `metabase-to-sigma` skill walks Phases 0–4: discover (cards + **database
+metadata** — MBQL refs columns by integer id), convert models → data model, check
+for a reusable existing DM, POST + read back (hard-fails on any error-typed column),
+convert the dashboard → workbook wired to the DM, apply the 24-col layout, then run
+the parity plan and compare totals to the Metabase cards.
+
+Every construct without a clean Sigma analog (cum-sum, segment refs, progress
+viz, click behaviors) is **flagged with a warning, never faked**.
+
+## Verify & wrap up
+Duration: 3
+
+- Parity gate: `assert-parity --check` green against the Metabase numbers (mind
+  Metabase's result cache — Sigma reads live).
+- Layout gate: `apply-layout.mjs` reported `layoutOnReadback: true`.
+- Row security (Pro/EE sandboxing): the skill detects, asks, and ports to Sigma
+  user attributes — skipping is loud and explicit.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/SKILL.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: metabase-to-sigma
+description: >-
+  Migrate Metabase content to Sigma. Use when the user has Metabase questions,
+  models, or dashboards and wants to recreate them in Sigma. Converts MBQL
+  cards/models (+ database metadata) → Sigma data model and dashboards → Sigma
+  workbooks, translating MBQL expressions/aggregations and flagging constructs
+  with no clean Sigma analog. Discovery via the Metabase REST API (API key or
+  session token) — works on open-source and Pro/EE alike.
+user-invocable: true
+---
+
+# Metabase → Sigma migration
+
+Convert Metabase **models + questions** into a Sigma **data model**, then convert the
+**dashboards** that sit on them into matching Sigma **workbooks**. Translate what maps
+cleanly; **flag what doesn't** (cum-sum/offset windows, saved segment refs,
+progress viz, click behaviors) instead of emitting wrong logic.
+
+> **Status: live-validated end to end.** Extraction was proven against a live
+> 7k-card / 1.5k-dashboard Metabase Cloud estate (v1.61.4 — 100% pMBQL); the
+> Sigma build path was validated with exact query parity, including models,
+> nested questions, combo charts, controls, and exact-grid layout
+> (`refs/design-notes.md` §9–§10d). The released wrapped/flat workbook code
+> representation is covered by offline tests and corpus goldens; repeat the
+> live POST/readback/PNG gate before extending the historical live claim to
+> that payload.
+
+> **This skill is customizable in plain language.** Read
+> `~/.metabase-to-sigma/preferences.md` if it exists at the start of every run,
+> restate the active preferences briefly, and honor them throughout (they may
+> override any default EXCEPT the verification gates). When the user corrects an
+> output or states a preference mid-run, OFFER to persist it — see
+> `refs/customization.md` for the three tiers (preferences / learned formula
+> rules / converter changes).
+
+<!-- mandatory-pre-read -->
+> Before a run, read `refs/design-notes.md`, `refs/rest-api.md`, and
+> `refs/control-parity.md`.
+<!-- /mandatory-pre-read -->
+> Load `refs/mbql-shapes.md`, `refs/expression-dsl.md`, or
+> `refs/template-tags.md` only when that phase needs the detail. For canonical
+> Sigma shapes, defer to `sigma-data-models` and `sigma-workbooks`.
+
+---
+
+## Prerequisites
+
+- **Metabase REST access** — an **API key** (v49+: Admin → Settings → Authentication →
+  API keys; preferred, durable) or a username/password session. Capture either with
+  `scripts/get-metabase-session.sh`. Open-source Metabase is fully sufficient — no
+  Pro/EE features required (serialization export is EE-only; this skill doesn't use it).
+- **Sigma** API credentials in `~/.sigma-migration/env` (or environment
+  variables), minted with `scripts/get-token.sh`.
+- **The same warehouse on both sides.** Sigma reads the warehouse live; parity only
+  means something when the Sigma connection reaches the database Metabase queries.
+  (Metabase's bundled H2 Sample Database is NOT reachable from Sigma — pick content
+  on a real warehouse, or land the data first.)
+- **Know your warehouse dialect.** The converter auto-detects it from the Sigma connection
+  (`--connection <id>` triggers a `GET /v2/connections/<id>` lookup), or pass `--warehouse`
+  explicitly: `bigquery` | `snowflake` | `databricks` | `redshift` | `postgres` | `athena`.
+  Required for correct array-aggregation rewrites (BigQuery `ARRAY_AGG` → `array_to_string`,
+  Snowflake → `LISTAGG`, Databricks `collect_list` → `array_join`, etc.). Without it,
+  native SQL cards with array aggregations will render as blank cells in Sigma.
+- **Node** for the converter (`converter/`: `npm ci` once).
+
+---
+
+## Phase 0 — Discover (Metabase REST)
+
+```bash
+export MB_BASE="https://<host>"        # + MB_KEY, or MB_USER/MB_PASS
+eval "$(scripts/get-metabase-session.sh)"
+scripts/metabase-discover.sh databases                  # find the warehouse connection
+scripts/metabase-discover.sh metadata 2 > metadata.json # FIELD IDS — required by the converter
+scripts/metabase-discover.sh collections                # folder tree
+scripts/metabase-discover.sh items 5                    # cards/models/dashboards in a collection
+scripts/metabase-discover.sh card 123      > orders-model.card.json
+scripts/metabase-discover.sh dashboard 9   > exec.dashboard.json
+```
+
+- **Always fetch `metadata <dbId>` first** — MBQL references columns by integer field
+  id; without the metadata map the converter falls back to per-card `result_metadata`
+  names (lossy, warned).
+- Models (`type: "model"`, or `dataset: true` pre-v50) are the semantic layer — fetch
+  them even when no dashboard uses them directly; questions stack on them via
+  `source-table: "card__N"`.
+- For estate-wide inventory + a migration shortlist, run the `metabase-assessment`
+  skill first — its `specs/` directory feeds this skill directly.
+
+## Phase 1 — Convert models/cards → Sigma data model
+
+```bash
+cd converter && npm ci
+node --import tsx/esm cli.ts ../bundle.json --metadata ../metadata.json \
+  --connection <SIGMA_CONN> --database <DB> --schema <SCHEMA>
+```
+
+`bundle.json` is `{ "cards": [ <card JSONs> ] }` (or pass a single card file). Emits
+the Sigma data-model JSON on stdout; stats + warnings on stderr. Read the warnings
+aloud to the user — they are the parts that need manual authoring (cum-sum/offset
+windows, segment/metric refs to inline, binned breakouts, field-filter SQL tags).
+
+## Phase 1.5 — Reuse an existing DM? (avoid sprawl)
+
+Before POSTing a NEW data model in Phase 2, check whether an existing Sigma DM already
+covers the same warehouse tables (don't add a 4th near-identical DM for the same schema):
+
+```bash
+python3 scripts/metabase-dm-signature.py --dm-spec dm.json --out dm-signature.json
+eval "$(scripts/get-token.sh)"
+ruby scripts/find-or-pick-dm.rb --workbook-signature dm-signature.json \
+  --out dm-match.json --auto-pick           # exit 0 = candidate ≥ min-score
+```
+
+- **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name, matched
+  cols (N/M), and the inherited-extras warning. If they reuse, run a **shape preflight**
+  (read the candidate spec back; every column the dashboard references must resolve with
+  no `type=error`), then **skip Phase 2** and run Phase 3 against the matched
+  `recommended_dm_id`.
+- **Score < 0.6** → POST new (Phase 2) and TELL the user no reusable DM was found.
+
+## Phase 1.9 — Choose where to build (ask first when no destination given)
+
+Don't pick the destination for the user. If they didn't supply a `--folder <id>`, ASK before the Phase 2 POST:
+
+1. `node scripts/pick-destination.mjs list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root), an existing **folder**, **My Documents** (when non-null — null for service tokens), or **create a new folder**: `node scripts/pick-destination.mjs create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>` to every `post-and-readback.mjs` call (DM + workbook). `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
+## Phase 2 — POST the data model + read back ids (hard gate)
+
+```bash
+eval "$(scripts/get-token.sh)"                 # SIGMA_BASE_URL + SIGMA_API_TOKEN
+node scripts/post-and-readback.mjs --type datamodel --spec dm.json \
+  --folder <folderId> --out dm-map.json
+```
+
+POSTs to `/v2/dataModels/spec`, reads the spec back, and **fails on any `type=error`
+column** (a spec can POST 200 yet have formulas that don't resolve at query time — the
+readback scan catches it, derived view included). `dm-map.json` carries the real
+`dataModelId` + element ids (Sigma reassigns them on POST). Do not proceed past a
+non-zero exit.
+
+## Phase 3 — Convert the dashboard → Sigma workbook, wired to the DM
+
+```bash
+node --import tsx/esm cli.ts ../exec.dashboard.json --metadata ../metadata.json --dm <dataModelId> \
+  --layout-out hints.json --control-scope-out control-scope.json > wb.json
+node scripts/remap-wb-to-dm-ids.mjs --wb wb.json --dm-id <dataModelId> --dm-spec dm.json --out wb.remapped.json
+ruby scripts/lib/preflight_lint.rb wb.remapped.json   # MANDATORY — fix all violations before POST
+node scripts/post-and-readback.mjs --type workbook --spec wb.remapped.json --folder <folderId>
+node scripts/apply-layout.mjs --workbook <workbookId> --hints hints.json
+```
+
+The workbook converter emits the released code representation: outer metadata
+plus `document`, flat `document.elements`, metadata-only pages, and a complete
+canonical `<Page>`/`<Element>` layout. The create write is therefore fully
+placed. `apply-layout.mjs` GETs the current document and performs the final
+layout-safe full-document PUT after any repair; never send a partial PUT.
+
+**Preflight (mandatory):** `ruby scripts/lib/preflight_lint.rb wb.remapped.json` exits 1 with a precise message on the two migration-killer bugs — a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows instead of an aggregated summary), and a malformed `control` (missing `id`/`controlId`/`controlType` or the flat list value fields `source`/`mode`/`selectionMode`/`values`). Fix every violation first; **never conclude a feature is "unsupported" from an `Invalid kind` error** — it means the inner fields are wrong. Verified shapes: `sigma-workbooks` `controls.md`/`tables.md`.
+
+Each dashcard becomes the matching Sigma element sourced from the migrated DM element
+(KPI/bar/line/area/pie/combo/scatter/table/pivot/map/funnel/gauge/waterfall/sankey;
+text cards → text elements; progress → a flagged table). The converter emits each element's
+`source.elementId` as the source card/table **name** (a placeholder) —
+`remap-wb-to-dm-ids.mjs` rewrites those to real ids from Phase 2's readback (native
+cards all read back "Custom SQL", so it falls back to column-set fingerprints and
+repairs every formula ref against the live DM columns).
+
+**Controls** (full contract: `refs/control-parity.md`). Metabase dashboard parameters
+declare their card targets explicitly (`parameter_mappings`) — the converter wires
+each mapping and emits the **`control-scope.json` sidecar** (`--control-scope-out`,
+keep it next to the workbook spec: post-and-readback and gate 7 pick it up there):
+
+- **scalar params** (string/number equality, incl. static-list → segmented grain
+  switchers with values + defaults) → hidden boolean `[Col] = [slug]` + element filter;
+- **range params** (`date/*` → date-range with flat `mode: "between"`,
+  `number/between` → number-range) → REAL control `filters` targets, re-rooted
+  through a hidden **base table** on a trailing `Data` page (control targets may
+  only point at table elements; list/scalar targets on datetime columns are
+  silently stripped — both verified cross-plugin gotchas);
+- **variable-tag params** (drive `{{tags}}` in card SQL) → `--dm-spec` emits
+  control→DM-parameter bindings; if the org rejects them, post-and-readback
+  **drops those controls** (decorative controls are exactly what gate 7 blocks —
+  the DM `{{tag}}` controls still carry the filter; sync a workbook control in
+  the UI when the org enables DM-parameter targeting, or pass
+  `--keep-rejected-bindings` to keep them and sync by hand);
+- **unmapped params + unwirable field-filters** → NO control, loud warning
+  (flag, never furniture).
+
+post-and-readback (workbook) finishes by running the SHARED layout + control lints
+on the readback spec — fix violations (repair recipes in `refs/control-parity.md`)
+or annotate genuine narrow intent in `control-scope.json` before moving on.
+Metabase's 24-col dashcard grid maps 1:1 onto Sigma's authoritative layout.
+`apply-layout.mjs --hints` confirms the exact geometry survives readback and
+re-runs the layout lint.
+
+## Phase 4 — Verify parity + the seven gates (hard gate — the real proof)
+
+```bash
+node scripts/assert-parity.mjs --plan --type workbook --id <workbookId>   # emits per-element SQL
+# run each through Sigma MCP or the Sigma query API; save totals to actual.json
+node scripts/assert-parity.mjs --check --actual actual.json --expected metabase.json --tol 0.01 \
+  --workdir <workdir>  --census '{"zones_total":N,"charts_built":M,"zones_unmatched":0,"unmatched_zone_names":[]}'
+ruby scripts/assert-phase6-ran.rb --workdir <workdir> --workbook-id <workbookId>   # gates 1–7
+```
+
+**Expected values must be LIVE**: re-run the Metabase cards (`POST /api/card/{id}/query`)
+at verification time — a baseline captured earlier drifts as warehouse rows land, and
+the diff reads as a phantom parity failure.
+
+`assert-parity --check` writes the `parity-final.json` sentinel into `--workdir`
+(post-and-readback already wrote `wb-ids.json` + `posted-workbooks.jsonl` there);
+derive the `--census` counts from the converter stats (dashcards converted vs
+elements built — name any legitimately unbuildable zones). Then
+**`assert-phase6-ran.rb` is the GREEN gate**: parity ran (1), no orphan workbooks
+(2), no error-typed columns (3), layout applied (4), tile census (5), layout lint
+(6), control lint honoring `control-scope.json` (7). Exit 0 or it isn't done.
+
+**Flip test** (runtime control evidence — REQUIRED after any hand-repaired wiring,
+recommended always; see `refs/control-parity.md` for why MCP cannot do this):
+
+```bash
+ruby scripts/probe-controls.rb --workbook-id <workbookId> --check-out-of-closure
+# date-range / number-range controls need an explicit flip value:
+#   --value <controlId>='min:2026-01-01,max:2026-03-31'
+```
+
+A mapped card's export must CHANGE under `parameters:{<controlId>: <value>}`; an
+unmapped same-page card must NOT (no leak).
+
+**Visual gate** (layout, control widgets, chart marks — things data queries can't see):
+export each page as PNG and LOOK at it:
+
+```bash
+# POST /v2/workbooks/{id}/export {"pageId":"<pageId>","format":{"type":"png","pixelWidth":1400}}
+# → {queryId} → poll GET /v2/query/{queryId}/download until 200 → PNG
+```
+
+Check: controls render as the right widget (segmented grain switcher, defaults filled),
+elements sit at the Metabase grid positions (not stacked), charts show marks (an empty
+chart with a title = a column/axis problem the readback scan can miss).
+
+A migration is **GREEN only when** (a) `assert-parity --check` passes, (b)
+`assert-phase6-ran.rb` exits 0 (all seven gates, control lint included), AND (c) the
+workbook came back with a clean layout (`apply-layout.mjs` reported
+`layoutOnReadback: true`) — never on a 200 POST alone. `metabase.json` = the numbers
+from the Metabase cards (run each card via `POST /api/card/{id}/query` — the one
+non-GET this skill may use, read-only in effect — or read them off the dashboard).
+Mind caching: Metabase serves cached results by default; Sigma reads live. A delta
+that matches rows landed since the cache filled is freshness, not a failure.
+
+**After parity passes, tell the user this in the conversation:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
+
+```bash
+node scripts/report-telemetry.mjs --duration <elapsed_seconds>
+# on failure: node scripts/report-telemetry.mjs --duration <elapsed_seconds> --failed
+```
+
+---
+
+## What converts, what's flagged (never faked)
+
+Converted coverage includes pMBQL normalization, MBQL joins/expressions/
+aggregations/breakouts, FK relationships, nested questions, compatible native
+SQL remodeling, Custom SQL fallback, template-tag controls, formats, and
+dashboard tabs/layout. Native workbook kinds include table, pivot, KPI,
+bar/line/area/combo/scatter/pie, maps, funnel, gauge, waterfall, and sankey.
+Every shelf/channel pointer uses the current `columnId` contract.
+
+Flagged coverage includes cumulative/offset windows, saved segment/legacy
+metric references, binning, multi-stage queries, click behaviors, smart-scalar
+comparisons, object detail views, gradient conditional formats, and Metabase
+progress displays. The converter preserves reviewable data and emits a loud
+warning rather than inventing semantics. Load `refs/expression-dsl.md`,
+`refs/template-tags.md`, and `refs/design-notes.md` for the detailed contract.
+
+## Security: Row-Level Security (sandboxing)
+
+Row security is **never silently dropped and never silently ported** — and it is handled
+by the **skill**, not baked into the converted model. Metabase **sandboxing is Pro/EE
+only** (`GET /api/mt/gtap` lists sandboxes; group-based). The converter only **detects
+and reports** (`security.json` + a loud `SECURITY:` line) when sandbox data is provided;
+on OSS there is nothing to detect — but **ask the customer anyway** (RLS is sometimes
+faked with per-group collections + duplicated filtered questions; inventory those by hand).
+
+**Flow (only when security was detected or found manually — zero overhead otherwise):**
+1. Convert + post the DM. Capture `dataModelId` + `security.json`
+   (manual entries use the same shape: `[{ "type": "row-filter", "name": …, "expression": …, "groups": […] }]`).
+2. **Gate (opt-in/out, default Port).** Plain-English summary of each rule + proposed
+   Sigma user-attribute mapping → **Port** / **Customize** / **Skip**. Reuse existing
+   Sigma user attributes/teams before creating new ones.
+3. Provision + apply with the shared engine:
+   ```bash
+   eval "$(scripts/get-token.sh)"
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <id>            # plan only
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <id> --provision --apply
+   ```
+4. Assign per-user attribute values from Metabase group membership
+   (`GET /api/permissions/group/{id}` lists members with emails — reconcile to Sigma members).
+
+**Skip is loud:** opting out leaves the migrated model showing ALL rows to everyone. Confirm first.
+
+## Gap scout — close a flagged expression
+
+For a flagged construct you want to actually resolve (an offset window, a segment ref,
+an unmapped op), spawn the **gap-scout subagent** (`scripts/gap-scout.md`): it proposes
+a Sigma formula, validates it against the customer's live Sigma via
+`scripts/scout-validate-and-persist.mjs`, and on success persists the rule to
+`~/.metabase-to-sigma/learned-rules.json` — which the converter CLI auto-applies
+*before* the built-in translator on the next run. If no formula validates, it returns
+an opt-in `scripts/escalate-gap.py` command to file a tracking issue (ask first).
+
+## Customizing the skill (your org, your rules)
+
+Everything above is the default behavior — not the required one. Tell Claude what
+you want different, in plain language, and ask it to remember:
+
+- **Run preferences** (naming, folders, which tabs/cards, control widget choices,
+  layout taste) → saved to `~/.metabase-to-sigma/preferences.md`, read at the start
+  of every run.
+- **Formula translations** specific to your SQL idioms → learned rules
+  (`~/.metabase-to-sigma/learned-rules.json`), validated live before persisting.
+- **Structural behavior** (chart mappings, DM shape) → converter changes with
+  fixture tests; share fixes back via `scripts/escalate-gap.py` or a PR.
+
+Both home-dir files survive `git pull`. Full guide + worked examples:
+`refs/customization.md`.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/PROVENANCE.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/PROVENANCE.json
@@ -1,0 +1,5 @@
+{
+  "source": "in-skill converter sources (cli.ts + metabase.ts + metabase-dashboard.ts + sigma-ids.ts + pmbql-normalize.mjs)",
+  "vendored_modules": "pmbql-normalize.mjs",
+  "note": "This converter is maintained as source inside the plugin. pmbql-normalize.mjs is authored source, not a generated or upstream-vendored bundle."
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/cli.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/cli.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Metabase → Sigma converter CLI.
+ *   node --import tsx/esm cli.ts <input.json> [opts]
+ *
+ * Auto-detects input:
+ *   JSON with `dashcards`/`ordered_cards`             → dashboard → Sigma workbook spec
+ *   JSON with `cards`, an array of cards, or a single
+ *   card with `dataset_query`                         → cards → Sigma data model
+ *
+ * Options: --metadata <metadata.json> --connection <id> --database <DB> --schema <S>
+ *          --dm <dataModelId> --security-out <file>
+ *          --layout-out <file> --control-scope-out <file>   (dashboards only)
+ *          --envelope   emit {dataModel|workbook,warnings,stats} for corpus use
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { convertMetabaseToSigma, applyWarehouseTransforms, type WarehouseDialect } from './metabase.js';
+import { convertMetabaseDashboardToSigma } from './metabase-dashboard.js';
+
+// Map Sigma connection type strings → our WarehouseDialect enum.
+const SIGMA_TYPE_MAP: Record<string, WarehouseDialect> = {
+  bigquery: 'bigquery', snowflake: 'snowflake', databricks: 'databricks',
+  redshift: 'redshift', postgres: 'postgres', postgresql: 'postgres',
+  mysql: 'mysql', athena: 'athena',
+};
+
+async function detectWarehouse(connectionId: string): Promise<WarehouseDialect> {
+  const base = process.env.SIGMA_BASE_URL?.replace(/\/$/, '');
+  const token = process.env.SIGMA_API_TOKEN;
+  if (!base || !token || !connectionId || connectionId === '<CONNECTION_ID>') return 'unknown';
+  try {
+    const res = await fetch(`${base}/v2/connections/${connectionId}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+    });
+    const json = await res.json() as any;
+    const type = String(json?.type || json?.connectionType || '').toLowerCase();
+    return SIGMA_TYPE_MAP[type] ?? 'unknown';
+  } catch { return 'unknown'; }
+}
+
+// Gap-scout learned rules (validated, customer-discovered translations) live in the
+// customer's home dir so a skill `git pull` never clobbers them. Applied before the
+// built-in translator (see scripts/gap-scout.md).
+function loadLearnedRules() {
+  try {
+    const p = join(homedir(), '.metabase-to-sigma', 'learned-rules.json');
+    const rules = JSON.parse(readFileSync(p, 'utf8'));
+    const arr = Array.isArray(rules) ? rules : (rules.rules || []);
+    if (arr.length) console.error(`[learned-rules] applying ${arr.length} customer rule(s) from ${p}`);
+    return arr;
+  } catch { return []; }
+}
+
+const args = process.argv.slice(2);
+const opt = (k: string, d = '') => { const i = args.indexOf('--' + k); return i >= 0 ? args[i + 1] : d; };
+// positional arg = the first token that is neither a flag nor a flag's value
+const input = args.find((a: string, i: number) => !a.startsWith('--') && !(i > 0 && args[i - 1].startsWith('--')));
+if (!input) { console.error('usage: cli.ts <cards.json|dashboard.json> [--metadata metadata.json --connection X --database DB --schema S --dm ID --security-out security.json]'); process.exit(1); }
+
+const raw = JSON.parse(readFileSync(input, 'utf8'));
+const metadataFile = opt('metadata');
+const metadata = metadataFile ? JSON.parse(readFileSync(metadataFile, 'utf8')) : undefined;
+const learnedRules = loadLearnedRules();
+
+const connectionId = opt('connection', '<CONNECTION_ID>');
+// --warehouse explicit > auto-detect from Sigma connection API > unknown (no transforms)
+const warehouseArg = opt('warehouse') as WarehouseDialect | '';
+const warehouse: WarehouseDialect = warehouseArg
+  ? (SIGMA_TYPE_MAP[warehouseArg.toLowerCase()] ?? warehouseArg as WarehouseDialect)
+  : await detectWarehouse(connectionId);
+if (warehouse !== 'unknown') console.error(`[warehouse] dialect: ${warehouse}`);
+else console.error(`[warehouse] dialect unknown — pass --warehouse <bigquery|snowflake|databricks|redshift|postgres|athena> to enable SQL transforms`);
+
+const isDashboard = !!(raw.dashcards || raw.ordered_cards);
+let res: any;
+if (isDashboard) {
+  res = convertMetabaseDashboardToSigma(raw, { dataModelId: opt('dm') || undefined, metadata, learnedRules });
+} else {
+  const cards = Array.isArray(raw) ? raw : raw.cards ? raw.cards : raw.dataset_query ? [raw] : [];
+  res = convertMetabaseToSigma(
+    { metadata: metadata ?? raw.metadata, cards, sandboxes: raw.sandboxes },
+    { connectionId, database: opt('database'), schema: opt('schema'), warehouse, learnedRules },
+  );
+}
+
+const payload = args.includes('--envelope')
+  ? (isDashboard
+    ? { workbook: res.workbook, warnings: res.warnings, stats: res.stats }
+    : { dataModel: res.model, warnings: res.warnings, stats: res.stats })
+  : (isDashboard ? res.workbook : res.model);
+process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+console.error(`\n[${isDashboard ? 'dashboard→workbook' : 'cards→data-model'}] stats: ${JSON.stringify(res.stats)}`);
+
+// 1:1 Metabase grid geometry (row/col/sizeX/sizeY per element) — feed to
+// scripts/apply-layout.mjs --hints to reproduce the dashboard layout exactly.
+if (isDashboard && res.layout && opt('layout-out')) {
+  writeFileSync(opt('layout-out'), JSON.stringify(res.layout, null, 2));
+  console.error(`layout hints → ${opt('layout-out')}`);
+}
+
+// control-scope.json sidecar (shared cross-plugin contract — see
+// scripts/lib/control_lint.rb header CONTRACT + refs/control-parity.md).
+// Write it NEXT TO the workbook spec in your workdir: post-and-readback and
+// assert-phase6-ran (gate 7) pick it up from there automatically.
+if (isDashboard && res.controlScope && opt('control-scope-out')) {
+  writeFileSync(opt('control-scope-out'), JSON.stringify(res.controlScope, null, 2));
+  console.error(`control scope sidecar → ${opt('control-scope-out')} (sourceFilterSignals=${res.controlScope.sourceFilterSignals}, controls=${res.controlScope.controls.length})`);
+}
+
+// Detected security (Metabase sandboxing) — detect-only; apply_sigma_rls.py ports it.
+if (res.security?.length) {
+  const out = opt('security-out', 'security.json');
+  writeFileSync(out, JSON.stringify(res.security, null, 2));
+  console.error(`SECURITY: ${res.security.length} rule(s) detected → ${out} — run scripts/apply_sigma_rls.py after posting the model (see SKILL.md "Security").`);
+}
+if (res.warnings.length) {
+  console.error(`warnings (${res.warnings.length}) — translated where possible, flagged where not:`);
+  res.warnings.forEach((w: string) => console.error('  ! ' + w));
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/metabase-dashboard.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/metabase-dashboard.ts
@@ -1,0 +1,1055 @@
+/**
+ * Metabase dashboard JSON → Sigma workbook code-representation payload.
+ *
+ * Input = GET /api/dashboard/{id}. Accepts BOTH the modern `dashcards` shape
+ * (size_x/size_y) and the legacy `ordered_cards` shape (sizeX/sizeY).
+ *
+ *   dashboard tab            → workbook page (no tabs → single page)
+ *   dashcard (by `display`)  → table / bar-chart (row = orientation:'horizontal' — the ONLY
+ *                              valid orientation value; vertical OMITS the key) / line-chart /
+ *                              area-chart / combo-chart / scatter-chart / pie-chart /
+ *                              kpi-chart / pivot-table / region-map | point-map /
+ *                              funnel-chart / gauge-chart / sankey-chart /
+ *                              waterfall-chart. Progress stays a flagged table.
+ *   text/heading dashcards   → text elements (markdown passes through)
+ *   dashboard parameters     → workbook controls (controlId = parameter slug); each
+ *                              parameter_mapping wires a REAL control `filters` target
+ *                              on a TABLE element (the dashcard itself when it is a
+ *                              table, else a hidden base table the chart re-roots
+ *                              through — chart/KPI targets 400, and boolean-match
+ *                              columns referencing list controls error live). The
+ *                              control-scope.json sidecar carries declared scope.
+ *
+ * Element sources are PLACEHOLDERS: source { kind:'table', elementId: '<DM element NAME>' }.
+ * The real Sigma element ids don't exist until the DM is POSTed —
+ * scripts/remap-wb-to-dm-ids.mjs rewrites the placeholders afterwards (matched by name).
+ *
+ * Workbook output follows the released code representation: outer metadata plus
+ * `document`, metadata-only pages, flat elements, and authoritative layout XML.
+ * Metabase's 24-column grid maps 1:1 to Sigma and client ids survive CREATE.
+ */
+
+import { resetIds, sigmaShortId, sigmaDisplayName, formatFromMask } from './sigma-ids.js';
+import { buildFieldIndex, recognizeSimpleNativeSql, translateMbqlExpr, translateAggregation, type FieldIndex, type MbqlCtx, type LearnedRule } from './metabase.js';
+// pMBQL → legacy at intake: embedded dashcard cards AND parameter_mapping
+// targets arrive in pMBQL form on modern instances (Cloud v1.61+).
+import { normalizeCard, normalizeClause } from './pmbql-normalize.mjs';
+
+// ── workbook spec types (minimal) ────────────────────────────────────────────
+interface WbColumn { id: string; name: string; formula: string; format?: Record<string, any>; hidden?: boolean; }
+interface WbControl {
+  id: string; kind: 'control'; controlId: string; name: string; controlType: string;
+  source?: Record<string, any>; value?: any; values?: any[]; mode?: string;
+  filters?: Array<{ source: { kind: string; elementId: string }; columnId: string }>;
+}
+interface WbElement {
+  id: string; kind: string; name?: string; source?: Record<string, any>;
+  columns?: WbColumn[]; order?: string[]; filters?: any[]; conditionalFormats?: any[];
+  rowsBy?: Array<{ columnId: string }>; columnsBy?: Array<{ columnId: string }>; values?: string[];
+  xAxis?: { columnId: string };                                                          // cartesian charts
+  yAxis?: { columnIds: Array<string | Record<string, any>> };
+  value?: { columnId: string };
+  color?: any; stacking?: string; orientation?: string;
+  latitude?: { columnId: string }; longitude?: { columnId: string };
+  region?: { columnId: string; regionType: string };
+  stage?: { columnId: string }; series?: { columnId: string };
+  stages?: Array<{ columnId: string }>;
+  body?: string;
+}
+interface WbPage { id: string; name: string; elements: WbElement[]; }
+
+export interface DashboardLayoutHint {
+  grid: number;
+  pages: Array<{ name: string; elements: Array<{ elementId: string; name: string; row: number; col: number; sizeX: number; sizeY: number }> }>;
+}
+/** control-scope.json sidecar (shared cross-plugin contract — see
+ *  scripts/lib/control_lint.rb header CONTRACT + refs/control-parity.md).
+ *  sourceFilterSignals = dashboard parameters with >=1 parameter_mapping
+ *  (Metabase parameters declare their card targets EXPLICITLY — an unmapped
+ *  parameter filters nothing in Metabase either, so it is not a signal).
+ *  Per-control `scope` = the converted element names of its mapped cards
+ *  (the declared-target allowlist); `mustReach` = the subset the converter
+ *  actually wired (hard assertions for the lint's closure walk). */
+export interface ControlScopeSidecar {
+  version: 1; source: 'metabase'; sourceFilterSignals: number;
+  controls: Array<{ controlId: string; sourceName?: string; scope: string[] | 'page'; mustReach: string[] }>;
+}
+export interface MetabaseDashboardResult {
+  workbook: {
+    name: string;
+    document: {
+      schemaVersion: number; kind: 'workbook';
+      pages: Array<{ id: string; name: string; visibility?: string }>;
+      elements: WbElement[]; layout: string;
+    };
+  };
+  warnings: string[];
+  stats: Record<string, number>;
+  layout: DashboardLayoutHint;
+  /** control-scope.json sidecar — write next to the workbook spec (cli --control-scope-out). */
+  controlScope: ControlScopeSidecar;
+  /** dashboard-parameter → native-template-tag wirings (the dominant pattern on
+   *  production estates: the parameter drives a {{tag}} in a card's SQL). The
+   *  DM converter emits the matching {{tag}} control; these record which
+   *  dashboard parameter should drive it. */
+  parameterWiring?: Array<{ parameter: string; slug: string; card: string; tag: string; kind: 'variable' | 'field-filter' }>;
+  unreproducibleFilters?: Array<{ controlId: string; name: string; reason: string; hint: string }>;
+}
+export interface MetabaseDashboardOptions {
+  workbookName?: string;
+  dataModelId?: string;
+  metadata?: any;                          // GET /api/database/{id}/metadata — field-id resolution
+  cardNameById?: Record<number, string>;   // card id → DM element name (for "card__N" sources)
+  learnedRules?: LearnedRule[];
+}
+
+// Metabase parameter type → Sigma control type. null type ⇒ flagged (warning, no control).
+function controlTypeFor(t: string): { type?: string; warn?: string } {
+  if (t === 'date/range') return { type: 'date-range' };
+  if (t === 'date' || t?.startsWith('date/')) return { type: 'date' };
+  if (t === 'temporal-unit') return { warn: 'temporal-unit ("time grouping") parameter has no Sigma control analog — flagged; pick a grouping in the chart instead.' };
+  if (t === 'string/=' || t === 'category' || t === 'id') return { type: 'list' };
+  if (t?.startsWith('string/')) return { type: 'list', warn: `parameter operator "${t}" approximated as a list (include) control — verify the filter semantics.` };
+  if (t === 'number/=') return { type: 'number' };
+  if (t === 'number/between') return { type: 'number-range' };
+  if (t?.startsWith('number/')) return { type: 'number', warn: `parameter operator "${t}" approximated as a number control — verify the filter semantics.` };
+  return { warn: `parameter type "${t}" not mapped — create the control manually.` };
+}
+
+const DISPLAY_KIND: Record<string, string> = {
+  table: 'table', bar: 'bar-chart', row: 'bar-chart', line: 'line-chart', area: 'area-chart',
+  combo: 'combo-chart', scatter: 'scatter-chart', pie: 'pie-chart',
+  scalar: 'kpi-chart', smartscalar: 'kpi-chart', trend: 'kpi-chart',
+  pivot: 'pivot-table', funnel: 'funnel-chart', gauge: 'gauge-chart',
+  sankey: 'sankey-chart', waterfall: 'waterfall-chart',
+};
+// No faithful native Sigma analog → flagged table, never faked.
+const NO_ANALOG = new Set(['progress']);
+const titleCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+const xmlAttr = (value: unknown) => String(value ?? '')
+  .replace(/&/g, '&amp;').replace(/"/g, '&quot;')
+  .replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Build the required, authoritative workbook layout from Metabase's exact
+ *  24-column dashboard grid. Controls occupy a band above source tiles;
+ *  utility/base elements are placed on the hidden Data page. */
+function buildWorkbookLayout(pages: WbPage[], hints: DashboardLayoutHint): string {
+  const hintByPage = new Map(hints.pages.map((p) => [p.name.toLowerCase(), p.elements]));
+  const rowScale = 2;
+  const kindHeight = (kind: string) => kind === 'control' ? 2
+    : kind === 'kpi-chart' ? 6
+    : kind.endsWith('-chart') ? 10
+    : (kind.endsWith('-map') || kind === 'pivot-table' || kind === 'table') ? 12
+    : kind === 'text' ? 3 : 10;
+
+  return pages.map((page) => {
+    const lines: string[] = [];
+    const placed = new Set<string>();
+    const controls = page.elements.filter((e) => e.kind === 'control');
+    const perRow = Math.min(Math.max(controls.length, 1), 4);
+
+    controls.forEach((control, i) => {
+      const span = Math.floor(24 / perRow);
+      const col0 = 1 + (i % perRow) * span;
+      const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+      const row0 = 1 + Math.floor(i / perRow) * kindHeight('control');
+      lines.push(`  <Element elementId="${xmlAttr(control.id)}" gridColumn="${col0} / ${col1}" gridRow="${row0} / ${row0 + kindHeight('control')}"/>`);
+      placed.add(control.id);
+    });
+
+    let contentStart = controls.length
+      ? 1 + Math.ceil(controls.length / perRow) * kindHeight('control')
+      : 1;
+    let nextRow = contentStart;
+    const byId = new Map(page.elements.map((e) => [e.id, e]));
+    for (const hint of hintByPage.get(page.name.toLowerCase()) || []) {
+      const element = byId.get(hint.elementId);
+      if (!element || placed.has(element.id)) continue;
+      const col0 = Math.max(1, hint.col + 1);
+      const col1 = Math.min(25, col0 + Math.max(hint.sizeX, 1));
+      const row0 = contentStart + Math.max(hint.row, 0) * rowScale;
+      const row1 = row0 + Math.max(hint.sizeY * rowScale, kindHeight(element.kind));
+      lines.push(`  <Element elementId="${xmlAttr(element.id)}" gridColumn="${col0} / ${col1}" gridRow="${row0} / ${row1}"/>`);
+      placed.add(element.id);
+      nextRow = Math.max(nextRow, row1);
+    }
+
+    for (const element of page.elements) {
+      if (placed.has(element.id)) continue;
+      const height = kindHeight(element.kind);
+      lines.push(`  <Element elementId="${xmlAttr(element.id)}" gridColumn="1 / 25" gridRow="${nextRow} / ${nextRow + height}"/>`);
+      placed.add(element.id);
+      nextRow += height;
+    }
+
+    return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${xmlAttr(page.id)}">\n${lines.join('\n')}\n</Page>`;
+  }).join('\n');
+}
+
+export function convertMetabaseDashboardToSigma(dashboard: any, options: MetabaseDashboardOptions = {}): MetabaseDashboardResult {
+  resetIds();
+  const warnings: string[] = [];
+  const dash = typeof dashboard === 'string' ? JSON.parse(dashboard) : dashboard;
+  const fidx: FieldIndex | null = options.metadata ? buildFieldIndex(options.metadata) : null;
+  const name = options.workbookName || dash.name || 'Metabase Dashboard';
+
+  // ── dashcards: accept BOTH the modern and the legacy shape ───────────────────
+  const rawDcs: any[] = dash.dashcards || dash.ordered_cards || [];
+  const dcs = rawDcs.map((d: any) => ({
+    raw: d,
+    card: d.card ? normalizeCard(d.card) : d.card,
+    cardId: d.card_id,
+    vs: { ...(d.card?.visualization_settings || {}), ...(d.visualization_settings || {}) },
+    tabId: d.dashboard_tab_id ?? null,
+    row: d.row ?? 0, col: d.col ?? 0,
+    sizeX: d.size_x ?? d.sizeX ?? 4, sizeY: d.size_y ?? d.sizeY ?? 4,
+    parameterMappings: d.parameter_mappings || [],
+  }));
+
+  // Simple native-SQL cards are auto-remodeled to a NATIVE Sigma data model (see
+  // recognizeSimpleNativeSql) so their columns are exposed and dashboard filters
+  // reproduce natively. Mirror that here: swap the card to its structured form
+  // (+ the alias-aligned result_metadata so the viz keeps its axes) and rewrite
+  // each field-filter template-tag mapping to a raw dimension target — which the
+  // proven MBQL dimension-wiring path below turns into a control + element filter.
+  for (const dc of dcs) {
+    if (!dc.card || dc.card.dataset_query?.type !== 'native') continue;
+    const remodeled = recognizeSimpleNativeSql(dc.card, fidx || undefined);
+    if (!remodeled) continue;
+    const tags = dc.card.dataset_query?.native?.['template-tags'] || {};
+    dc.card = { ...dc.card, dataset_query: { type: 'query', database: dc.card.dataset_query.database, query: remodeled.query }, result_metadata: remodeled.resultMetadata };
+    dc.parameterMappings = dc.parameterMappings.map((pm: any) => {
+      const tgt = pm.target;
+      const tag = Array.isArray(tgt) && Array.isArray(tgt[1]) && tgt[1][0] === 'template-tag' ? String(tgt[1][1]) : null;
+      const dim = tag && tags[tag]?.type === 'dimension' ? tags[tag].dimension : null;
+      return dim ? { ...pm, target: ['dimension', dim] } : pm;
+    });
+  }
+
+  // ── parameters → controls (controlId = slug; wiring below is per-mapping) ────
+  // Metabase parameters declare their card targets EXPLICITLY (per-dashcard
+  // parameter_mappings) — count mappings up front so (a) unmapped parameters
+  // are skipped (they filter nothing in Metabase either; porting one would
+  // ship furniture the control lint rightly rejects), and (b) range-typed
+  // mapped parameters get REAL control filter targets (below) instead of the
+  // boolean-equality formula, which is wrong for range semantics.
+  const mappingCountByParam = new Map<string, number>();
+  for (const dc of dcs) for (const pm of dc.parameterMappings) {
+    mappingCountByParam.set(pm.parameter_id, (mappingCountByParam.get(pm.parameter_id) || 0) + 1);
+  }
+  const paramById = new Map<string, any>();
+  const controls: WbControl[] = [];
+  const controlBySlug = new Map<string, WbControl>();
+  for (const p of dash.parameters || []) {
+    paramById.set(p.id, p);
+    let { type, warn } = controlTypeFor(p.type);
+    if (warn) warnings.push(`parameter "${p.name}" (${p.type}): ${warn}`);
+    if (!type) continue;
+    if (!mappingCountByParam.get(p.id)) {
+      warnings.push(`parameter "${p.name}" (${p.type}) has NO parameter_mappings — it filters nothing in Metabase; no control emitted (flag, never furniture). Map it to a card in Metabase first if it should do something.`);
+      continue;
+    }
+    // Date parameters wired to dimension targets become date-RANGE controls:
+    // a scalar date control can only express equality, and the only verified
+    // Sigma wiring for a datetime target column is a date-range control with
+    // flat mode "between" (list/scalar targets on datetime columns are
+    // silently stripped at POST — see refs/control-parity.md).
+    if (type === 'date') type = 'date-range';
+    const ctrl: any = {
+      id: sigmaShortId(), kind: 'control', controlId: p.slug || p.id, name: p.name || p.slug,
+      controlType: type,
+    };
+    // Metabase static value list (e.g. day/week/month grain switchers) → Sigma's
+    // segmented control (the native idiom for small fixed choices); larger lists
+    // stay a list control with a manual source.
+    const staticVals: any[] | null =
+      p.values_source_type === 'static-list' ? (p.values_source_config?.values || null) : null;
+    if (staticVals?.length && type === 'list') {
+      ctrl.controlType = staticVals.length <= 6 ? 'segmented' : 'list';
+      ctrl.source = {
+        kind: 'manual',
+        valueType: typeof staticVals[0] === 'number' ? 'number' : 'text',
+        values: staticVals,
+      };
+    }
+    // Union discriminants are REQUIRED per controlType (same live-verified contract
+    // as DM controls — omitting them fails validation as `Invalid kind: "control"`).
+    if (ctrl.controlType === 'text') ctrl.mode = 'equals';
+    if (ctrl.controlType === 'number') ctrl.mode = '=';
+    if (ctrl.controlType === 'date') ctrl.mode = '=';
+    if (ctrl.controlType === 'date-range') ctrl.mode = 'between';
+    // Defaults: list controls take `values` (array), everything else scalar `value`;
+    // never emit an explicit null. Range controls: Metabase encodes defaults as
+    // relative tokens ("past30days") / "A~B" strings with no verified Sigma spec
+    // analog — dropped with a warning, set the default in the Sigma UI.
+    if (p.default != null) {
+      if (ctrl.controlType === 'date-range' || ctrl.controlType === 'number-range') {
+        warnings.push(`parameter "${p.name}": range default ${JSON.stringify(p.default)} has no verified Sigma spec shape — control emitted WITHOUT a default; set it in the UI.`);
+      } else if (ctrl.controlType === 'list') {
+        ctrl.values = Array.isArray(p.default) ? p.default : [p.default];
+      } else {
+        let v = Array.isArray(p.default) ? p.default[0] : p.default;
+        // Metabase stores number defaults as strings ("20") — Sigma number controls want numbers.
+        if (ctrl.controlType === 'number' && typeof v === 'string' && v.trim() !== '' && !isNaN(Number(v))) v = Number(v);
+        ctrl.value = v;
+      }
+    }
+    controls.push(ctrl);
+    controlBySlug.set(ctrl.controlId, ctrl);
+  }
+
+  // field-id → display name (metadata first; result_metadata fallback per card)
+  const mkCtx = (card: any, prefix: string | null): MbqlCtx => {
+    const rmById = new Map<number, any>();
+    for (const rm of card?.result_metadata || []) {
+      const fr = rm.field_ref;
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') rmById.set(fr[1], rm);
+    }
+    const display = (ref: any): string => {
+      const idOrName = Array.isArray(ref) ? ref[1] : ref;
+      if (typeof idOrName === 'number') {
+        const f = fidx?.byId.get(idOrName);
+        if (f) return f.displayName;
+        const rm = rmById.get(idOrName);
+        if (rm) return rm.display_name || sigmaDisplayName(rm.name);
+        warnings.push(`card "${card?.name}": field ${idOrName} unresolved (pass --metadata) — emitted [Field ${idOrName}].`);
+        return `Field ${idOrName}`;
+      }
+      return sigmaDisplayName(String(idOrName ?? ''));
+    };
+    const ctx: MbqlCtx = {
+      fieldDisplay: display,
+      resolveField: (ref: any) => {
+        const opts = (Array.isArray(ref) && ref[2]) || {};
+        const disp = display(ref);
+        let out = prefix ? `[${prefix}/${disp}]` : `[${disp}]`;
+        if (opts['temporal-unit']) out = `DateTrunc("${opts['temporal-unit']}", ${out})`;
+        if (opts.binning) ctx.warn(`numeric binning on [${disp}] is flagged — recreate with BinFixed/BinCount on the element.`);
+        return out;
+      },
+      warn: (m) => warnings.push(`card "${card?.name}": ${m}`),
+      learnedRules: options.learnedRules,
+    };
+    return ctx;
+  };
+
+  // Resolve the DM-element-NAME placeholder this dashcard sources.
+  // remap-wb-to-dm-ids.mjs rewrites it to the real posted element id (matched by name).
+  const sourceNameFor = (card: any): string => {
+    const dq = card.dataset_query || {};
+    if (dq.type === 'native') {
+      warnings.push(`card "${card.name}" is a native-SQL question — its DM sql element carries NO name (Sigma derives one); wire this element's source.elementId manually after posting the DM.`);
+      return card.name || 'Custom SQL';
+    }
+    const q = dq.query || {};
+    const src = q['source-table'];
+    if (typeof src === 'string' && src.startsWith('card__')) {
+      const n = Number(src.slice('card__'.length));
+      const mapped = options.cardNameById?.[n];
+      if (mapped) return mapped;
+      // Parent card not on this dashboard and no mapping provided — the DM
+      // converter gives the NESTED card its own element (sourced from the parent),
+      // so this card's own name is the resolvable placeholder (live-verified;
+      // a "card__N" placeholder 400s at POST).
+      if (card.name) {
+        warnings.push(`card "${card.name}" sources nested card ${n} — no card-name mapping; sourced its OWN DM element by card name (the DM converter creates one per nested card). Pass cardNameById to source the parent model instead.`);
+        return card.name;
+      }
+      warnings.push(`card "${card.name}" sources nested card ${n} — no card-name mapping provided; emitted placeholder "card__${n}" (remap will report it unresolved; pass cardNameById or fix by hand).`);
+      return `card__${n}`;
+    }
+    if (typeof src === 'number') {
+      const t = fidx?.tableById.get(src);
+      if (!t) { warnings.push(`card "${card.name}": source table ${src} not in metadata — emitted placeholder "table_${src}".`); return `table_${src}`; }
+      if (Array.isArray(q.joins) && q.joins.length) {
+        // The DM converter gives every MBQL-join card its OWN join element, named
+        // after the card, with exactly the card's columns. Source that — the generic
+        // FK-derived "<Table> View" suffixes duplicate columns ("Category (PRODUCT_DIM)")
+        // so card-named refs 400 against it (live-verified "Dependency not found").
+        return card.name || `${sigmaDisplayName(t.name)} View`;
+      }
+      // Implicit FK joins (source-field refs) need the dim columns the base table
+      // doesn't have — read from the FK-derived "<Table> View" element instead.
+      if (JSON.stringify(q).includes('"source-field"')) return `${sigmaDisplayName(t.name)} View`;
+      return sigmaDisplayName(t.name);
+    }
+    warnings.push(`card "${card.name}": unrecognized source ${JSON.stringify(src)} — emitted placeholder "<element>".`);
+    return '<element>';
+  };
+
+  // column_settings → Sigma format (number_style/decimals/currency/prefix/suffix)
+  const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', EUR: '€', GBP: '£', JPY: '¥', CAD: '$', AUD: '$' };
+  const formatFromColumnSettings = (s: any): Record<string, any> | undefined => {
+    if (!s) return undefined;
+    const d = s.decimals ?? 2;
+    let fmt: Record<string, any> | null = null;
+    if (s.number_style === 'currency' || s.currency) {
+      const sym = CURRENCY_SYMBOL[String(s.currency || 'USD').toUpperCase()] || '$';
+      fmt = { kind: 'number', formatString: `${sym},.${s.decimals ?? 2}f`, currencySymbol: sym };
+    } else if (s.number_style === 'percent') {
+      fmt = formatFromMask(`0${d ? '.' + '0'.repeat(d) : ''}%`);
+    } else if (s.number_style === 'decimal' || s.decimals != null) {
+      fmt = formatFromMask(`#,##0${d ? '.' + '0'.repeat(d) : ''}`);
+    }
+    if (s.suffix) fmt = { ...(fmt || { kind: 'number', formatString: ',.2f' }), suffix: s.suffix };
+    if (s.prefix) fmt = { ...(fmt || { kind: 'number', formatString: ',.2f' }), prefix: s.prefix };
+    // date_style / time_style: Sigma date-format spec shape is not yet verified
+    // against a live readback — ignored silently (display-only, data unaffected).
+    return fmt || undefined;
+  };
+
+  // table.column_formatting → Sigma conditionalFormats (single rules convert;
+  // range/gradient scales are flagged — backgroundScale spec shape unverified).
+  const CF_OPERATOR: Record<string, string> = {
+    '=': '=', '!=': '!=', '<': '<', '>': '>', '<=': '<=', '>=': '>=',
+    'is-null': 'IsNull', 'not-null': 'IsNotNull', contains: 'Contains',
+    'does-not-contain': 'NotContains', 'starts-with': 'StartsWith', 'ends-with': 'EndsWith',
+  };
+  const buildConditionalFormats = (card: any, rules: any[], byKey: Map<string, string>): any[] => {
+    const out: any[] = [];
+    for (const r of rules || []) {
+      const columnIds = (r.columns || []).map((n: string) => byKey.get(String(n).toLowerCase())).filter(Boolean);
+      if (!columnIds.length) { warnings.push(`card "${card.name}": a conditional-formatting rule targets unresolved column(s) ${JSON.stringify(r.columns)} — skipped.`); continue; }
+      if (r.type === 'single') {
+        const condition = CF_OPERATOR[String(r.operator)];
+        if (!condition) { warnings.push(`card "${card.name}": conditional-formatting operator "${r.operator}" has no Sigma mapping — rule skipped.`); continue; }
+        const cf: any = { type: 'single', columnIds, condition, style: { backgroundColor: r.color || '#509EE3' } };
+        if (r.value !== undefined && condition !== 'IsNull' && condition !== 'IsNotNull') cf.value = r.value;
+        out.push(cf);
+        if (r.highlight_row) warnings.push(`card "${card.name}": a conditional-formatting rule highlights the WHOLE ROW — Sigma's converted rule colors the matched column(s) only; extend columnIds to all columns if row highlighting is required.`);
+      } else {
+        warnings.push(`card "${card.name}": a "${r.type}" (gradient/range) conditional-formatting rule is flagged — recreate as a Sigma backgroundScale conditional format in the UI (spec shape not yet live-verified).`);
+      }
+    }
+    return out;
+  };
+
+  interface BuiltCols {
+    cols: WbColumn[]; order: string[];
+    byKey: Map<string, string>;            // result name / display name (lowercase) → col id
+    byFieldId: Map<number, string>;        // MBQL field id → col id
+    byAggIndex: Map<number, string>;       // ["aggregation", n] → col id
+    dimIds: string[]; metricIds: string[];
+    keyOfId: Map<string, string>;          // col id → result_metadata name (series_settings keys)
+  }
+
+  const buildCardColumns = (card: any, sourceName: string, ctx: MbqlCtx): BuiltCols => {
+    const out: BuiltCols = { cols: [], order: [], byKey: new Map(), byFieldId: new Map(), byAggIndex: new Map(), dimIds: [], metricIds: [], keyOfId: new Map() };
+    const dq = card.dataset_query || {};
+    const q = dq.type === 'query' ? dq.query || {} : null;
+    let rms: any[] = card.result_metadata || [];
+    if (!rms.length && q) {
+      // never-run cards may carry no result_metadata — synthesize from the MBQL itself
+      warnings.push(`card "${card.name}" has no result_metadata — columns synthesized from its MBQL (run the question once to capture exact result names).`);
+      rms = [
+        ...(q.breakout || []).map((b: any) => ({ name: ctx.fieldDisplay(b), display_name: ctx.fieldDisplay(b), field_ref: b })),
+        ...(q.aggregation || []).map((_: any, i: number) => ({ name: `agg${i}`, display_name: '', field_ref: ['aggregation', i] })),
+      ];
+    }
+    let aggSeq = 0;
+    for (const rm of rms) {
+      if (rm.name === 'pivot-grouping') continue; // Metabase-internal pivot column
+      let fr = rm.field_ref;
+      // Pivot (and some cached) result_metadata carries field_ref: null — reconstruct
+      // from the MBQL by name (agg result cols are named sum/count/avg/…; live-verified).
+      if (!Array.isArray(fr) && q) {
+        const nmLower = String(rm.name || '').toLowerCase();
+        if (q.aggregation?.length && /^(sum|count|avg|min|max|stddev|distinct|share|cum_sum|cum_count)(_\d+)?$/.test(nmLower)) {
+          fr = ['aggregation', Math.min(aggSeq++, q.aggregation.length - 1)];
+        } else {
+          const b = (q.breakout || []).find((br: any) => ctx.fieldDisplay(br).toLowerCase() === String(rm.display_name || rm.name || '').toLowerCase());
+          if (b) fr = b;
+        }
+      }
+      // Prettify ALWAYS (idempotent) — raw native aliases (x_axis_type, count(*))
+      // otherwise become the visible axis/column labels.
+      let formula = ''; let isMetric = false; let nm = sigmaDisplayName(rm.display_name || rm.name || 'Column');
+      if (Array.isArray(fr) && fr[0] === 'aggregation') {
+        const agg = q?.aggregation?.[fr[1]];
+        if (agg) {
+          const tr = translateAggregation(agg, ctx);
+          formula = tr.formula;
+          if (!nm) nm = tr.name;
+        } else { formula = `[${nm}]`; }       // native/aggregated upstream — passthrough
+        isMetric = true;
+      } else if (Array.isArray(fr) && fr[0] === 'expression') {
+        const ex = q?.expressions?.[fr[1]];
+        formula = ex ? translateMbqlExpr(ex, ctx) : `[${fr[1]}]`;
+      } else if (Array.isArray(fr) && fr[0] === 'field') {
+        formula = ctx.resolveField(fr);
+      } else {
+        formula = `[${nm}]`;                  // native result column — bare display ref
+      }
+      const id = sigmaShortId();
+      const col: WbColumn = { id, name: nm, formula };
+      out.cols.push(col); out.order.push(id);
+      if (rm.name) { out.byKey.set(String(rm.name).toLowerCase(), id); out.keyOfId.set(id, rm.name); }
+      out.byKey.set(nm.toLowerCase(), id);
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') out.byFieldId.set(fr[1], id);
+      if (Array.isArray(fr) && fr[0] === 'aggregation') out.byAggIndex.set(fr[1], id);
+      (isMetric ? out.metricIds : out.dimIds).push(id);
+    }
+    return out;
+  };
+
+  // resolve a column_split / graph.* entry (field ref | agg ref | name string) → col id
+  const resolveEntry = (entry: any, built: BuiltCols, ctx: MbqlCtx): string | undefined => {
+    if (typeof entry === 'string') return built.byKey.get(entry.toLowerCase());
+    if (Array.isArray(entry) && entry[0] === 'aggregation') return built.byAggIndex.get(entry[1]);
+    if (Array.isArray(entry) && entry[0] === 'field') {
+      if (typeof entry[1] === 'number' && built.byFieldId.has(entry[1])) return built.byFieldId.get(entry[1]);
+      return built.byKey.get(ctx.fieldDisplay(entry).toLowerCase());
+    }
+    return undefined;
+  };
+
+  // dashboard-parameter → template-tag wirings (aggregated; see parameterWiring)
+  const tagWirings: NonNullable<MetabaseDashboardResult['parameterWiring']> = [];
+
+  // ── control-scope bookkeeping (the sidecar contract) ─────────────────────────
+  // scope = converted element names of each control's MAPPED cards (declared
+  // targets); reach = the subset the converter actually wired (bool formula,
+  // range filter target, or field-filter recreation). dmBound = controls whose
+  // only wiring is the control→DM-parameter binding (remap --dm-spec).
+  const scopeBySlug = new Map<string, Set<string>>();
+  const reachBySlug = new Map<string, Set<string>>();
+  const dmBoundSlugs = new Set<string>();
+  const record = (m: Map<string, Set<string>>, slug: string, name?: string) => {
+    if (!name) return;
+    if (!m.has(slug)) m.set(slug, new Set());
+    m.get(slug)!.add(name);
+  };
+
+  // Hidden sourcing roots for range-control filter targets. A Sigma control's
+  // `filters` target may only point at a TABLE element (chart/KPI targets 400
+  // "Dependency not found") — so a range-mapped chart is re-rooted through a
+  // base table that sources the same DM element and carries the columns the
+  // chart (and the control target) needs. Base tables live on a final "Data"
+  // page whose id starts with "data" (the cross-plugin convention the layout
+  // gates use to exempt utility pages).
+  const baseTables: WbElement[] = [];
+
+  // ── per-dashcard element builder ───────────────────────────────────────────
+  const buildElement = (dc: (typeof dcs)[number]): WbElement | null => {
+    const vs = dc.vs;
+    // text / heading dashcards (card_id null + virtual_card) → text elements
+    if (dc.cardId == null && vs.virtual_card) {
+      const display = vs.virtual_card.display;
+      if (display === 'text' || display === 'heading') {
+        // Live contract: text elements carry `body` (string), not `text` —
+        // POST 400s "body: Invalid string: undefined".
+        return { id: sigmaShortId(), kind: 'text', name: 'Text', body: vs.text || '' } as any;
+      }
+      warnings.push(`virtual card (display "${display}") is not a text/heading — skipped (link/action cards have no Sigma spec analog).`);
+      return null;
+    }
+    const card = dc.card;
+    if (!card) { warnings.push(`dashcard ${dc.raw.id}: card ${dc.cardId} not embedded in the dashboard JSON — skipped.`); return null; }
+    if (vs.click_behavior || Object.values(vs.column_settings || {}).some((c: any) => c?.click_behavior)) {
+      warnings.push(`card "${card.name}": click_behavior (cross-filter / link) is not converted — re-create as a Sigma action.`);
+    }
+
+    const display = String(card.display || 'table');
+    const sourceName = sourceNameFor(card);
+    const ctx = mkCtx(card, card.dataset_query?.type === 'native' ? null : sourceName);
+    const built = buildCardColumns(card, sourceName, ctx);
+
+    // column_settings → formats. Keys: '["name","COL"]' or '["ref",["field",72,null]]'.
+    for (const [key, setting] of Object.entries(vs.column_settings || {})) {
+      try {
+        const k = JSON.parse(key);
+        const colId = k[0] === 'name' ? built.byKey.get(String(k[1]).toLowerCase())
+          : k[0] === 'ref' ? resolveEntry(k[1], built, ctx) : undefined;
+        const fmt = formatFromColumnSettings(setting);
+        if (colId && fmt) { const c = built.cols.find((c) => c.id === colId); if (c) c.format = fmt; }
+      } catch { /* unparseable column_settings key — ignore */ }
+    }
+
+    // Cross-document DM references are kind 'data-model' (kind 'table' is for
+    // same-workbook elements — live-verified 400 "Dependency not found").
+    const source: Record<string, any> = { kind: 'data-model', elementId: sourceName };
+    if (options.dataModelId) source.dataModelId = options.dataModelId;
+    const el: WbElement = {
+      id: sigmaShortId(), kind: DISPLAY_KIND[display] || 'table', name: card.name || `Card ${card.id}`,
+      source, columns: built.cols, order: built.order,
+    };
+
+    // graph.dimensions / graph.metrics matched through result_metadata names
+    const dimIds = ((vs['graph.dimensions'] || []).filter(Boolean)
+      .map((n: string) => built.byKey.get(n.toLowerCase())).filter(Boolean) as string[]);
+    const metIds = ((vs['graph.metrics'] || []).filter(Boolean)
+      .map((n: string) => built.byKey.get(n.toLowerCase())).filter(Boolean) as string[]);
+    const xIds = dimIds.length ? dimIds : built.dimIds;
+    const yIds = metIds.length ? metIds : built.metricIds;
+
+    if (NO_ANALOG.has(display)) {
+      // never fake a viz — emit the data as a table + a LOUD warning
+      el.kind = 'table';
+      el.name = `${card.name} (was ${display})`;
+      warnings.push(`card "${card.name}" is a Metabase ${display} — no faithful native Sigma mapping is verified; emitted its data as a TABLE. Re-pick a Sigma viz in the workbook.`);
+    } else if (display === 'object') {
+      // single-record detail view — flagged, emitted as a table (never faked)
+      el.kind = 'table';
+      el.name = `${card.name} (object detail)`;
+      warnings.push(`card "${card.name}" is a Metabase object DETAIL view (single record) — emitted its data as a flagged TABLE; recreate the detail experience with element filters / drill in Sigma.`);
+    } else if (el.kind === 'kpi-chart') {
+      const scalarField = vs['scalar.field'] ? built.byKey.get(String(vs['scalar.field']).toLowerCase()) : undefined;
+      const valId = scalarField || yIds[0] || built.metricIds[0] || built.order[0];
+      if (!valId) { warnings.push(`card "${card.name}" (scalar) resolved no value column — skipped.`); return null; }
+      el.value = { columnId: valId };   // kpi-chart wants {columnId}, NOT {id}
+      if (display === 'smartscalar' || display === 'trend') {
+        warnings.push(`card "${card.name}" is a ${display} — the VALUE converts; the auto "vs previous period" comparison does not. Add a Sigma KPI comparison manually.`);
+      }
+    } else if (el.kind === 'pie-chart') {
+      const sliceId = (vs['pie.dimension'] && built.byKey.get(String(vs['pie.dimension']).toLowerCase())) || xIds[0];
+      const valId = (vs['pie.metric'] && built.byKey.get(String(vs['pie.metric']).toLowerCase())) || yIds[0];
+      if (sliceId) el.color = { columnId: sliceId };
+      if (valId) el.value = { columnId: valId };
+      if (!sliceId || !valId) warnings.push(`card "${card.name}" (pie): could not resolve ${!sliceId ? 'slice dimension' : 'value'} — fix in the workbook.`);
+    } else if (el.kind === 'pivot-table') {
+      const split = vs['pivot_table.column_split'] || {};
+      const rowsBy = (split.rows || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean).map((columnId: string) => ({ columnId }));
+      const columnsBy = (split.columns || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean).map((columnId: string) => ({ columnId }));
+      let values = (split.values || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean) as string[];
+      if (!values.length) values = built.metricIds;
+      // rowsBy/columnsBy = arrays of {columnId}, values = bare column-id strings —
+      // without rowsBy+columnsBy the pivot silently collapses to one grand-total cell.
+      el.rowsBy = rowsBy; el.columnsBy = columnsBy; el.values = values;
+      if (!rowsBy.length && !columnsBy.length) warnings.push(`card "${card.name}" (pivot): no row/column split resolved — the pivot will collapse to a single grand-total cell; set rowsBy/columnsBy.`);
+    } else if (display === 'map') {
+      const mapType = vs['map.type'] || 'region';
+      if (mapType === 'pin') {
+        const latId = built.cols.find((c) => /\blat/i.test(c.name))?.id;
+        const lonId = built.cols.find((c) => /\b(lon|lng)/i.test(c.name))?.id;
+        if (latId && lonId) {
+          el.kind = 'point-map'; el.latitude = { columnId: latId }; el.longitude = { columnId: lonId };
+        } else {
+          el.kind = 'table'; el.name = `${card.name} (was pin map)`;
+          warnings.push(`card "${card.name}" (pin map): no lat/long columns resolved — emitted its data as a table.`);
+        }
+      } else {
+        const regId = xIds[0] || built.dimIds[0];
+        if (regId) {
+          el.kind = 'region-map'; el.region = { columnId: regId, regionType: vs['map.region'] === 'us_states' ? 'us-state' : 'country' };
+          if (yIds[0]) el.color = { by: 'scale', column: yIds[0] };
+          warnings.push(`card "${card.name}" → region-map: regionType guessed from map.region — verify (country / us-state / us-county / us-zipcode / ca-province).`);
+        } else {
+          el.kind = 'table'; el.name = `${card.name} (was region map)`;
+          warnings.push(`card "${card.name}" (region map): no region column resolved — emitted its data as a table.`);
+        }
+      }
+    } else if (el.kind === 'funnel-chart') {
+      if (xIds[0] && yIds[0]) {
+        el.stage = { columnId: xIds[0] };
+        el.series = { columnId: yIds[0] };
+      } else {
+        el.kind = 'table'; el.name = `${card.name} (was funnel)`;
+        warnings.push(`card "${card.name}" (funnel): a stage dimension and measure are required — emitted its data as a TABLE.`);
+      }
+    } else if (el.kind === 'gauge-chart') {
+      const valId = yIds[0] || built.metricIds[0] || built.order[0];
+      if (valId) el.value = { columnId: valId };
+      else {
+        el.kind = 'table'; el.name = `${card.name} (was gauge)`;
+        warnings.push(`card "${card.name}" (gauge): no value column resolved — emitted its data as a TABLE.`);
+      }
+    } else if (el.kind === 'sankey-chart') {
+      if (xIds.length >= 2 && yIds[0]) {
+        el.stages = xIds.map((columnId) => ({ columnId }));
+        el.value = { columnId: yIds[0] };
+      } else {
+        el.kind = 'table'; el.name = `${card.name} (was sankey)`;
+        warnings.push(`card "${card.name}" (sankey): at least two stage dimensions and one measure are required — emitted its data as a TABLE.`);
+      }
+    } else if (el.kind.endsWith('-chart')) {
+      // cartesian: bar / row / line / area / combo / scatter / waterfall
+      if (xIds[0]) el.xAxis = { columnId: xIds[0] };
+      else warnings.push(`card "${card.name}" (${display}): no x-axis dimension resolved — set it in the workbook.`);
+      if (el.kind === 'combo-chart') {
+        // series_settings per-series display → bare-string (default mark) vs object
+        // (overridden mark / secondary axis) forms on yAxis.columnIds — the persisted
+        // dual-axis shape (feedback_sigma_combo_dual_axis).
+        const ss = vs.series_settings || {};
+        el.yAxis = {
+          columnIds: yIds.map((id) => {
+            const key = built.keyOfId.get(id);
+            const d = key ? ss[key]?.display : undefined;
+            return d && d !== 'bar' ? { columnId: id } : id;
+          }),
+        };
+        if (Object.keys(ss).length) warnings.push(`card "${card.name}" (combo): per-series marks emitted via the bare-string/object yAxis form — verify each series' mark + axis in Sigma.`);
+      } else if (yIds.length) {
+        el.yAxis = { columnIds: yIds };
+      } else {
+        warnings.push(`card "${card.name}" (${display}): no measure resolved for the value axis — add one in the workbook.`);
+      }
+      if (xIds.length > 1) el.color = { by: 'category', column: xIds[1] };  // 2nd dimension = series color
+      if (display === 'row') el.orientation = 'horizontal';  // 'horizontal' is the ONLY valid value; vertical bar OMITS the key
+      // Live-verified enum: none | stacked | normalized (Metabase's 'normalized'
+      // passes through verbatim; 'percent' is rejected "Invalid value: string").
+      const stack = vs['stackable.stack_type'];
+      if (stack === 'stacked') el.stacking = 'stacked';
+      else if (stack === 'normalized') el.stacking = 'normalized';
+    }
+    // display === 'table' → plain table element: columns + order already set.
+
+    // series_settings → series display names (rename the y columns); colors are
+    // positional-only in the Sigma spec (bar color.scheme) — flagged, not guessed.
+    if (vs.series_settings && el.kind !== 'combo-chart') {
+      let renamed = 0; let colored = 0;
+      for (const [key, s] of Object.entries(vs.series_settings as Record<string, any>)) {
+        const colId = built.byKey.get(String(key).toLowerCase());
+        const c = colId && built.cols.find((c) => c.id === colId);
+        if (c && s?.title && s.title !== c.name) { built.byKey.set(String(s.title).toLowerCase(), c.id); c.name = s.title; renamed++; }
+        if (s?.color) colored++;
+      }
+      if (colored) warnings.push(`card "${card.name}": ${colored} per-series color(s) in series_settings — Sigma's spec colors bar categories positionally (color.scheme) and pie/line series via theme only; re-apply colors in the workbook.`);
+      if (renamed) warnings.push(`card "${card.name}": ${renamed} series renamed from series_settings titles.`);
+    }
+
+    // table.column_formatting → Sigma conditionalFormats (single rules; ranges flagged)
+    if (Array.isArray(vs['table.column_formatting']) && vs['table.column_formatting'].length) {
+      const cfs = buildConditionalFormats(card, vs['table.column_formatting'], built.byKey);
+      if (cfs.length) el.conditionalFormats = cfs;
+    }
+
+    // table.columns enabled:false → hide
+    for (const tc of vs['table.columns'] || []) {
+      if (tc?.enabled === false && tc.name) {
+        const id = built.byKey.get(String(tc.name).toLowerCase());
+        const c = id && built.cols.find((c) => c.id === id);
+        if (c) c.hidden = true;
+      }
+    }
+
+    // ── parameter_mappings → control `filters` targets ─────────────────────────
+    // Every wirable mapping becomes a REAL control filter target — the verified
+    // cross-plugin wiring (refs/control-parity.md). A control reference inside a
+    // boolean match column (`[Col] = [slug]`) reads back as an error-typed
+    // column for list controls (live-caught 2026-06-12), so targets are the
+    // only honest form. Targets may only point at TABLE elements: a table
+    // dashcard is targeted directly; charts/KPIs re-root through a hidden base
+    // TABLE (collected in `pendingTargets`, materialized below). List/segmented
+    // targets on numeric or datetime columns are silently stripped at POST —
+    // those bind through a hidden Text() cast column (`cast`).
+    const pendingTargets: Array<{ slug: string; disp: string; fieldRef?: any; cast: boolean }> = [];
+    const NUMERIC_OR_DATETIME = /type\/(Integer|BigInteger|Float|Decimal|Number|DateTime|Date|Time)/;
+    const needsCast = (slug: string, baseType?: string) => {
+      const t = controlBySlug.get(slug)?.controlType;
+      return (t === 'list' || t === 'segmented' || t === 'text')
+        && !!baseType && NUMERIC_OR_DATETIME.test(baseType);
+    };
+    for (const pm of dc.parameterMappings) {
+      const p = paramById.get(pm.parameter_id);
+      if (!p) { warnings.push(`card "${card.name}": parameter_mapping references unknown parameter ${pm.parameter_id} — skipped.`); continue; }
+      const slug = p.slug || p.id;
+      record(scopeBySlug, slug, el.name);
+      let tgt = pm.target;
+      // pMBQL targets carry [op, {opts}, …] inner clauses — normalize them.
+      if (Array.isArray(tgt) && tgt.length >= 2) tgt = [tgt[0], normalizeClause(tgt[1])];
+      // native template-tag targets (the DOMINANT production pattern — 13.5k of
+      // 14.6k mappings on the reference estate): the parameter drives a {{tag}}
+      // in the card's SQL. The DM converter emits the {{tag}} control; record
+      // the wiring (aggregated into one warning per parameter, not per mapping).
+      const innerTag = Array.isArray(tgt) && Array.isArray(tgt[1]) && tgt[1][0] === 'template-tag' ? String(tgt[1][1]) : null;
+      if (innerTag && (tgt[0] === 'variable' || tgt[0] === 'dimension')) {
+        if (tgt[0] === 'variable') {
+          tagWirings.push({ parameter: p.name || slug, slug, card: card.name || String(card.id), tag: innerTag, kind: 'variable' });
+          dmBoundSlugs.add(slug);
+          continue;
+        }
+        // dimension + template-tag = the parameter drives a FIELD FILTER tag.
+        // The DM converter neutralized that tag to 1=1 — recreate the filter
+        // here when the tag's mapped column is in the card's result set.
+        tagWirings.push({ parameter: p.name || slug, slug, card: card.name || String(card.id), tag: innerTag, kind: 'field-filter' });
+        const tag = card.dataset_query?.native?.['template-tags']?.[innerTag];
+        const dimRef = tag?.dimension;
+        const dimColId = Array.isArray(dimRef) ? resolveEntry(dimRef, built, ctx) : undefined;
+        if (dimColId) {
+          const targetCol = built.cols.find((c) => c.id === dimColId)!;
+          const fieldId = Array.isArray(dimRef) && typeof dimRef[1] === 'number' ? dimRef[1] : undefined;
+          const baseType = (fieldId != null && fidx?.byId.get(fieldId)?.baseType)
+            || (card.result_metadata || []).find((rm: any) => rm.name && built.byKey.get(String(rm.name).toLowerCase()) === dimColId)?.base_type;
+          pendingTargets.push({ slug, disp: targetCol.name, fieldRef: dimRef, cast: needsCast(slug, baseType) });
+          record(reachBySlug, slug, el.name);
+        } else {
+          warnings.push(`card "${card.name}": parameter "${p.name}" drives field-filter tag {{${innerTag}}} but the tag's column is not in the card's result set — add the column to the SQL SELECT, then filter it via the "${slug}" control.`);
+        }
+        continue;
+      }
+      if (Array.isArray(tgt) && tgt[0] === 'text-tag') {
+        warnings.push(`card "${card.name}": parameter "${p.name}" targets a TEXT TAG (markdown placeholder) — Sigma text elements cannot bind controls; re-author the text or drop the binding.`);
+        continue;
+      }
+      if (!Array.isArray(tgt) || tgt[0] !== 'dimension') {
+        warnings.push(`card "${card.name}": parameter "${p.name}" targets ${JSON.stringify(tgt)} — unmappable; wire it manually.`);
+        continue;
+      }
+      const fieldRef = tgt[1];
+      const disp = ctx.fieldDisplay(fieldRef);
+      const baseType = (typeof fieldRef?.[1] === 'number' ? fidx?.byId.get(fieldRef[1])?.baseType : undefined)
+        || (Array.isArray(fieldRef) && fieldRef[2]?.['base-type']) || undefined;
+      pendingTargets.push({ slug, disp, fieldRef, cast: needsCast(slug, baseType) });
+      record(reachBySlug, slug, el.name);
+    }
+
+    // card-level MBQL filter → hidden boolean column + element filter (element is card-specific here, so this is safe)
+    const q = card.dataset_query?.type === 'query' ? card.dataset_query.query : null;
+    if (q?.filter) {
+      const formula = translateMbqlExpr(q.filter, ctx);
+      const fid = sigmaShortId();
+      built.cols.push({ id: fid, name: `Filter: ${card.name || card.id}`, formula, hidden: true });
+      (el.filters ||= []).push({ id: sigmaShortId(), columnId: fid, kind: 'list', mode: 'include', values: [true] });
+    }
+
+    // ── mapped targets → table element + control filter targets ────────────────
+    // A table dashcard is targeted DIRECTLY (it is already a table element); a
+    // chart/KPI/pivot re-roots through a hidden base TABLE (same DM source,
+    // passthrough columns) on the Data page — control targets may only point at
+    // table elements, and the element inherits the filter through the source
+    // closure. List/segmented targets on numeric/datetime columns bind through
+    // a hidden Text() cast column (silently stripped otherwise — verified).
+    if (pendingTargets.length) {
+      const isNative = card.dataset_query?.type === 'native';
+      let targetElId: string;
+      let targetCols: WbColumn[];        // column set on the TARGET table
+      let colByDisp: (disp: string) => WbColumn | undefined;
+
+      if (el.kind === 'table') {
+        // the dashcard is already a table — target it directly
+        targetElId = el.id;
+        targetCols = built.cols;
+        colByDisp = (disp) => {
+          let c = built.cols.find((cc) => cc.name === disp);
+          if (!c) {
+            const pt = pendingTargets.find((r) => r.disp === disp);
+            c = { id: sigmaShortId(), name: disp, formula: pt?.fieldRef ? ctx.resolveField(pt.fieldRef) : `[${disp}]`, hidden: true };
+            built.cols.push(c);
+            built.byKey.set(disp.toLowerCase(), c.id);
+          }
+          return c;
+        };
+      } else {
+        const baseName = `${card.name || `Card ${card.id}`} Base`;
+        // passthrough set: every source ref in the element's formulas + the targets.
+        // A "source ref" is a `[sourceName/X]`-prefixed token (MBQL cards) or, on
+        // native cards, a bare `[X]` that is either a passthrough column reading
+        // itself or a token that names no local column (a direct source read);
+        // bare refs to OTHER local columns and `[slug]` control refs stay local.
+        const needed = new Set<string>(pendingTargets.map((r) => r.disp));
+        const localNames = new Set(built.cols.map((cc) => cc.name));
+        const isPassthroughSelf = (c: WbColumn, tok: string) => c.name === tok && String(c.formula).trim() === `[${tok}]`;
+        const prefixed = new RegExp(`\\[${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/([^\\]]+)\\]`, 'g');
+        for (const c of built.cols) {
+          const f = String(c.formula || '');
+          if (isNative) {
+            for (const m of f.matchAll(/\[([^\]/]+)\]/g)) {
+              const tok = m[1];
+              if (controlBySlug.has(tok)) continue;
+              if (isPassthroughSelf(c, tok) || !localNames.has(tok)) needed.add(tok);
+            }
+          } else {
+            for (const m of f.matchAll(prefixed)) needed.add(m[1]);
+          }
+        }
+        const srcPrefix = isNative ? '' : `${sourceName}/`;
+        const baseCols: WbColumn[] = [...needed].map((n) => ({ id: sigmaShortId(), name: n, formula: `[${srcPrefix}${n}]` }));
+        const baseEl: WbElement = {
+          id: sigmaShortId(), kind: 'table', name: baseName,
+          source: { ...source }, columns: baseCols, order: baseCols.map((c) => c.id),
+        };
+        baseTables.push(baseEl);
+        // re-root the chart: source the base table, rewrite source refs through it
+        el.source = { kind: 'table', elementId: baseEl.id };
+        for (const c of built.cols) {
+          if (typeof c.formula !== 'string') continue;
+          if (isNative) {
+            const orig = c.formula;
+            c.formula = orig.replace(/\[([^\]/]+)\]/g, (whole, tok) => {
+              if (controlBySlug.has(tok)) return whole;
+              if (isPassthroughSelf(c, tok) || !localNames.has(tok)) return `[${baseName}/${tok}]`;
+              return whole;
+            });
+          } else {
+            c.formula = c.formula.split(`[${sourceName}/`).join(`[${baseName}/`);
+          }
+        }
+        targetElId = baseEl.id;
+        targetCols = baseCols;
+        colByDisp = (disp) => baseCols.find((c) => c.name === disp);
+      }
+
+      for (const pt of pendingTargets) {
+        const ctrl = controlBySlug.get(pt.slug);
+        const tc = colByDisp(pt.disp);
+        if (!ctrl || !tc) continue;
+        let columnId = tc.id;
+        if (pt.cast) {
+          // numeric/datetime list target — bind through a hidden Text() cast
+          let cast = targetCols.find((c) => c.name === `${pt.disp} (Text)`);
+          if (!cast) {
+            cast = { id: sigmaShortId(), name: `${pt.disp} (Text)`, formula: `Text([${pt.disp}])`, hidden: true };
+            targetCols.push(cast);
+            const holder = targetElId === el.id ? el : baseTables[baseTables.length - 1];
+            if (holder.order) holder.order.push(cast.id);
+          }
+          columnId = cast.id;
+        }
+        (ctrl.filters ||= []).push({ source: { kind: 'table', elementId: targetElId }, columnId });
+      }
+    }
+
+    el.columns = built.cols;
+    el.order = built.order;
+    return el;
+  };
+
+  // ── pages: one per dashboard tab (no tabs → single page) ─────────────────────
+  const tabs: any[] = dash.tabs?.length ? dash.tabs : [null];
+  const pages: WbPage[] = [];
+  const layout: DashboardLayoutHint = { grid: 24, pages: [] };
+  const builtPages: Array<{ name: string; els: WbElement[] }> = [];
+
+  for (const tab of tabs) {
+    const pageName = tab ? (tab.name || `Tab ${tab.id}`) : 'Page 1';
+    const pageDcs = dcs
+      .filter((d) => tab === null || (d.tabId ?? tabs[0]?.id) === tab.id)
+      .sort((a, b) => a.row - b.row || a.col - b.col);
+    const els: WbElement[] = [];
+    const hints: DashboardLayoutHint['pages'][number]['elements'] = [];
+    for (const dc of pageDcs) {
+      const el = buildElement(dc);
+      if (!el) continue;
+      els.push(el);
+      hints.push({ elementId: el.id, name: el.name || el.kind, row: dc.row, col: dc.col, sizeX: dc.sizeX, sizeY: dc.sizeY });
+    }
+    builtPages.push({ name: pageName, els });
+    layout.pages.push({ name: pageName, elements: hints });
+  }
+
+  // Prune controls the converter KNOWS are furniture. A control is only LIVE if
+  // it has a real Sigma wiring path: a formula reference (reachBySlug) or an
+  // element `filters` target. Two failure modes are flagged, never shipped:
+  //   1. field-filter parameters whose column is missing from every mapped
+  //      card's result set (no target to bind).
+  //   2. variable-tag parameters that only drive a DM-SQL {{tag}} (dmBoundSlugs).
+  //      LIVE-DISPROVEN 2026-06-15 on a validation org: a workbook control bound
+  //      only to a DM custom-SQL {{param}} is INERT — the export API ignores a
+  //      text grain control entirely and a numeric one mis-substitutes and
+  //      breaks the query (0 rows). The control lint rightly flags these dead.
+  //      So they are NOT emitted; they go into `unreproducibleFilters` with a
+  //      manual-remodel hint instead of shipping furniture that lies.
+  const unreproducibleFilters: Array<{ controlId: string; name: string; reason: string; hint: string }> = [];
+  const liveControls = controls.filter((c) => {
+    const wired = reachBySlug.has(c.controlId) || (c.filters || []).length > 0;
+    if (wired) return true;
+    if (dmBoundSlugs.has(c.controlId)) {
+      unreproducibleFilters.push({
+        controlId: c.controlId, name: c.name,
+        reason: 'drives a native {{tag}} consumed pre-aggregation inside custom SQL — a workbook control bound to a DM-SQL parameter is inert (live-disproven)',
+        hint: 'rebuild as a native Sigma control: surface the underlying column/date in the element and filter/group on it (date-trunc control for granularity, relative-date filter for a window, list control for a value), or sync this control to the DM parameter in the Sigma UI.',
+      });
+      warnings.push(`control "${c.name}" [${c.controlId}] only drives a DM custom-SQL {{tag}} — NOT emitted (a workbook control bound to a DM-SQL parameter is inert, live-disproven). Listed in unreproducibleFilters with a remodel hint.`);
+    } else {
+      unreproducibleFilters.push({
+        controlId: c.controlId, name: c.name,
+        reason: 'its mapped column is not in any consuming element\'s result set (consumed then aggregated away inside SQL)',
+        hint: 'add the column to the card\'s SELECT (and GROUP BY) so it lands in the result set, then this control binds as an element filter automatically.',
+      });
+      warnings.push(`control "${c.name}" [${c.controlId}] has no wirable target in any mapped card — control NOT emitted (it would be dead furniture; see the per-card warnings for the fix).`);
+    }
+    return false;
+  });
+
+  // Assemble pages: controls live on the first page, AFTER the elements they
+  // target (a control whose `filters` target appears later in the spec fails
+  // at POST — verified cross-plugin gotcha, refs/control-parity.md).
+  let placedControls = false;
+  for (const bp of builtPages) {
+    const pageEls: WbElement[] = !placedControls && liveControls.length ? [...bp.els, ...(liveControls as any)] : bp.els;
+    if (!placedControls && liveControls.length) placedControls = true;
+    pages.push({ id: sigmaShortId(), name: bp.name, elements: pageEls });
+  }
+
+  // Hidden base-table sourcing roots live on a trailing "Data" page; its id
+  // starts with "data" — the cross-plugin convention layout gates use to
+  // exempt utility pages from dashboard-layout checks.
+  if (baseTables.length) {
+    pages.push({ id: `data${sigmaShortId()}`, name: 'Data', elements: baseTables });
+  }
+
+  // one aggregated warning per parameter that drives native template tags
+  // (per-mapping warnings would be thousands of lines on production estates)
+  if (tagWirings.length) {
+    const bySlug = new Map<string, typeof tagWirings>();
+    for (const w of tagWirings) { (bySlug.get(w.slug) || bySlug.set(w.slug, []).get(w.slug)!).push(w); }
+    for (const [slug, ws] of bySlug) {
+      const tags = [...new Set(ws.map((w) => w.tag))];
+      warnings.push(`parameter "${ws[0].parameter}" (control "${slug}") drives native template tag${tags.length > 1 ? 's' : ''} {{${tags.join('}}, {{')}}} across ${ws.length} card(s) — the DM converter emits the matching {{tag}} control(s); consolidate: either reference the DM control directly or sync this workbook control's value to it (see parameterWiring in the result + refs/template-tags.md).`);
+    }
+  }
+
+  const allEls = pages.filter((p) => p.name !== 'Data').flatMap((p) => p.elements).filter((e) => e.kind !== 'control');
+  const stats = {
+    dashcards: dcs.length,
+    pages: pages.length,
+    tables: allEls.filter((e) => e.kind === 'table').length,
+    pivots: allEls.filter((e) => e.kind === 'pivot-table').length,
+    kpis: allEls.filter((e) => e.kind === 'kpi-chart').length,
+    charts: allEls.filter((e) => e.kind.endsWith('-chart') && e.kind !== 'kpi-chart').length,
+    maps: allEls.filter((e) => e.kind.endsWith('-map')).length,
+    texts: allEls.filter((e) => e.kind === 'text').length,
+    columns: allEls.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    filters: allEls.reduce((n, e) => n + (e.filters?.length || 0), 0),
+    controls: liveControls.length,
+    baseTables: baseTables.length,
+  };
+
+  // control-scope.json sidecar (shared cross-plugin contract — control_lint.rb
+  // header CONTRACT + refs/control-parity.md). Signals = mapped parameters;
+  // scope = each control's DECLARED card targets (converted element names);
+  // mustReach = the subset the converter actually wired. dm-bound controls
+  // (variable-tag → control.parameters via remap --dm-spec) carry their scope
+  // as declared intent — if the org rejects the binding, post-and-readback
+  // drops them and patches this sidecar (see scripts/post-and-readback.mjs).
+  const controlScope: ControlScopeSidecar = {
+    version: 1, source: 'metabase',
+    sourceFilterSignals: [...mappingCountByParam.keys()].filter((id) => paramById.has(id)).length,
+    controls: liveControls.map((c) => ({
+      controlId: c.controlId,
+      sourceName: `Metabase parameter "${c.name}"${dmBoundSlugs.has(c.controlId) ? ' (drives native {{tag}}s via DM-parameter binding)' : ''}`,
+      scope: [...(scopeBySlug.get(c.controlId) || [])],
+      mustReach: [...(reachBySlug.get(c.controlId) || [])],
+    })),
+  };
+
+  const documentPages = pages.map((page) => ({
+    id: page.id,
+    name: page.name,
+    ...(page.name === 'Data' ? { visibility: 'hidden' } : {}),
+  }));
+  // Controls come after every element they target, including hidden Data-page
+  // base tables. Forward filter targets are rejected by workbook CREATE.
+  const flatElements = [
+    ...pages.flatMap((page) => page.elements).filter((element) => element.kind !== 'control'),
+    ...(liveControls as WbElement[]),
+  ];
+  const workbook = {
+    name,
+    document: {
+      schemaVersion: 1,
+      kind: 'workbook' as const,
+      pages: documentPages,
+      elements: flatElements,
+      layout: buildWorkbookLayout(pages, layout),
+    },
+  };
+
+  return {
+    workbook,
+    warnings, stats, layout, controlScope,
+    ...(tagWirings.length ? { parameterWiring: tagWirings } : {}),
+    ...(unreproducibleFilters.length ? { unreproducibleFilters } : {}),
+  };
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/metabase.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/metabase.ts
@@ -1,0 +1,1049 @@
+/**
+ * Metabase → Sigma Data Model converter.   [LIVE-VALIDATED 2026-06-11 — exact parity; see refs/design-notes.md §10]
+ *
+ * Input = plain REST JSON (see refs/rest-api.md):
+ *   { metadata?: <GET /api/database/{id}/metadata>, cards: [<GET /api/card/{id}>, …],
+ *     sandboxes?: [<GET /api/mt/gtap> entries — EE row sandboxing, detect-only] }
+ *
+ * Mapping (refs/design-notes.md decisions 1–8):
+ *   referenced warehouse table         → `warehouse-table` element (all metadata fields as raw columns)
+ *   MBQL card with `joins`             → its own element with a `join` source (left/right/inner/full)
+ *   nested question (source "card__N") → element sourced from card N's element (kind:'table')
+ *   native SQL card                    → sql-source element (statement verbatim; NO element name;
+ *                                        {{tags}} flagged with the control to create)
+ *   `expressions`                      → calculated columns (translateMbqlExpr)
+ *   `aggregation` (+ aggregation-options names) → element metrics
+ *   breakout temporal-unit             → DateTrunc calc column
+ *   fk_target_field_id (both tables present)    → DM relationship + derived join view
+ *   sandboxes                          → `security` (DETECT-ONLY — never injected into the model)
+ *
+ * MBQL arrives already parsed (nested JSON arrays), so translateMbqlExpr walks a
+ * tree — no regex DSL parsing. Every row of refs/expression-dsl.md is implemented;
+ * flagged ops (cum-sum, offset, segment, metric, binning) emit a readable
+ * "unmapped" comment placeholder + a loud warning — never silent, never faked.
+ */
+
+import {
+  resetIds, sigmaShortId, sigmaInodeId, sigmaDisplayName, sigmaColFormula,
+  inferSigmaFormat, buildDerivedElements,
+  type SigmaElement, type SigmaColumn, type SigmaMetric, type ConversionResult,
+} from './sigma-ids.js';
+// pMBQL ("lib/" MBQL) → legacy MBQL — modern instances (Cloud v1.61+) return
+// dataset_query as {"lib/type":"mbql/query","stages":[…]}; normalize at intake.
+import { normalizeCard } from './pmbql-normalize.mjs';
+
+// ── options / shared types ────────────────────────────────────────────────────
+
+export interface LearnedRule { pattern: string; template: string; flags?: string }
+
+export type WarehouseDialect = 'bigquery' | 'snowflake' | 'databricks' | 'redshift' | 'postgres' | 'mysql' | 'athena' | 'unknown';
+
+export interface MetabaseConvertOptions {
+  connectionId?: string;
+  database?: string;       // warehouse database for source paths (e.g. DEMO_DB)
+  schema?: string;         // overrides table.schema when set
+  modelName?: string;
+  warehouse?: WarehouseDialect;  // drives SQL dialect transforms (array agg, etc.)
+  // Customer-discovered translation rules (gap-scout, ~/.metabase-to-sigma/learned-rules.json).
+  // Applied BEFORE the built-in translator: a rule whose regex matches the FULL
+  // JSON serialization of an MBQL node wins (template may use $1.. captures).
+  learnedRules?: LearnedRule[];
+}
+
+/**
+ * Apply warehouse-specific SQL transforms to a native SQL statement.
+ * Called after tag rewriting, before the statement is written to the spec.
+ *
+ * Currently handles the single most common rendering failure:
+ *   Array aggregations — Sigma cannot display array/nested types in table cells.
+ *   Each warehouse has a different string-aggregation idiom.
+ */
+export function applyWarehouseTransforms(sql: string, warehouse: WarehouseDialect): string {
+  switch (warehouse) {
+    case 'bigquery':
+      // ARRAY_AGG(x [IGNORE NULLS]) → array_to_string(ARRAY_AGG(x [IGNORE NULLS]), ', ')
+      // Skip if already wrapped to avoid double-wrapping on re-runs.
+      return sql.replace(
+        /\bARRAY_AGG\s*(\([^)]+(?:\s+IGNORE\s+NULLS)?\)(?:\s+IGNORE\s+NULLS)?)/gi,
+        (m) => m.toLowerCase().includes('array_to_string') ? m : `array_to_string(${m}, ', ')`,
+      );
+    case 'snowflake':
+      // Snowflake ARRAY_AGG returns VARIANT — Sigma renders it as "[object]".
+      // LISTAGG is simpler and returns a plain string.
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `LISTAGG(${arg}, ', ')`,
+      );
+    case 'databricks':
+      // collect_list(x) returns an array type — wrap in array_join.
+      return sql.replace(
+        /\bcollect_list\s*\(([^)]+)\)/gi,
+        (_m, arg) => `array_join(collect_list(${arg}), ', ')`,
+      );
+    case 'redshift':
+    case 'postgres':
+      // STRING_AGG is ANSI and works on both.
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `STRING_AGG(CAST(${arg} AS VARCHAR), ', ')`,
+      );
+    case 'athena':
+      // Athena (Trino): array_join(array_agg(x), ', ')
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `array_join(array_agg(${arg}), ', ')`,
+      );
+    default:
+      return sql;
+  }
+}
+
+export interface MetabaseFieldInfo {
+  id: number; tableId: number; tableName: string; schema?: string;
+  columnName: string; displayName: string; baseType?: string;
+  fkTargetFieldId?: number | null;
+}
+export interface MetabaseTableInfo { id: number; name: string; schema?: string; fields: MetabaseFieldInfo[]; }
+export interface FieldIndex { byId: Map<number, MetabaseFieldInfo>; tableById: Map<number, MetabaseTableInfo>; tableByLeaf: Map<string, number>; }
+
+/** GET /api/database/{id}/metadata → field-id index (MBQL refs columns by integer id). */
+export function buildFieldIndex(metadata: any): FieldIndex {
+  const byId = new Map<number, MetabaseFieldInfo>();
+  const tableById = new Map<number, MetabaseTableInfo>();
+  const tableByLeaf = new Map<string, number>();
+  for (const t of metadata?.tables || []) {
+    const ti: MetabaseTableInfo = { id: t.id, name: t.name, schema: t.schema, fields: [] };
+    for (const f of t.fields || []) {
+      const fi: MetabaseFieldInfo = {
+        id: f.id, tableId: t.id, tableName: t.name, schema: t.schema,
+        columnName: f.name,
+        // Sigma-derived display name (NOT Metabase's display_name) so sibling
+        // bracket refs resolve against the raw-column auto-derived name.
+        displayName: sigmaDisplayName(f.name),
+        baseType: f.base_type, fkTargetFieldId: f.fk_target_field_id ?? null,
+      };
+      ti.fields.push(fi); byId.set(f.id, fi);
+    }
+    tableById.set(t.id, ti);
+    if (t.name) tableByLeaf.set(String(t.name).toLowerCase(), t.id);
+  }
+  return { byId, tableById, tableByLeaf };
+}
+
+// ── simple native-SQL → native-model recognizer ─────────────────────────────
+// A native-SQL card that is just a single SELECT over warehouse table(s) is
+// re-expressed as a structured (MBQL) query so it converts to a NATIVE Sigma
+// data model (table/join source, raw columns, aggregation metrics) instead of a
+// custom-SQL element. That is what makes its dashboard filters reproducible: the
+// underlying columns are exposed, so Sigma controls/element-filters work natively
+// (custom-SQL {{param}} filtering is inert from the workbook — live-disproven).
+// Returns a synthetic { 'source-table', joins?, aggregation?, breakout? } query,
+// or null when the SQL is too complex (CTE / subquery / CASE / window / set-op /
+// non-field-filter variable tag) — those fall back to a flagged custom-SQL element.
+const LEAF = (path: string) => String(path).trim().replace(/[`"\];]/g, '').split('.').pop()!.toLowerCase();
+const AGG_FN: Record<string, string> = { sum: 'sum', avg: 'avg', count: 'count', min: 'min', max: 'max', 'count_distinct': 'distinct', median: 'median', stddev: 'stddev' };
+
+export function recognizeSimpleNativeSql(card: any, fidx?: FieldIndex): any | null {
+  if (!fidx) return null;
+  const dq = card?.dataset_query;
+  if (!dq || dq.type !== 'native') return null;
+  let sql = String(dq.native?.query || '');
+  const tags: Record<string, any> = dq.native?.['template-tags'] || {};
+  if (!sql.trim()) return null;
+  sql = sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ').replace(/\s+/g, ' ').trim();
+  // bail on anything we will not model faithfully
+  if (/^\s*with\b/i.test(sql)) return null;
+  if (/\b(union|intersect|except|having)\b/i.test(sql)) return null;
+  if (/\bover\s*\(/i.test(sql) || /\bcase\b/i.test(sql) || /\(\s*select\b/i.test(sql)) return null;
+  // only field-filter (dimension) tags are reproducible without custom SQL;
+  // a bare {{value}} variable tag needs SQL substitution → keep as custom SQL.
+  for (const t of Object.values(tags)) if (String(t?.type).toLowerCase() !== 'dimension') return null;
+
+  // split top-level clauses (safe: no subqueries past the guards above)
+  const find = (kw: RegExp) => { const m = kw.exec(sql); return m ? m.index : -1; };
+  if (!/^\s*select\b/i.test(sql)) return null;
+  const iFrom = find(/\bfrom\b/i); if (iFrom < 0) return null;
+  const iWhere = find(/\bwhere\b/i);
+  const iGroup = find(/\bgroup\s+by\b/i);
+  const iOrder = find(/\border\s+by\b/i);
+  const bound = (start: number) => {
+    const ends = [iWhere, iGroup, iOrder].filter((x) => x > start);
+    return ends.length ? Math.min(...ends) : sql.length;
+  };
+  const selectList = sql.slice(sql.search(/select\b/i) + 6, iFrom).trim();
+  const fromClause = sql.slice(iFrom + 4, bound(iFrom)).trim();
+  const groupClause = iGroup >= 0 ? sql.slice(iGroup + sql.slice(iGroup).match(/^group\s+by/i)![0].length, bound(iGroup)).trim() : '';
+  // WHERE must contain ONLY field-filter tags (which we surface as Sigma controls/
+  // element-filters) and trivial 1=1 / [[optional]] markers — anything else is a
+  // real predicate that the remodel would SILENTLY DROP (wrong numbers). Bail to
+  // custom SQL in that case (never silently mistranslate). Also bail on LIMIT.
+  const whereClause = iWhere >= 0 ? sql.slice(iWhere + 5, bound(iWhere)).trim() : '';
+  if (whereClause) {
+    const residual = whereClause
+      .replace(/\{\{\s*[^}]+\s*\}\}/g, ' ').replace(/\[\[|\]\]/g, ' ')
+      .replace(/\b1\s*=\s*1\b/g, ' ').replace(/\b(and|or)\b/gi, ' ')
+      .replace(/[()\s]+/g, '');
+    if (residual) return null;
+  }
+  if (/\blimit\b\s+\d/i.test(sql)) return null;
+
+  // FROM + JOINs → alias→tableId map (first source = base)
+  const aliasTable = new Map<string, number>();
+  let baseTableId: number | null = null;
+  const joins: any[] = [];
+  // tokenize: base then repeated "[type] join <path> [as] <alias> on <cond>"
+  const joinRe = /\b(?:(inner|left|right|full)\s+)?(?:outer\s+)?join\b/gi;
+  const firstJoin = sql.slice(iFrom).search(joinRe);
+  const baseSeg = (firstJoin < 0 ? fromClause : sql.slice(iFrom + 4, iFrom + firstJoin)).trim();
+  const parseRef = (seg: string): { tid: number; alias?: string } | null => {
+    const parts = seg.trim().split(/\s+/);
+    const tid = fidx.tableByLeaf?.get(LEAF(parts[0]));
+    if (tid == null) return null;
+    let alias: string | undefined;
+    if (parts.length >= 3 && /^as$/i.test(parts[1])) alias = parts[2];
+    else if (parts.length === 2) alias = parts[1];
+    return { tid, alias };
+  };
+  const baseRef = parseRef(baseSeg); if (!baseRef) return null;
+  baseTableId = baseRef.tid; if (baseRef.alias) aliasTable.set(baseRef.alias.toLowerCase(), baseRef.tid);
+  // walk joins
+  const joinClause = firstJoin < 0 ? '' : sql.slice(iFrom + firstJoin, bound(iFrom));
+  if (joinClause) {
+    const segRe = /\b(?:(inner|left|right|full)\s+)?(?:outer\s+)?join\b\s+([\s\S]+?)\s+on\s+([\s\S]+?)(?=\b(?:inner\s+|left\s+|right\s+|full\s+)?(?:outer\s+)?join\b|$)/gi;
+    let jm: RegExpExecArray | null;
+    while ((jm = segRe.exec(joinClause))) {
+      const [, jtype, jref, jcond] = jm;
+      const r = parseRef(jref); if (!r) return null;
+      if (r.alias) aliasTable.set(r.alias.toLowerCase(), r.tid);
+      const cm = /([\w.]+)\s*=\s*([\w.]+)/.exec(jcond); if (!cm) return null;
+      const resolveCol = (tok: string): any | null => {
+        const [a, c] = tok.includes('.') ? tok.split('.') : [undefined, tok];
+        const tid = a ? aliasTable.get(a.toLowerCase()) ?? baseTableId : baseTableId;
+        const f = tid != null ? fidx.tableById.get(tid)?.fields.find((x) => x.columnName.toLowerCase() === c.toLowerCase()) : undefined;
+        return f ? ['field', f.id, a && aliasTable.get(a.toLowerCase()) !== baseTableId ? { 'join-alias': a } : null] : null;
+      };
+      const L = resolveCol(cm[1]), R = resolveCol(cm[2]); if (!L || !R) return null;
+      joins.push({ 'source-table': r.tid, strategy: `${(jtype || 'left').toLowerCase()}-join`, alias: r.alias,
+        condition: ['=', L, R] });
+    }
+  }
+
+  // resolve a "[alias.]col" token to a field ref
+  const colRef = (tok: string): any | null => {
+    const [a, c] = tok.includes('.') ? tok.split('.') : [undefined, tok];
+    const tid = a ? aliasTable.get(a.toLowerCase()) : baseTableId;
+    if (tid == null) return null;
+    const f = fidx.tableById.get(tid)?.fields.find((x) => x.columnName.toLowerCase() === c.replace(/[`"]/g, '').toLowerCase());
+    return f ? ['field', f.id, a && tid !== baseTableId ? { 'join-alias': a } : null] : null;
+  };
+
+  // SELECT list → aggregations + plain dimensions. Track each item's output ALIAS
+  // (explicit `as X`, else the column/function name) so the dashboard can re-map
+  // the card's viz settings (graph.dimensions/metrics reference these aliases).
+  const items = selectList.split(/,(?![^(]*\))/).map((s) => s.trim());
+  if (items.some((s) => !s)) return null;   // trailing/empty comma (e.g. BQ `…, from`) — don't trust the parse; keep verbatim SQL
+  const aggregation: any[] = [];
+  const breakout: any[] = [];
+  const resultMetadata: any[] = [];
+  const explicitAlias = (it: string): string | null => { const m = /\s+as\s+(["`\w]+)\s*$/i.exec(it); return m ? m[1].replace(/["`]/g, '') : null; };
+  for (const it of items) {
+    const expr = it.replace(/\s+as\s+["`\w]+\s*$/i, '').trim();
+    const am = /^(\w+)\s*\(\s*(distinct\s+)?(.+?)\s*\)$/i.exec(expr);
+    if (am && AGG_FN[am[1].toLowerCase()]) {
+      const fn = AGG_FN[(am[2] ? 'count_distinct' : am[1]).toLowerCase()] || AGG_FN[am[1].toLowerCase()];
+      const arg = am[3].trim();
+      const aggIdx = aggregation.length;
+      if (arg === '*' || /^\d+$/.test(arg)) aggregation.push(['count']);
+      else { const ref = colRef(arg); if (!ref) return null; aggregation.push([fn, ref]); }
+      const alias = explicitAlias(it) || am[1].toLowerCase();
+      resultMetadata.push({ name: alias, display_name: alias, field_ref: ['aggregation', aggIdx] });
+      continue;
+    }
+    if (!/^[\w.`"]+$/.test(expr)) return null;       // reject non-trivial expressions
+    const ref = colRef(expr); if (!ref) return null;
+    const alias = explicitAlias(it) || expr.split('.').pop()!.replace(/[`"]/g, '');
+    breakout.push(ref);
+    resultMetadata.push({ name: alias, display_name: alias, field_ref: ref });
+  }
+  // If a GROUP BY is present it defines the dimension grain; honor it (ordinals
+  // map to the Nth select item). Otherwise the SELECT dims are the breakout.
+  if (groupClause) {
+    breakout.length = 0;
+    for (const g of groupClause.split(/,(?![^(]*\))/).map((s) => s.trim()).filter(Boolean)) {
+      if (/^\d+$/.test(g)) { const rm = resultMetadata[Number(g) - 1]; if (rm && Array.isArray(rm.field_ref) && rm.field_ref[0] === 'field') breakout.push(rm.field_ref); continue; }
+      const ref = colRef(g); if (!ref) return null;
+      breakout.push(ref);
+    }
+  }
+  // Surface every field-filter tag's mapped column as an extra breakout dimension
+  // (so it lands in the result set + the element exposes it) — that is what lets
+  // the dashboard reproduce the filter as a native Sigma control/element-filter.
+  // It is NOT added to the viz, so it never becomes an unwanted chart axis.
+  for (const t of Object.values(tags)) {
+    const dim = (t as any).dimension;
+    const fid = Array.isArray(dim) && dim[0] === 'field' && typeof dim[1] === 'number' ? dim[1] : null;
+    if (fid == null || resultMetadata.some((rm) => Array.isArray(rm.field_ref) && rm.field_ref[1] === fid)) continue;
+    const f = fidx.byId.get(fid); if (!f) continue;
+    breakout.push(dim);
+    resultMetadata.push({ name: f.columnName, display_name: f.columnName, field_ref: dim });
+  }
+
+  const query = { database: dq.database, 'source-table': baseTableId, ...(joins.length ? { joins } : {}),
+    ...(aggregation.length ? { aggregation } : {}), ...(breakout.length ? { breakout } : {}) };
+  return { query, resultMetadata };
+}
+
+// ── MBQL expression tree → Sigma formula ─────────────────────────────────────
+
+export interface MbqlCtx {
+  /** ["field", id|name, opts] → bracketed Sigma ref (DateTrunc-wrapped if temporal-unit). */
+  resolveField: (ref: any) => string;
+  /** Same ref → bare display name (for naming metrics/columns). */
+  fieldDisplay: (ref: any) => string;
+  warn: (msg: string) => void;
+  learnedRules?: LearnedRule[];
+}
+
+const DATEPART: Record<string, string> = {
+  'get-year': 'year', 'get-quarter': 'quarter', 'get-month': 'month', 'get-week': 'week',
+  'get-day': 'day', 'get-day-of-week': 'dayofweek', 'get-hour': 'hour',
+  'get-minute': 'minute', 'get-second': 'second',
+};
+
+export function translateMbqlExpr(node: any, ctx: MbqlCtx): string {
+  // Learned rules first — a validated customer rule beats the built-in translation.
+  // Contract mirrors cognos applyLearnedRules: regex pattern → template, but matched
+  // against the FULL JSON serialization of the node (MBQL is a tree, not a string).
+  if (ctx.learnedRules?.length && typeof node === 'object' && node !== null) {
+    const json = JSON.stringify(node);
+    for (const r of ctx.learnedRules) {
+      try {
+        const re = new RegExp(r.pattern, r.flags || '');
+        const m = json.match(re);
+        if (m && m.index === 0 && m[0].length === json.length) return json.replace(re, r.template);
+      } catch { /* bad rule — skip */ }
+    }
+  }
+  if (node === null || node === undefined) return 'Null';
+  if (typeof node === 'number') return String(node);
+  if (typeof node === 'boolean') return node ? 'True' : 'False';
+  if (typeof node === 'string') return `"${node.replace(/"/g, '\\"')}"`;
+  if (!Array.isArray(node)) {
+    ctx.warn(`unrecognized MBQL node ${JSON.stringify(node).slice(0, 60)} — emitted a placeholder.`);
+    return `/* unmapped: ${JSON.stringify(node).slice(0, 40)} */`;
+  }
+
+  const op = String(node[0]).toLowerCase();
+  const t = (x: any) => translateMbqlExpr(x, ctx);
+  const args = () => node.slice(1).map(t);
+
+  switch (op) {
+    case 'field': return ctx.resolveField(node);
+    case 'expression': return `[${node[1]}]`;                 // sibling custom-column ref
+    case 'value': return t(node[1]);                          // literal wrapper unwraps transparently
+
+    // n-ary arithmetic → left-fold binary
+    case '+': case '-': case '*': case '/': {
+      const a = args();
+      return a.length === 1 ? a[0] : a.reduce((acc, x) => `(${acc} ${op} ${x})`);
+    }
+
+    case 'case': {
+      const clauses: any[] = node[1] || [];
+      const dflt = node[2] && typeof node[2] === 'object' && 'default' in node[2] ? t(node[2].default) : 'Null';
+      let out = dflt;
+      for (let i = clauses.length - 1; i >= 0; i--) out = `If(${t(clauses[i][0])}, ${t(clauses[i][1])}, ${out})`;
+      return out;
+    }
+
+    case 'coalesce': return `Coalesce(${args().join(', ')})`;
+    case 'concat': return `Concat(${args().join(', ')})`;
+    case 'substring': return node[3] !== undefined
+      ? `Mid(${t(node[1])}, ${t(node[2])}, ${t(node[3])})` : `Mid(${t(node[1])}, ${t(node[2])})`;
+    case 'trim': return `Trim(${t(node[1])})`;
+    case 'ltrim': return `LTrim(${t(node[1])})`;
+    case 'rtrim': return `RTrim(${t(node[1])})`;
+    case 'upper': return `Upper(${t(node[1])})`;
+    case 'lower': return `Lower(${t(node[1])})`;
+    case 'length': return `Len(${t(node[1])})`;
+    case 'replace': return `Replace(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+    case 'regex-match-first': return `RegexpExtract(${t(node[1])}, ${t(node[2])})`;
+    case 'split-part': return `SplitPart(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+
+    case 'round': return `Round(${args().join(', ')})`;
+    case 'floor': return `Floor(${t(node[1])})`;
+    case 'ceil': return `Ceiling(${t(node[1])})`;
+    case 'abs': return `Abs(${t(node[1])})`;
+    case 'sqrt': return `Sqrt(${t(node[1])})`;
+    case 'exp': return `Exp(${t(node[1])})`;
+    case 'power': return `Power(${t(node[1])}, ${t(node[2])})`;
+    case 'log': return `Log(${t(node[1])}, 10)`;              // Metabase log is base-10
+
+    case 'datetime-add': return `DateAdd("${node[3]}", ${t(node[2])}, ${t(node[1])})`;
+    case 'datetime-subtract': {
+      const n = node[2];
+      const neg = typeof n === 'number' ? String(-n) : `-(${t(n)})`;
+      return `DateAdd("${node[3]}", ${neg}, ${t(node[1])})`;
+    }
+    case 'datetime-diff': return `DateDiff("${node[3]}", ${t(node[1])}, ${t(node[2])})`;
+    case 'get-year': case 'get-quarter': case 'get-month': case 'get-week':
+    case 'get-day': case 'get-day-of-week': case 'get-hour': case 'get-minute': case 'get-second':
+      return `DatePart("${DATEPART[op]}", ${t(node[1])})`;
+    case 'now': return 'Now()';
+    case 'relative-datetime':
+      return node[1] === 'current' ? 'Today()' : `DateAdd("${node[2]}", ${t(node[1])}, Today())`;
+
+    // type casts (Metabase 50+ expression functions)
+    case 'text': return `Text(${t(node[1])})`;
+    case 'integer': return `Int(${t(node[1])})`;
+    case 'float': return `Number(${t(node[1])})`;
+    case 'date': return `DateTrunc("day", ${t(node[1])})`;   // date(x) = day-truncated datetime
+
+    // comparisons — multi-value `=` ⇒ infix `or` chain; multi `!=` ⇒ infix `and` chain.
+    // Sigma has NO IsIn, and NO Or()/And() FUNCTIONS either — `Or(a, b)` returns
+    // "Invalid formula" at POST (live-verified 2026-06-12); and/or are infix only.
+    // (pMBQL `in`/`not-in` are normalized to multi-value =/!= upstream; aliased here too)
+    case 'in': case 'not-in': case '=': case '!=': {
+      const eq = op === '=' || op === 'in' ? '=' : '!=';
+      const a = t(node[1]);
+      const vals = node.slice(2).map(t);
+      if (vals.length <= 1) return `${a} ${eq} ${vals[0] ?? 'Null'}`;
+      const parts = vals.map((v: string) => `${a} ${eq} ${v}`);
+      return eq === '=' ? `(${parts.join(' or ')})` : `(${parts.join(' and ')})`;
+    }
+    case '<': case '<=': case '>': case '>=':
+      return `${t(node[1])} ${op} ${t(node[2])}`;
+    case 'between': return `Between(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+    case 'and': return `(${args().join(' and ')})`;
+    case 'or': return `(${args().join(' or ')})`;
+    case 'not': return `Not(${t(node[1])})`;
+    case 'is-null': return `IsNull(${t(node[1])})`;
+    case 'not-null': return `IsNotNull(${t(node[1])})`;
+    case 'is-empty': return `(IsNull(${t(node[1])}) or ${t(node[1])} = "")`;
+    case 'not-empty': return `(IsNotNull(${t(node[1])}) and ${t(node[1])} != "")`;
+
+    case 'starts-with': case 'ends-with': case 'contains': case 'does-not-contain': {
+      const fn = op === 'starts-with' ? 'StartsWith' : op === 'ends-with' ? 'EndsWith' : 'Contains';
+      const opts = node[3] && typeof node[3] === 'object' ? node[3] : {};
+      const caseSensitive = opts['case-sensitive'] === true;
+      const s = t(node[1]), sub = t(node[2]);
+      // Metabase string matching is case-INSENSITIVE by default — wrap in Lower()
+      const body = caseSensitive ? `${fn}(${s}, ${sub})` : `${fn}(Lower(${s}), Lower(${sub}))`;
+      return op === 'does-not-contain' ? `Not(${body})` : body;
+    }
+
+    case 'time-interval': {
+      const f = t(node[1]); const n = node[2]; const unit = node[3];
+      if (n === 'current') return `DateTrunc("${unit}", ${f}) = DateTrunc("${unit}", Today())`;
+      return typeof n === 'number' && n > 0
+        ? `${f} <= DateAdd("${unit}", ${n}, Today())`
+        : `${f} >= DateAdd("${unit}", ${typeof n === 'number' ? n : t(n)}, Today())`;
+    }
+    case 'inside': {
+      // ["inside", latField, lonField, latMax, lonMin, latMin, lonMax] → lat/lon Between pair
+      const [lat, lon, latMax, lonMin, latMin, lonMax] = node.slice(1).map(t);
+      return `(Between(${lat}, ${latMin}, ${latMax}) and Between(${lon}, ${lonMin}, ${lonMax}))`;
+    }
+
+    // ── aggregations (legal at the top of an aggregation clause) ──────────────
+    case 'count': return 'Count()';
+    case 'sum': return `Sum(${t(node[1])})`;
+    case 'avg': return `Avg(${t(node[1])})`;
+    case 'min': return `Min(${t(node[1])})`;
+    case 'max': return `Max(${t(node[1])})`;
+    case 'median': return `Median(${t(node[1])})`;
+    case 'distinct': return `CountDistinct(${t(node[1])})`;
+    case 'stddev': return `StdDev(${t(node[1])})`;
+    case 'var': return `Variance(${t(node[1])})`;
+    case 'percentile': return `Percentile(${t(node[1])}, ${t(node[2])})`;
+    case 'count-where': return `CountIf(${t(node[1])})`;            // condition only — no field arg
+    case 'sum-where': return `SumIf(${t(node[1])}, ${t(node[2])})`; // FIELD FIRST
+    case 'share': return `CountIf(${t(node[1])}) / Count()`;
+    case 'aggregation-options': return t(node[1]);                  // wrapper only supplies the name
+
+    // ── flagged — never faked ──────────────────────────────────────────────────
+    case 'cum-sum': case 'cum-count':
+      ctx.warn(`"${op}" is a running total — rebuild with CumulativeSum in the date-grouped workbook element (window scope lives on the consuming element).`);
+      return `/* unmapped: ${op} */`;
+    case 'offset':
+      ctx.warn('"offset" is a lag/lead window function — rebuild with Lag/window calc in the consuming element.');
+      return '/* unmapped: offset */';
+    case 'segment':
+      ctx.warn(`["segment", ${node[1]}] references a saved segment — inline its MBQL from GET /api/segment/${node[1]} and re-run.`);
+      return `/* unmapped: segment ${node[1]} */`;
+    case 'metric':
+      ctx.warn(`["metric", ${node[1]}] references a saved (legacy) metric — inline its MBQL from GET /api/legacy-metric/${node[1]} and re-run.`);
+      return `/* unmapped: metric ${node[1]} */`;
+    case 'aggregation':
+      ctx.warn(`["aggregation", ${node[1]}] positional ref outside order-by — not resolvable here.`);
+      return `/* unmapped: aggregation ${node[1]} */`;
+
+    default:
+      ctx.warn(`MBQL op "${op}" has no confirmed Sigma mapping — emitted a placeholder; review/translate manually.`);
+      return `/* unmapped: ${op} */`;
+  }
+}
+
+const AGG_LABEL: Record<string, (d: string) => string> = {
+  count: () => 'Count',
+  sum: (d) => `Sum of ${d}`, avg: (d) => `Average of ${d}`, min: (d) => `Min of ${d}`,
+  max: (d) => `Max of ${d}`, median: (d) => `Median of ${d}`,
+  distinct: (d) => `Distinct Count of ${d}`, stddev: (d) => `StdDev of ${d}`,
+  var: (d) => `Variance of ${d}`, percentile: (d) => `Percentile of ${d}`,
+  'count-where': () => 'Count of Matching Rows', 'sum-where': (d) => `Sum of ${d} (Filtered)`,
+  share: () => 'Share of Matching Rows',
+  'cum-sum': (d) => `Cumulative Sum of ${d}`, 'cum-count': () => 'Cumulative Count',
+};
+
+/** Aggregation clause → { formula, name } — named via aggregation-options, else derived ("Sum of Revenue"). */
+export function translateAggregation(node: any, ctx: MbqlCtx): { formula: string; name: string } {
+  let inner = node; let name: string | undefined;
+  if (Array.isArray(node) && String(node[0]).toLowerCase() === 'aggregation-options') {
+    inner = node[1];
+    const o = node[2] || {};
+    name = o['display-name'] || (o.name ? sigmaDisplayName(o.name) : undefined);
+  }
+  const formula = translateMbqlExpr(inner, ctx);
+  if (!name) {
+    const op = Array.isArray(inner) ? String(inner[0]).toLowerCase() : '';
+    const fieldRef = Array.isArray(inner) ? inner.find((x: any) => Array.isArray(x) && x[0] === 'field') : undefined;
+    const disp = fieldRef ? ctx.fieldDisplay(fieldRef) : '';
+    name = AGG_LABEL[op] ? AGG_LABEL[op](disp) : sigmaDisplayName(op || 'Metric');
+  }
+  return { formula, name };
+}
+
+// ── convert ───────────────────────────────────────────────────────────────────
+
+// Live-verified enum: inner | left-outer | right-outer | full-outer | lookup.
+const JOIN_TYPE: Record<string, string> = {
+  'left-join': 'left-outer', 'right-join': 'right-outer', 'inner-join': 'inner', 'full-join': 'full-outer',
+};
+const titleCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+function normalizeInput(input: any): { metadata?: any; cards: any[]; sandboxes?: any[] } {
+  const root = typeof input === 'string' ? JSON.parse(input) : input;
+  // pMBQL → legacy at extraction intake; per-card sniff (a list may mix formats).
+  const norm = (cs: any[]) => (cs || []).map((c) => normalizeCard(c));
+  if (Array.isArray(root)) return { cards: norm(root) };
+  if (root?.cards) return { metadata: root.metadata, cards: norm(root.cards), sandboxes: root.sandboxes };
+  if (root?.dataset_query) return { cards: norm([root]) };
+  return { metadata: root?.metadata, cards: [], sandboxes: root?.sandboxes };
+}
+
+export function convertMetabaseToSigma(input: string | object, options: MetabaseConvertOptions = {}): ConversionResult {
+  resetIds();
+  const { connectionId = '<CONNECTION_ID>', database = '', schema = '' } = options;
+  const warnings: string[] = [];
+  const inp = normalizeInput(input);
+  const fidx = inp.metadata ? buildFieldIndex(inp.metadata) : null;
+  if (!fidx) warnings.push("no database metadata provided — falling back to each card's result_metadata names (table qualifiers are lost); pass GET /api/database/{id}/metadata as input.metadata.");
+
+  // Engine-aware database default when --database is omitted: Metabase metadata
+  // carries the warehouse identifier in engine-specific `details` keys
+  // (Snowflake `db`; BigQuery `project-id` — Sigma BQ paths are [project, dataset, table]).
+  const metaEngine: string = inp.metadata?.engine || '';
+  const metaDb: string = (() => {
+    const d = inp.metadata?.details || {};
+    const keys = /bigquery/.test(metaEngine)
+      ? ['project-id', 'project-id-from-credentials']
+      : ['db', 'dbname', 'database'];
+    for (const k of keys) if (typeof d[k] === 'string' && d[k]) return d[k];
+    return '';
+  })();
+
+  interface ElemCtx {
+    element: SigmaElement; columns: SigmaColumn[]; metrics: SigmaMetric[]; order: string[];
+    colIdByName: Map<string, string>; colIdByFieldId: Map<number, string>;
+    ownedByCard: boolean;   // card-specific element (join/nested/sql) — safe for element filters
+  }
+  const elemCtxs: ElemCtx[] = [];
+  const tableCtxByTableId = new Map<number, ElemCtx>();
+  const newCtx = (element: SigmaElement, ownedByCard: boolean): ElemCtx => {
+    const c: ElemCtx = {
+      element, columns: element.columns as SigmaColumn[], metrics: [], order: element.order as string[],
+      colIdByName: new Map(), colIdByFieldId: new Map(), ownedByCard,
+    };
+    elemCtxs.push(c); return c;
+  };
+
+  const tablePath = (t: MetabaseTableInfo): string[] => {
+    const path: string[] = [database || metaDb || '<DATABASE>'];
+    // Per-table schema FIRST — estates span schemas/datasets; --schema is only a
+    // fallback for metadata that omits it.
+    const sch = t.schema || schema || '';
+    if (sch) path.push(sch);
+    // Preserve case: Snowflake metadata reports uppercase physical names already;
+    // BigQuery (case-sensitive) reports lowercase — uppercasing breaks BQ paths
+    // AND the formula prefixes that must match the path tail (live-verified:
+    // [accounts/Account Id] on path […, 'accounts'] resolves; ACCOUNTS would not).
+    path.push(t.name);
+    return path;
+  };
+
+  // Referenced warehouse table → warehouse-table element (one per table, deduped).
+  const ensureTableElement = (tableId: number): ElemCtx | null => {
+    const existing = tableCtxByTableId.get(tableId);
+    if (existing) return existing;
+    const t = fidx?.tableById.get(tableId);
+    if (!t) { warnings.push(`table ${tableId} is not in the database metadata — cannot emit a warehouse-table element for it.`); return null; }
+    // Case-preserved: the warehouse-element column prefix must match the path tail
+    // exactly (BQ is lowercase; Snowflake metadata is already uppercase).
+    const tableTail = t.name;
+    const element: SigmaElement = {
+      id: sigmaShortId(), kind: 'table', name: sigmaDisplayName(t.name),
+      source: { connectionId, kind: 'warehouse-table', path: tablePath(t) },
+      columns: [], order: [],
+    };
+    const ctx = newCtx(element, false);
+    tableCtxByTableId.set(tableId, ctx);
+    for (const f of t.fields) {
+      const id = sigmaInodeId(f.columnName);
+      ctx.columns.push({ id, formula: sigmaColFormula(tableTail, f.columnName) });
+      ctx.order.push(id);
+      ctx.colIdByName.set(f.displayName.toLowerCase(), id);
+      ctx.colIdByFieldId.set(f.id, id);
+    }
+    return ctx;
+  };
+
+  // Per-card MBQL translation context: field-id resolution via metadata, falling
+  // back to the card's result_metadata names (with a warning — decision 1).
+  const mkMbqlCtx = (card: any): MbqlCtx => {
+    const rmById = new Map<number, any>();
+    for (const rm of card.result_metadata || []) {
+      const fr = rm.field_ref;
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') rmById.set(fr[1], rm);
+    }
+    const display = (ref: any): string => {
+      const idOrName = Array.isArray(ref) ? ref[1] : ref;
+      if (typeof idOrName === 'number') {
+        const f = fidx?.byId.get(idOrName);
+        if (f) return f.displayName;
+        const rm = rmById.get(idOrName);
+        if (rm) return rm.display_name || sigmaDisplayName(rm.name);
+        warnings.push(`card "${card.name}": field ${idOrName} could not be resolved (no metadata match, no result_metadata match) — emitted [Field ${idOrName}]. Fallback chain: pass /api/database/{id}/metadata; if that 403s on a scoped key, GET /api/field/${idOrName} works even for restricted DBs.`);
+        return `Field ${idOrName}`;
+      }
+      return sigmaDisplayName(String(idOrName ?? ''));
+    };
+    const ctx: MbqlCtx = {
+      fieldDisplay: display,
+      resolveField: (ref: any) => {
+        const opts = (Array.isArray(ref) && ref[2]) || {};
+        // Implicit FK join ([field, dimField, {source-field}]) — the dim table must
+        // exist as an element or the FK relationship (and the derived view column
+        // the consuming chart needs) is silently dropped (live-verified).
+        if (opts['source-field'] && Array.isArray(ref) && typeof ref[1] === 'number') {
+          const f = fidx?.byId.get(ref[1]);
+          if (f) ensureTableElement(f.tableId);
+        }
+        let out = `[${display(ref)}]`;
+        if (opts['temporal-unit']) out = `DateTrunc("${opts['temporal-unit']}", ${out})`;
+        if (opts.binning) ctx.warn(`numeric binning on [${display(ref)}] is flagged — recreate with BinFixed/BinCount in the workbook element.`);
+        return out;
+      },
+      warn: (m) => warnings.push(`card "${card.name}": ${m}`),
+      learnedRules: options.learnedRules,
+    };
+    return ctx;
+  };
+
+  const parseJoinCondition = (cond: any, ctxM: MbqlCtx): Array<{ left: string; right: string }> => {
+    // Join-condition refs are bare [Column] scoped to each side, using Sigma's
+    // PRETTIFIED display name of the physical column ('[Product Key]'; the physical
+    // '[PRODUCT_KEY]' 400s "Column reference not found" — live-verified).
+    const rawCol = (ref: any): string => {
+      if (Array.isArray(ref) && ref[0] === 'field' && typeof ref[1] === 'number') {
+        const f = fidx?.byId.get(ref[1]);
+        if (f) return `[${sigmaDisplayName(f.columnName)}]`;
+      }
+      return `[${ctxM.fieldDisplay(ref)}]`;
+    };
+    const out: Array<{ left: string; right: string }> = [];
+    const walk = (c: any) => {
+      if (!Array.isArray(c)) return;
+      const op = String(c[0]).toLowerCase();
+      if (op === 'and') { c.slice(1).forEach(walk); return; }
+      if (op === '=' && c.length === 3) out.push({ left: rawCol(c[1]), right: rawCol(c[2]) });
+    };
+    walk(cond);
+    return out;
+  };
+
+  // MBQL card with `joins` → its own element with a join source.
+  const buildJoinElement = (card: any, q: any, ctxM: MbqlCtx): ElemCtx | null => {
+    const baseId = q['source-table'];
+    const baseT = typeof baseId === 'number' ? fidx?.tableById.get(baseId) : undefined;
+    if (!baseT) { warnings.push(`card "${card.name}" joins from table ${JSON.stringify(baseId)}, which is not in the metadata — join element skipped.`); return null; }
+    ensureTableElement(baseId);  // base + joined tables also get warehouse-table elements (FK relationships, reuse)
+    const joins: any[] = [];
+    const joinedTables: MetabaseTableInfo[] = [];
+    for (const j of q.joins || []) {
+      const jt = typeof j['source-table'] === 'number' ? fidx?.tableById.get(j['source-table']) : undefined;
+      if (!jt) { warnings.push(`card "${card.name}": join to ${JSON.stringify(j['source-table'])} not resolvable (card-source join or missing metadata) — that join was skipped.`); continue; }
+      ensureTableElement(j['source-table']);
+      joinedTables.push(jt);
+      const on = parseJoinCondition(j.condition, ctxM);
+      if (!on.length) warnings.push(`card "${card.name}": join condition for ${jt.name} is not a simple equi-join — author the ON clause in Sigma.`);
+      joins.push({
+        // connectionId is REQUIRED on each join side (nested sources carry their own
+        // connection — live-verified 400 "joins[0].left.connectionId: Invalid string").
+        // Conditions live in `columns` (not `on`), and the relationship `name` is the
+        // formula prefix for this right source's columns ([NAME/Col]).
+        left: { kind: 'warehouse-table', connectionId, path: tablePath(baseT) },
+        right: { kind: 'warehouse-table', connectionId, path: tablePath(jt) },
+        joinType: JOIN_TYPE[j.strategy || 'left-join'] || 'left-outer',
+        columns: on,
+        name: jt.name,
+      });
+    }
+    const element: SigmaElement = {
+      id: sigmaShortId(), kind: 'table', name: card.name || `Card ${card.id}`,
+      // source.name is the formula prefix for the head source's columns.
+      source: { kind: 'join', name: baseT.name, connectionId, joins },
+      columns: [], order: [],
+    };
+    const ctx = newCtx(element, true);
+    const addRaw = (t: MetabaseTableInfo) => {
+      for (const f of t.fields) {
+        const key = f.displayName.toLowerCase();
+        if (ctx.colIdByName.has(key)) continue; // duplicate display name (e.g. the join key on both sides) — first wins
+        const id = sigmaInodeId(f.columnName);
+        ctx.columns.push({ id, formula: sigmaColFormula(t.name, f.columnName) });
+        ctx.order.push(id);
+        ctx.colIdByName.set(key, id);
+        ctx.colIdByFieldId.set(f.id, id);
+      }
+    };
+    addRaw(baseT);
+    for (const jt of joinedTables) addRaw(jt);
+    return ctx;
+  };
+
+  const addCalc = (ctx: ElemCtx, name: string, formula: string): void => {
+    if (ctx.colIdByName.has(name.toLowerCase())) return; // same-named calc already on this (shared) element
+    const id = sigmaShortId();
+    ctx.columns.push({ id, name, formula });
+    ctx.order.push(id);
+    ctx.colIdByName.set(name.toLowerCase(), id);
+  };
+  const addMetric = (ctx: ElemCtx, name: string, formula: string): void => {
+    if (ctx.metrics.some((m) => m.name === name)) return;
+    const m: SigmaMetric = { id: sigmaShortId(), name, formula };
+    const fmt = inferSigmaFormat(formula, name);
+    if (fmt) (m as any).format = fmt;
+    ctx.metrics.push(m);
+  };
+
+  const cards: any[] = inp.cards || [];
+  const cardById = new Map<number, any>(cards.filter((c) => c?.id != null).map((c) => [c.id, c]));
+  const cardElemId = new Map<number, string>();
+  const inFlight = new Set<number>();
+  let sqlElements = 0;
+
+  // ── template tags → Sigma controls (45% of cards on the reference estate) ────
+  // Plain variable tags keep their {{tag}} verbatim — Sigma custom SQL uses the
+  // SAME {{control-id}} parameter syntax — and get a matching control element.
+  // Field-filter (dimension) tags expand to a whole SQL predicate at runtime, so
+  // the {{tag}} is replaced with a documented `1=1 /* … */` and the filter is
+  // recreated as a control + element filter on the consuming workbook element.
+  // See refs/template-tags.md for the full mapping table.
+  const TAG_CONTROL_TYPE: Record<string, string> = { text: 'text', number: 'number', date: 'date', boolean: 'switch' };
+  const controlElements: SigmaElement[] = [];
+  const controlByControlId = new Map<string, any>();
+  const ensureControl = (controlId: string, name: string, controlType: string, value: any): void => {
+    const existing = controlByControlId.get(controlId);
+    if (existing) {
+      if (existing.controlType !== controlType) {
+        warnings.push(`template tag "${controlId}" appears with conflicting types (${existing.controlType} vs ${controlType}) across cards — one control was emitted with type ${existing.controlType}; review.`);
+      }
+      return;
+    }
+    // Each controlType variant has REQUIRED discriminant fields (live-verified: omitting
+    // text's `mode` fails the union match and surfaces as `Invalid kind: "control"`).
+    const ctrl: any = { id: sigmaShortId(), kind: 'control', controlId, name, controlType };
+    if (controlType === 'text') ctrl.mode = 'equals';
+    if (controlType === 'number') ctrl.mode = '=';
+    if (controlType === 'date') ctrl.mode = '=';
+    if (controlType === 'switch') ctrl.mode = 'True/All';
+    if (value != null) ctrl.value = value;
+    controlByControlId.set(controlId, ctrl);
+    controlElements.push(ctrl);
+  };
+  const TAG_RE = (tag: string) => new RegExp(`\\{\\{\\s*${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\}\\}`, 'g');
+
+  /** Rewrite a native statement per its template tags; returns the SQL to emit. */
+  const processNativeSql = (card: any, statement: string, tags: Record<string, any>): string => {
+    let sql = statement;
+    const tagType = (n: string) => String(tags[n]?.type || 'text').toLowerCase();
+    // 1. Optional [[ … ]] blocks (Metabase: included only when the tag has a value).
+    sql = sql.replace(/\[\[([\s\S]*?)\]\]/g, (_m, body: string) => {
+      const inner = [...body.matchAll(/\{\{\s*([^{}\s]+)\s*\}\}/g)].map((m) => m[1]);
+      const keep = inner.length > 0 && inner.every((n) =>
+        tagType(n) === 'dimension' || tags[n]?.default != null);
+      if (keep) {
+        warnings.push(`card "${card.name}": optional [[…]] block kept ACTIVE (its tag${inner.length > 1 ? 's' : ''} {{${inner.join('}}, {{')}}} ${inner.every((n) => tagType(n) === 'dimension') ? 'are field filters that neutralize to 1=1' : 'have defaults'}) — verify the always-on semantics.`);
+        return body;
+      }
+      warnings.push(`card "${card.name}": optional [[…]] block DROPPED (tag has no default — Metabase omits it when empty; Sigma has no optional-clause syntax). Re-add the clause around the control if the filter must be available: ${body.trim().slice(0, 80)}`);
+      return '';
+    });
+    // 2. Per-tag handling.
+    for (const [tagName, tagRaw] of Object.entries(tags)) {
+      const tag: any = tagRaw;
+      const ttype = String(tag?.type || 'text').toLowerCase();
+      const display = tag?.['display-name'] || sigmaDisplayName(tagName);
+      if (ttype === 'dimension') {
+        // field filter — expands to a whole WHERE predicate at runtime
+        const dim = tag.dimension;
+        const fieldId = Array.isArray(dim) && dim[0] === 'field' && typeof dim[1] === 'number' ? dim[1] : null;
+        const f = fieldId != null ? fidx?.byId.get(fieldId) : undefined;
+        const colDesc = f ? `[${f.displayName}] (${f.tableName})` : `the tag's mapped column (field ${fieldId ?? '?'} — resolve via GET /api/field/{id})`;
+        // NO {{braces}} in the comment — Sigma resolves {{…}} refs even inside SQL
+        // comments and 400s on the missing control (live-verified).
+        sql = sql.replace(TAG_RE(tagName), `1=1 /* Metabase field filter '${tagName}' → filter ${f ? `[${f.displayName}]` : 'the mapped column'} on the consuming Sigma element */`);
+        warnings.push(`card "${card.name}": native {{${tagName}}} is a FIELD FILTER (widget ${tag['widget-type'] || '?'}) on ${colDesc} — the predicate was neutralized to 1=1 in the SQL; recreate it as a Sigma control + element filter on that column in the workbook (field filters expand to a whole WHERE clause, not a scalar).`);
+      } else if (ttype === 'card') {
+        // {{#N}} sub-question — inline its SQL when the referenced card is available
+        const refId = tag['card-id'];
+        const ref = refId != null ? cardById.get(refId) : undefined;
+        const refDq = ref?.dataset_query;
+        const refTags = refDq?.native?.['template-tags'] || {};
+        if (refDq?.type === 'native' && Object.keys(refTags).length === 0) {
+          sql = sql.replace(TAG_RE(tagName), `(\n${refDq.native?.query || ''}\n)`);
+          warnings.push(`card "${card.name}": native {{${tagName}}} (sub-question card ${refId}) was INLINED as a sub-select from card ${refId}'s SQL — verify.`);
+        } else {
+          warnings.push(`card "${card.name}": native {{${tagName}}} references card ${refId ?? '?'} — ${ref ? 'it is not a tag-free native card, so it was NOT inlined automatically' : `fetch GET /api/card/${refId ?? '{id}'}, add it to the input set, and re-run to inline it`}; resolve manually before posting.`);
+        }
+      } else if (ttype === 'snippet') {
+        warnings.push(`card "${card.name}": native {{${tagName}}} splices a SQL snippet — inline it (GET /api/native-query-snippet) into the statement before posting; Sigma has no snippet library.`);
+      } else {
+        // text / number / date / boolean variable — SAME {{name}} syntax in Sigma custom SQL
+        const controlType = TAG_CONTROL_TYPE[ttype] || 'text';
+        ensureControl(tagName, display, controlType, tag?.default);
+        warnings.push(`card "${card.name}": native {{${tagName}}} (${ttype}) — a Sigma ${controlType} control "${display}" (controlId "${tagName}") was emitted; the {{${tagName}}} reference is kept verbatim (Sigma custom SQL uses the same {{control-id}} parameter syntax). Verify the control's default${tag?.required ? ' (tag is REQUIRED — set a default or the element errors until set)' : ''}.`);
+      }
+    }
+    // 3. Warehouse-specific SQL transforms (array agg → string agg, etc.)
+    if (options.warehouse && options.warehouse !== 'unknown') {
+      sql = applyWarehouseTransforms(sql, options.warehouse);
+    }
+    // 4. Strip trailing semicolon(s): Sigma wraps a custom-SQL element's statement
+    // as a subquery `( … )`, so a trailing `;` is a syntax error at POST
+    // (live-verified on BigQuery: `Expected ")" but got ";"`). Metabase tolerates it.
+    sql = sql.replace(/;\s*$/, '').trimEnd();
+    return sql;
+  };
+
+  const processCard = (card: any): void => {
+    if (!card) return;
+    if (card.id != null && cardElemId.has(card.id)) return;
+    if (card.id != null && inFlight.has(card.id)) { warnings.push(`card ${card.id} participates in a circular card__ reference chain — skipped.`); return; }
+    if (card.id != null) inFlight.add(card.id);
+    const done = () => { if (card.id != null) inFlight.delete(card.id); };
+    let dq = card.dataset_query || {};
+    // Simple native SQL → native Sigma data model (so filters are reproducible
+    // natively — see recognizeSimpleNativeSql). Complex SQL stays custom SQL below.
+    if (dq.type === 'native') {
+      const remodeled = recognizeSimpleNativeSql(card, fidx || undefined);
+      if (remodeled) {
+        dq = { type: 'query', database: dq.database, query: remodeled.query };
+        warnings.push(`card "${card.name}": simple native SQL auto-remodeled to a NATIVE Sigma data model (table/join source + aggregation) — its columns are exposed so dashboard filters reproduce as native Sigma controls/element-filters (no custom SQL).`);
+      }
+    }
+    const ctxM = mkMbqlCtx(card);
+
+    // ── native SQL card → sql-source element (statement near-verbatim, NO element name) ──
+    // SQL dialect passes through to Sigma custom SQL untouched — same-warehouse
+    // migrations (e.g. BigQuery→BigQuery) are near-verbatim.
+    if (dq.type === 'native') {
+      const statement = processNativeSql(card, dq.native?.query || '', dq.native?.['template-tags'] || {});
+      const element: SigmaElement = {
+        // No `name` field: Sigma derives the sql element's own identifier.
+        id: sigmaShortId(), kind: 'table',
+        source: { kind: 'sql', connectionId, statement },
+        columns: [], order: [],
+      };
+      const ctx = newCtx(element, true);
+      for (const rm of card.result_metadata || []) {
+        // Prettify ALWAYS (sigmaDisplayName is idempotent): native-card display_name
+        // is the raw alias (x_axis_type), which otherwise becomes the chart label.
+        const disp = sigmaDisplayName(rm.display_name || rm.name);
+        const id = sigmaShortId();
+        // sql-element column refs MUST be [Custom SQL/ALIAS] (raw SQL output alias).
+        // Bare [Display Name] refs POST 200 but resolve to type "error" at query
+        // time (live-verified — the readback gate exists for exactly this).
+        ctx.columns.push({ id, name: disp, formula: `[Custom SQL/${rm.name || disp}]` });
+        ctx.order.push(id);
+        ctx.colIdByName.set(disp.toLowerCase(), id);
+      }
+      if (card.id != null) cardElemId.set(card.id, element.id);
+      sqlElements++;
+      done();
+      return;
+    }
+
+    // ── MBQL card ────────────────────────────────────────────────────────────────
+    const q = dq.query || {};
+    if (q['source-query']) {
+      // multi-stage query (pMBQL stages>1 / legacy nested source-query) — rare
+      // (14 of 7,023 on the reference estate) and structurally a sub-query;
+      // flagged, never silently mistranslated.
+      warnings.push(`card "${card.name}" is a MULTI-STAGE query (nested source-query) — not auto-converted; rebuild as a chain of Sigma elements (inner stage → element, outer stage → child element) or a custom-SQL element. Card skipped.`);
+      done(); return;
+    }
+    const src = q['source-table'];
+    let target: ElemCtx | null = null;
+
+    if (typeof src === 'string' && src.startsWith('card__')) {
+      // Nested question — sourced from card N's element when card N is in the input set.
+      const n = Number(src.slice('card__'.length));
+      const parent = cardById.get(n);
+      if (!parent) { warnings.push(`card "${card.name}" is a nested question on card ${n}, which is NOT in the input set — fetch GET /api/card/${n}, add it, and re-run; card skipped.`); done(); return; }
+      processCard(parent);
+      const parentElemId = cardElemId.get(n);
+      if (!parentElemId) { warnings.push(`card "${card.name}": its source card ${n} did not produce an element — skipped.`); done(); return; }
+      const element: SigmaElement = {
+        id: sigmaShortId(), kind: 'table', name: card.name || `Card ${card.id}`,
+        source: { kind: 'table', elementId: parentElemId },
+        columns: [], order: [],
+      };
+      target = newCtx(element, true);
+      // Passthrough the parent's columns — a table-sourced element starts EMPTY
+      // (zero queryable columns live-verified), so anything consuming this element
+      // (the workbook chart for this very card) has nothing to reference without them.
+      const parentCtx = elemCtxs.find((c) => c.element.id === parentElemId);
+      const parentName = parentCtx?.element.name || 'Parent';
+      for (const pc of parentCtx?.columns || []) {
+        const tail = pc.name || /\/([^\]/]+)\]$/.exec(String(pc.formula || ''))?.[1];
+        if (!tail || target.colIdByName.has(tail.toLowerCase())) continue;
+        const id = sigmaShortId();
+        target.columns.push({ id, name: tail, formula: `[${parentName}/${tail}]` });
+        target.order.push(id);
+        target.colIdByName.set(tail.toLowerCase(), id);
+      }
+    } else if (Array.isArray(q.joins) && q.joins.length) {
+      target = buildJoinElement(card, q, ctxM);
+    } else if (typeof src === 'number') {
+      target = ensureTableElement(src);
+      if (!target) warnings.push(`card "${card.name}" skipped — its source table ${src} is unknown.`);
+    } else if (src !== undefined) {
+      warnings.push(`card "${card.name}": unrecognized source-table ${JSON.stringify(src)} — skipped.`);
+    }
+    if (!target) { done(); return; }
+    if (card.id != null) cardElemId.set(card.id, target.element.id);
+
+    // expressions → calculated columns
+    for (const [name, expr] of Object.entries(q.expressions || {})) {
+      addCalc(target, String(name), translateMbqlExpr(expr, ctxM));
+    }
+    // breakout temporal-unit → DateTrunc calc column (plain breakouts are already raw columns)
+    for (const b of q.breakout || []) {
+      const unit = Array.isArray(b) && b[2]?.['temporal-unit'];
+      if (unit) addCalc(target, `${ctxM.fieldDisplay(b)} (${titleCase(String(unit))})`, ctxM.resolveField(b));
+      else if (Array.isArray(b) && b[2]?.binning) ctxM.resolveField(b); // emits the binning warning
+      // implicit FK breakout ([field, dim, {source-field}]) — resolveField ensures the
+      // dim TABLE element exists, so the FK relationship + derived-view column survive
+      else if (Array.isArray(b) && b[2]?.['source-field']) ctxM.resolveField(b);
+    }
+    // aggregations → element metrics
+    for (const a of q.aggregation || []) {
+      const { formula, name } = translateAggregation(a, ctxM);
+      addMetric(target, name, formula);
+    }
+    // card filter: safe on a card-owned element; NEVER on a shared table element
+    // (an element filter on a shared-source element propagates into every consumer).
+    if (q.filter) {
+      const formula = translateMbqlExpr(q.filter, ctxM);
+      if (target.ownedByCard) {
+        const id = sigmaShortId();
+        target.columns.push({ id, name: `Filter: ${card.name || card.id}`, formula, hidden: true });
+        ((target.element as any).filters ||= []).push({ id: sigmaShortId(), columnId: id, kind: 'list', mode: 'include', values: [true] });
+      } else {
+        warnings.push(`card "${card.name}": its MBQL filter translates to ${formula} — NOT applied to the shared "${target.element.name}" element (a filter there would propagate to every consumer); apply it on the consuming workbook element.`);
+      }
+    }
+    if (q.limit != null && !target.ownedByCard) {
+      warnings.push(`card "${card.name}": row limit ${q.limit} not ported — never cap a shared DM element; apply a top-N on the consuming workbook element if needed.`);
+    }
+    done();
+  };
+
+  for (const card of cards) processCard(card);
+
+  // ── FK metadata → relationships on the fact-side element (both tables present) ──
+  let relationshipCount = 0;
+  for (const [tableId, ctx] of tableCtxByTableId) {
+    const t = fidx?.tableById.get(tableId);
+    if (!t) continue;
+    for (const f of t.fields) {
+      if (!f.fkTargetFieldId) continue;
+      const tgtField = fidx!.byId.get(f.fkTargetFieldId);
+      if (!tgtField) continue;
+      const tgtCtx = tableCtxByTableId.get(tgtField.tableId);
+      if (!tgtCtx) continue;  // both tables must be present in the model
+      const sourceColumnId = ctx.colIdByFieldId.get(f.id);
+      const targetColumnId = tgtCtx.colIdByFieldId.get(tgtField.id);
+      if (!sourceColumnId || !targetColumnId) continue;
+      (ctx.element.relationships ||= []).push({
+        id: sigmaShortId(),
+        name: tgtField.tableName,   // relationship name = target table tail, case-preserved
+        targetElementId: tgtCtx.element.id,
+        keys: [{ sourceColumnId, targetColumnId }],
+      });
+      relationshipCount++;
+    }
+  }
+
+  // ── finalize ──────────────────────────────────────────────────────────────────
+  const elements: SigmaElement[] = [];
+  for (const ctx of elemCtxs) {
+    if (ctx.metrics.length) (ctx.element as any).metrics = ctx.metrics;
+    elements.push(ctx.element);
+  }
+  for (const de of buildDerivedElements(elements)) elements.push(de);
+  // template-tag controls last (so {{tag}} refs in sql elements have a target)
+  for (const ctrl of controlElements) elements.push(ctrl);
+
+  // ── Metabase sandboxing (EE row security) — DETECT-ONLY, never injected ───────
+  const security = (inp.sandboxes || []).map((s: any) => {
+    const tname = fidx?.tableById.get(s.table_id)?.name || `table ${s.table_id}`;
+    const parts = Object.entries(s.attribute_remappings || {}).map(([attr, tgt]: [string, any]) => {
+      const tgtRef = Array.isArray(tgt) && tgt[0] === 'dimension' ? tgt[1] : tgt;
+      const col = Array.isArray(tgtRef) && tgtRef[0] === 'field'
+        ? (fidx?.byId.get(tgtRef[1])?.displayName || `field ${tgtRef[1]}`)
+        : JSON.stringify(tgt);
+      return `[${col}] = user attribute "${attr}"`;
+    });
+    return {
+      type: 'row-filter',
+      name: s.name || `Sandbox: ${tname}`,
+      expression: parts.length ? parts.join(' AND ') : (s.card_id != null ? `rows restricted to saved question ${s.card_id}` : '(no attribute remappings found)'),
+      groups: [s.group_id].filter((g: any) => g != null),
+    };
+  });
+  if (security.length) {
+    warnings.push(`SECURITY: ${security.length} Metabase sandbox(es) detected — NOT ported into the model spec. ` +
+      `Run the skill's RLS flow (scripts/apply_sigma_rls.py) after posting the model; skipping leaves ALL rows visible to everyone.`);
+  }
+
+  const stats = {
+    cards: cards.length,
+    elements: elements.length,
+    sqlElements,
+    controls: controlElements.length,
+    columns: elements.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    metrics: elements.reduce((n, e) => n + ((e as any).metrics?.length || 0), 0),
+    relationships: relationshipCount,
+  };
+  return {
+    model: {
+      name: options.modelName || inp.metadata?.name || 'Metabase Data Model',
+      schemaVersion: 1,
+      pages: [{ id: sigmaShortId(), name: 'Page 1', elements }],
+    },
+    warnings, stats,
+    ...(security.length ? { security } : {}),
+  };
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/package-lock.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/package-lock.json
@@ -1,0 +1,931 @@
+{
+  "name": "metabase-to-sigma-converter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "metabase-to-sigma-converter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "metabase-to-sigma": "cli.ts"
+      },
+      "devDependencies": {
+        "@types/node": "^26.5.0",
+        "tsx": "^4.23.13",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.5.0.tgz",
+      "integrity": "sha512-dVSGpriSoCgz8WnDNTuSSuSv1PC/ALXihO4ulRZt7Md8k9mlbdin3lGOcDE8SnWOgf513ByWlXd7BK4azmyg/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.9.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.13",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.13.tgz",
+      "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.9.0.tgz",
+      "integrity": "sha512-KTDyRTYX8sWmKXAikPHHSyc63CRPETMctyjKFupcC6OBLXT3xsN0e9aF7m+mIXutFWpUXuedtowG7iLOzp0kQg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/package.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "metabase-to-sigma-converter",
+  "version": "0.1.0",
+  "description": "Metabase → Sigma converter (cards/models JSON → data model; dashboard JSON → workbook). Zero runtime dependencies — every input is plain REST JSON.",
+  "type": "module",
+  "license": "MIT",
+  "bin": {
+    "metabase-to-sigma": "cli.ts"
+  },
+  "scripts": {
+    "convert": "node --import tsx/esm cli.ts",
+    "typecheck": "tsc --noEmit",
+    "test": "npm run typecheck && node --import tsx/esm test.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.5.0",
+    "tsx": "^4.23.13",
+    "typescript": "^7.0.2"
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/pmbql-normalize.d.mts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/pmbql-normalize.d.mts
@@ -1,0 +1,2 @@
+export function normalizeCard(card: any): any;
+export function normalizeClause(clause: any): any;

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/pmbql-normalize.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/pmbql-normalize.mjs
@@ -1,0 +1,228 @@
+/**
+ * pMBQL ("lib/" MBQL, Metabase Lib) → legacy MBQL normalizer.
+ *
+ * Modern Metabase instances (observed: Metabase Cloud v1.61.x; 100% of a
+ * 7k-card production estate) return `dataset_query` in pMBQL form:
+ *
+ *   { "lib/type": "mbql/query", "database": N, "stages": [ ... ] }
+ *
+ * instead of the legacy `{ "type": "native"|"query", ... }` the converter and
+ * scorer were built against. A single card-list response may contain EITHER
+ * format depending on instance version — sniff the `lib/type` key, never the
+ * version string.
+ *
+ * Shape differences handled here (all verified against production payloads):
+ *   query    {lib/type:"mbql/query", stages:[…]}     → {type, database, native|query}
+ *   stage    mbql.stage/native {native:"sql", template-tags} → {native:{query, template-tags}}
+ *   stage    mbql.stage/mbql   {aggregation, breakout, filters, joins, …}
+ *   clause   [op, {opts}, …args]                     → [op, …args] (opts map is ALWAYS
+ *            the 2nd element in pMBQL; legacy puts it last, or 3rd for "field")
+ *   field    ["field", {opts}, idOrName]             → ["field", idOrName, opts|null]
+ *   filters  array (implicit AND)                    → single `filter` (["and", …])
+ *   in/not-in                                        → multi-value "="/"!=" (the
+ *            converter renders those as Or/And chains — Sigma has no IsIn)
+ *   named aggregation (name/display-name in opts)    → ["aggregation-options", inner, {…}]
+ *   expressions list (lib/expression-name in opts)   → {name: clause} map
+ *   source-card N                                    → source-table "card__N"
+ *   joins {stages:[{source-table}], conditions:[…]}  → {source-table, condition, …}
+ *   multi-stage (rare but real: 14 of 7,023 cards)   → legacy source-query nesting
+ *   template-tags dimension clauses                  → legacy field refs
+ *
+ * `normalizeCard` prefers the server-provided `legacy_query` JSON string when
+ * present and parseable (the instance's own down-conversion — authoritative),
+ * falling back to this normalizer. Zero dependencies; usable from Node ≥18.
+ *
+ * NOTE: this file exists in two locations (converter + assessment scripts) so
+ * each skill stays self-contained. The converter test suite asserts the two
+ * copies are byte-identical — edit one, copy to the other.
+ */
+
+const isOptsMap = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+
+/** A pMBQL clause is [op:string, optsMap, ...args] — opts ALWAYS second. */
+const isPmbqlClause = (n) => Array.isArray(n) && typeof n[0] === 'string' && isOptsMap(n[1]);
+
+function cleanOpts(opts) {
+  const out = {};
+  for (const [k, v] of Object.entries(opts || {})) {
+    if (k.startsWith('lib/') || k === 'effective-type' || k === 'ident') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const STRING_MATCH_OPS = new Set(['starts-with', 'ends-with', 'contains', 'does-not-contain']);
+
+/** Recursively normalize a pMBQL clause tree into legacy MBQL. */
+export function normalizeClause(node) {
+  if (!Array.isArray(node)) return node;
+  if (!isPmbqlClause(node)) return node.map(normalizeClause); // e.g. case clause-pair lists
+  const op = node[0];
+  const opts = cleanOpts(node[1]);
+  const args = node.slice(2);
+  const hasOpts = Object.keys(opts).length > 0;
+
+  switch (op) {
+    case 'field':
+      // ["field", {opts}, idOrName] → ["field", idOrName, opts|null]
+      return ['field', args[0], hasOpts ? opts : null];
+    case 'expression':
+      return hasOpts ? ['expression', args[0], opts] : ['expression', args[0]];
+    case 'aggregation':
+      return ['aggregation', args[0]];
+    case 'template-tag':
+      return ['template-tag', args[0]];
+    case 'value':
+      return normalizeClause(args[0]); // literal wrapper — unwrap
+    case 'absolute-datetime':
+      return normalizeClause(args[0]); // legacy filters carry the bare ISO string
+    case 'case':
+    case 'if': {
+      // ["case", {opts}, [[pred, expr], …], default?] → ["case", [[…]], {default}?]
+      const pairs = (args[0] || []).map((p) =>
+        Array.isArray(p) ? [normalizeClause(p[0]), normalizeClause(p[1])] : p);
+      const out = ['case', pairs];
+      if (args.length > 1 && args[1] !== undefined) out.push({ default: normalizeClause(args[1]) });
+      return out;
+    }
+    case 'in':
+      return ['=', ...args.map(normalizeClause)];
+    case 'not-in':
+      return ['!=', ...args.map(normalizeClause)];
+    case 'time-interval':
+    case 'relative-time-interval': {
+      // ["time-interval", {opts}, field, n, unit] → ["time-interval", field, n, unit, opts?]
+      const rest = args.map(normalizeClause);
+      return hasOpts ? ['time-interval', ...rest, opts] : ['time-interval', ...rest];
+    }
+    case 'segment':
+    case 'metric':
+      return [op, args[0]];
+    default: {
+      const rest = args.map(normalizeClause);
+      // string-match ops carry case-sensitive in opts — legacy puts it last
+      if (STRING_MATCH_OPS.has(op) && hasOpts) return [op, ...rest, opts];
+      return [op, ...rest];
+    }
+  }
+}
+
+/** Aggregation clause — pMBQL names live in opts → legacy aggregation-options wrapper. */
+function normalizeAggregation(a) {
+  if (!isPmbqlClause(a)) return normalizeClause(a);
+  const o = a[1];
+  const norm = normalizeClause(a);
+  const nm = o['display-name'] || o.name;
+  if (!nm) return norm;
+  const wrap = {};
+  if (o.name) wrap.name = o.name;
+  if (o['display-name']) wrap['display-name'] = o['display-name'];
+  return ['aggregation-options', norm, wrap];
+}
+
+function normalizeJoin(j) {
+  const out = {};
+  const st0 = (j.stages && j.stages[0]) || {};
+  if (st0['source-card'] != null) out['source-table'] = `card__${st0['source-card']}`;
+  else if (st0['source-table'] != null) out['source-table'] = st0['source-table'];
+  else if (j['source-table'] != null) out['source-table'] = j['source-table'];
+  if (j.alias != null) out.alias = j.alias;
+  if (j.strategy != null) out.strategy = j.strategy;
+  if (Array.isArray(j.conditions)) {
+    const cs = j.conditions.map(normalizeClause);
+    out.condition = cs.length === 1 ? cs[0] : ['and', ...cs];
+  } else if (j.condition) {
+    out.condition = normalizeClause(j.condition);
+  }
+  if (j.fields != null) out.fields = Array.isArray(j.fields) ? j.fields.map(normalizeClause) : j.fields;
+  return out;
+}
+
+function normalizeTemplateTags(tags) {
+  if (!tags) return tags;
+  const out = {};
+  for (const [k, t] of Object.entries(tags)) {
+    out[k] = t && t.dimension ? { ...t, dimension: normalizeClause(t.dimension) } : t;
+  }
+  return out;
+}
+
+/** One pMBQL stage → legacy query object (native stages return {__native}). */
+function normalizeStage(stage, prev) {
+  if (stage['lib/type'] === 'mbql.stage/native') {
+    const native = { query: stage.native ?? stage.query ?? '' };
+    if (stage['template-tags']) native['template-tags'] = normalizeTemplateTags(stage['template-tags']);
+    if (stage.collection) native.collection = stage.collection; // MongoDB
+    return { __native: native };
+  }
+  const q = {};
+  if (prev) {
+    q['source-query'] = prev.__native
+      ? { native: prev.__native.query, 'template-tags': prev.__native['template-tags'] || {} }
+      : prev;
+  } else if (stage['source-card'] != null) {
+    q['source-table'] = `card__${stage['source-card']}`;
+  } else if (stage['source-table'] != null) {
+    q['source-table'] = stage['source-table'];
+  }
+  if (Array.isArray(stage.joins)) q.joins = stage.joins.map(normalizeJoin);
+  if (Array.isArray(stage.expressions)) {
+    q.expressions = {};
+    for (const e of stage.expressions) {
+      const nm = (isPmbqlClause(e) && e[1]['lib/expression-name']) || `expr_${Object.keys(q.expressions).length}`;
+      q.expressions[nm] = normalizeClause(e);
+    }
+  }
+  if (Array.isArray(stage.aggregation)) q.aggregation = stage.aggregation.map(normalizeAggregation);
+  if (Array.isArray(stage.breakout)) q.breakout = stage.breakout.map(normalizeClause);
+  if (Array.isArray(stage.filters) && stage.filters.length) {
+    const fs = stage.filters.map(normalizeClause);
+    q.filter = fs.length === 1 ? fs[0] : ['and', ...fs];
+  } else if (stage.filter) {
+    q.filter = normalizeClause(stage.filter);
+  }
+  if (Array.isArray(stage['order-by'])) {
+    q['order-by'] = stage['order-by'].map((o) =>
+      Array.isArray(o) && isOptsMap(o[1]) ? [o[0], normalizeClause(o[2])] : normalizeClause(o));
+  }
+  if (stage.limit != null) q.limit = stage.limit;
+  if (Array.isArray(stage.fields)) q.fields = stage.fields.map(normalizeClause);
+  return q;
+}
+
+export function isPmbqlQuery(dq) {
+  return !!dq && typeof dq === 'object' && dq['lib/type'] === 'mbql/query';
+}
+
+/**
+ * pMBQL dataset_query → legacy dataset_query. Legacy input passes through
+ * untouched (format-sniffing: a list endpoint may return either).
+ */
+export function normalizeDatasetQuery(dq) {
+  if (!isPmbqlQuery(dq)) return dq;
+  const stages = Array.isArray(dq.stages) ? dq.stages : [];
+  let acc = null;
+  for (const s of stages) acc = normalizeStage(s, acc);
+  if (acc && acc.__native) return { type: 'native', database: dq.database, native: acc.__native };
+  return { type: 'query', database: dq.database, query: acc || {} };
+}
+
+/**
+ * Normalize a full card object (non-mutating). Prefers the server-provided
+ * `legacy_query` (a JSON string — the instance's own down-conversion, present
+ * on ~70% of cards observed) and falls back to normalizeDatasetQuery.
+ */
+export function normalizeCard(card) {
+  if (!card || typeof card !== 'object') return card;
+  if (!isPmbqlQuery(card.dataset_query)) return card;
+  if (typeof card.legacy_query === 'string' && card.legacy_query.trim().startsWith('{')) {
+    try {
+      const lq = JSON.parse(card.legacy_query);
+      if (lq && (lq.type === 'native' || lq.type === 'query')) return { ...card, dataset_query: lq };
+    } catch { /* fall through to the normalizer */ }
+  }
+  if (isOptsMap(card.legacy_query) && (card.legacy_query.type === 'native' || card.legacy_query.type === 'query')) {
+    return { ...card, dataset_query: card.legacy_query };
+  }
+  return { ...card, dataset_query: normalizeDatasetQuery(card.dataset_query) };
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/sigma-ids.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/sigma-ids.ts
@@ -1,0 +1,352 @@
+/**
+ * Shared Sigma Computing ID generation and naming utilities.
+ * Extracted from the Sigma Data Model Manager tool.
+ */
+
+const SIGMA_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const _usedIds = new Set<string>();
+
+/** Small words that Sigma keeps lowercase in display names (unless first word) */
+const SIGMA_LOWERCASE_WORDS = new Set([
+  'a','an','the','and','but','or','for','nor','so','yet',
+  'at','by','in','of','on','to','up','as','into','via','per'
+]);
+
+/** Reset the ID registry — call at the start of each conversion run */
+export function resetIds(): void {
+  _usedIds.clear();
+}
+
+/** Generate a unique short random ID (base62) */
+export function sigmaShortId(len = 10): string {
+  let id: string;
+  do {
+    id = Array.from({ length: len }, () =>
+      SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]
+    ).join('');
+  } while (_usedIds.has(id));
+  _usedIds.add(id);
+  return id;
+}
+
+/** Column IDs use Sigma's inode format: inode-{22-char base62}/{IDENTIFIER} */
+export function sigmaInodeId(identifier: string): string {
+  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+}
+
+/**
+ * SNAKE_CASE or camelCase → "Title Case" display name.
+ *
+ * Matches Sigma's OWN derivation rule for warehouse column names (verified
+ * empirically against live DM readbacks, 2026-06-10): Sigma splits words at
+ * underscores, camelCase boundaries, AND every letter↔digit boundary — in BOTH
+ * directions. E.g. CY_Q1_REVENUE → "Cy Q 1 Revenue" (NOT "Cy Q1 Revenue"),
+ * FY2024 → "Fy 2024", PY_Q4 → "Py Q 4". Raw-column formula refs
+ * ([TABLE/Display Name]) must reproduce this exactly or the POST fails with
+ * "dependency not found" (beads-sigma-c31q).
+ */
+export function sigmaDisplayName(s: string): string {
+  // Insert underscores at camelCase + letter↔digit boundaries so OrderDate →
+  // Order_Date and CY_Q1 → CY_Q_1 (Sigma splits BOTH letters→digits and
+  // digits→letters).
+  const normalized = (s || '')
+    .replace(/([a-z])([A-Z])/g, '$1_$2')        // camelCase → camel_Case
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')  // HTMLParser → HTML_Parser
+    .replace(/([A-Za-z])([0-9])/g, '$1_$2')     // Q1 → Q_1, FY2024 → FY_2024
+    .replace(/([0-9])([A-Za-z])/g, '$1_$2');    // 2024FY → 2024_FY
+  // Split on underscores AND whitespace so the function is IDEMPOTENT:
+  // sigmaDisplayName("Cyq Rev") === "Cyq Rev". Formulas pass through the expression
+  // translator more than once, and same-element sibling refs are resolved
+  // case-SENSITIVELY by Sigma — a non-idempotent derivation ("Cyq Rev" → "Cyq rev")
+  // breaks the ref and the column compiles to type "error".
+  // AP-style: FIRST and LAST words always capitalize, stopwords only stay lowercase
+  // mid-name (live-verified: IS_EMAIL_OPT_IN → "Is Email Opt In", DAYS_TO_SHIP →
+  // "Days to Ship"; cross-element refs are case-SENSITIVE so a wrong-case trailing
+  // stopword compiles to type "error").
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  return words.map((w, i) =>
+    (i === 0 || i === words.length - 1 || !SIGMA_LOWERCASE_WORDS.has(w))
+      ? w.charAt(0).toUpperCase() + w.slice(1)
+      : w
+  ).join(' ');
+}
+
+/** Column formula: [TABLE_NAME/Display Name] */
+export function sigmaColFormula(tableName: string, identifier: string): string {
+  return `[${tableName}/${sigmaDisplayName(identifier)}]`;
+}
+
+/** Metric formula: aggregation referencing column by display name (no table prefix) */
+export function sigmaAggFormula(agg: string, identifier: string): string {
+  const dn = sigmaDisplayName(identifier);
+  const map: Record<string, string> = {
+    sum:            `Sum([${dn}])`,
+    avg:            `Avg([${dn}])`,
+    average:        `Avg([${dn}])`,
+    min:            `Min([${dn}])`,
+    max:            `Max([${dn}])`,
+    count:          `CountIf(IsNotNull([${dn}]))`,
+    count_distinct: `CountDistinct([${dn}])`,
+    count_distict:  `CountDistinct([${dn}])`,
+    median:         `Median([${dn}])`,
+    percentile:     `Percentile([${dn}], 0.5)`,
+    sum_boolean:    `CountIf([${dn}])`,
+  };
+  return map[agg?.toLowerCase()] || `Sum([${dn}])`;
+}
+
+/**
+ * Infer a Sigma format object from a formula string and display name.
+ * Returns null when no rule matches (omit format from output).
+ *
+ * Priority:
+ *  1. Formula is already ×100 percent scale (e.g. `* 100`) → plain number + % suffix
+ *  2. Ratio pattern (Agg() / Agg())                         → ,.2%
+ *  3. Name keywords for %                                    → ,.2%
+ *  4. Name keywords for currency                             → $,.2f
+ *  5. Count/CountDistinct formula                            → ,.0f integer
+ */
+/**
+ * Map a source-tool numeric format mask (Excel/.NET style, e.g. "$#,0.00",
+ * "0.0%", "#,##0") to a Sigma format object. The PRIMARY format signal when the
+ * source carries one — far more reliable than guessing from the formula/name
+ * (beads-sigma-4q7k). Returns null for masks we don't recognize (e.g. dates,
+ * "General Date") so the heuristic fallback still runs.
+ */
+export function formatFromMask(mask?: string): Record<string, any> | null {
+  if (!mask || typeof mask !== 'string') return null;
+  const s = mask.trim();
+  if (!s || /general|date|time|@|yy|dd/i.test(s)) return null;
+  // decimals = run of 0/# after a decimal point in the mask
+  const decM = s.match(/\.([0#]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const isPercent = /%/.test(s);
+  const isCurrency = /[$£€¥]/.test(s);
+  if (isPercent) return { kind: 'number', formatString: `,.${decimals}%` };
+  if (isCurrency) return { kind: 'number', formatString: `$,.${decimals}f`, currencySymbol: '$' };
+  if (/[0#]/.test(s)) return { kind: 'number', formatString: `,.${decimals}f` };
+  return null;
+}
+
+export function inferSigmaFormat(formula: string, displayName?: string, sourceMask?: string): Record<string, any> | null {
+  // Honor the source format mask first when present — most reliable signal.
+  const fromMask = formatFromMask(sourceMask);
+  if (fromMask) return fromMask;
+  if (!formula) return null;
+  const f = formula.trim();
+  const n = (displayName || '').toLowerCase();
+
+  const alreadyPctScale = /\*\s*100\b/.test(f);
+  if (alreadyPctScale && /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: 'number', formatString: ',.2f', suffix: '%' };
+  }
+  const currencyWord = /\b(revenue|sales|profit|cost|spend|amount|discounts?|price|value|aov|arpu)\b/;
+  // A ratio of two aggregates is a PERCENTAGE only when both operands are the same unit
+  // (e.g. count/count, revenue/revenue) — NOT when it's a per-unit measure like
+  // Sum(Revenue)/CountDistinct(Order) (a dollar amount) or Sum(Revenue)/Count(*) (AOV).
+  const ratio = f.match(/^([A-Za-z]+)\s*\(([^)]*)\)\s*\/\s*([A-Za-z]+)\s*\(([^)]*)\)$/);
+  if (ratio) {
+    const [, numFn, numArg, denFn, denArg] = ratio;
+    const isCount = (fn: string) => /^Count/i.test(fn);
+    const numIsCurrency = currencyWord.test(numArg.toLowerCase());
+    const nameSaysPct = /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n);
+    if (nameSaysPct || (isCount(numFn) && isCount(denFn))) {
+      return { kind: 'number', formatString: ',.2%' };
+    }
+    // Currency numerator over a non-currency denominator (count / quantity) → $ per-unit.
+    if (numIsCurrency) {
+      return { kind: 'number', formatString: '$,.2f', currencySymbol: '$' };
+    }
+    // Otherwise a plain decimal ratio.
+    return { kind: 'number', formatString: ',.2f' };
+  }
+  if (/\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: 'number', formatString: ',.2%' };
+  }
+  if (currencyWord.test(n)) {
+    return { kind: 'number', formatString: '$,.2f', currencySymbol: '$' };
+  }
+  if (/^Count(?:Distinct|If|DistinctIf)?\s*\(/.test(f)) {
+    return { kind: 'number', formatString: ',.0f' };
+  }
+  return null;
+}
+
+/** Sigma Data Model JSON Schema reference (for prompts/docs) */
+export const DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  ⚠ The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API — use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) — condition only, NO field argument
+  SumIf(field, condition) — FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf — all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+
+/** Common column/element interfaces */
+export interface SigmaColumn {
+  id: string;
+  formula: string;
+  name?: string;
+  description?: string;
+  hidden?: boolean;
+}
+
+export interface SigmaMetric {
+  id: string;
+  formula: string;
+  name: string;
+  description?: string;
+}
+
+export interface SigmaRelationshipKey {
+  sourceColumnId: string;
+  targetColumnId: string;
+}
+
+export interface SigmaRelationship {
+  id: string;
+  targetElementId: string;
+  keys: SigmaRelationshipKey[];
+  name: string;
+  relationshipType?: string;
+}
+
+export interface SigmaElement {
+  id: string;
+  kind: string;
+  source: Record<string, any>;
+  columns: SigmaColumn[];
+  metrics?: SigmaMetric[];
+  relationships?: SigmaRelationship[];
+  order: string[];
+  [key: string]: any;
+}
+
+export interface SigmaPage {
+  id: string;
+  name: string;
+  elements: SigmaElement[];
+}
+
+export interface SigmaDataModel {
+  name: string;
+  schemaVersion?: number;
+  pages: SigmaPage[];
+}
+
+export interface ConversionResult {
+  model: SigmaDataModel;
+  warnings: string[];
+  stats: Record<string, number>;
+  /**
+   * Detected source-tool security rules (RLS/CLS). The converter only DETECTS
+   * and reports — it never injects security into the model spec (a stateless
+   * converter can't provision Sigma user attributes, so an injected
+   * CurrentUserAttributeText filter would fail-closed to 0 rows). The skill's
+   * apply_sigma_rls.py provisions + applies these after the model is posted.
+   */
+  security?: Array<Record<string, any>>;
+}
+
+export interface ElementResult {
+  element: SigmaElement;
+  elementId: string;
+  colIdMap: Record<string, string>;
+}
+
+/**
+ * Build a derived "join view" element for each source element that has outgoing
+ * relationships. The derived element exposes own columns plus dim columns via
+ * [SRC/REL_NAME/Col] cross-element formulas. Used by Qlik, OAC, Alteryx, Atlan.
+ */
+export function buildDerivedElements(elements: SigmaElement[]): SigmaElement[] {
+  const derived: SigmaElement[] = [];
+  for (const srcEl of elements) {
+    if (!srcEl.relationships?.length) continue;
+    if (srcEl.source?.kind !== 'warehouse-table') continue;
+
+    const srcPath: string[] = srcEl.source.path || [];
+    const srcTableName: string = srcPath[srcPath.length - 1] || '';
+    // The base prefix in formulas must match what Sigma resolves the base element as:
+    //   - if the element has an explicit `name` field, that is its identifier
+    //   - otherwise Sigma falls back to the warehouse-table path-tail uppercase
+    const baseName: string = srcEl.name || srcTableName;
+    // Derived element NAME must differ from the base so [<base>/Field] is unambiguous.
+    const derivedName = `${srcEl.name || sigmaDisplayName(srcTableName)} View`;
+    const viewCols: Array<{ id: string; formula: string }> = [];
+    const viewOrder: string[] = [];
+
+    for (const col of (srcEl.columns || [])) {
+      if (!col.formula || col.formula.startsWith('/*')) continue;
+      const fm = col.formula.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      if (!fm) continue; // skip calc cols
+      const dispName = fm[2];
+      // A "/" in the display name breaks Sigma's slash-delimited bracket ref — skip.
+      if (dispName.includes('/')) continue;
+      const cId = sigmaShortId();
+      viewCols.push({ id: cId, formula: `[${baseName}/${dispName}]` });
+      viewOrder.push(cId);
+    }
+
+    for (const rel of srcEl.relationships) {
+      if (!rel.name) continue;
+      const tgtEl = elements.find(e => e.id === rel.targetElementId);
+      if (!tgtEl || tgtEl.source?.kind !== 'warehouse-table') continue;
+      // Skip the relationship's OWN key column(s): a cross-element passthrough of a join key compiles to type "error" in Sigma.
+      const relKeyIds = new Set((rel.keys || []).map(k => k.targetColumnId));
+      for (const col of (tgtEl.columns || [])) {
+        if (relKeyIds.has(col.id)) continue;
+        if (!col.formula || col.formula.startsWith('/*')) continue;
+        const fm = col.formula.match(/^\[([^\]]+)\]$/);
+        if (!fm) continue;
+        const inner = fm[1];
+        // The display name is everything after the FIRST slash (the table/element
+        // prefix). Use indexOf, not lastIndexOf — a display name may itself contain a
+        // slash (e.g. Tableau caption "Product Key/Name").
+        const s = inner.indexOf('/');
+        const dispName = s >= 0 ? inner.slice(s + 1) : inner;
+        // A display name containing a "/" cannot be referenced via Sigma's
+        // slash-delimited bracket syntax ([Base/Rel/Field] would over-segment). Such a
+        // column stays accessible on its own dimension element; just don't surface it as
+        // a denormalized cross-element passthrough (it would compile to type "error").
+        if (dispName.includes('/')) continue;
+        const cId = sigmaShortId();
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewOrder.push(cId);
+      }
+    }
+
+    if (viewCols.length > 0) {
+      derived.push({
+        id: sigmaShortId(),
+        kind: 'table',
+        name: derivedName,
+        source: { kind: 'table', elementId: srcEl.id },
+        columns: viewCols,
+        order: viewOrder,
+      });
+    }
+  }
+  return derived;
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/sigma-ids.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/sigma-ids.ts
@@ -5,6 +5,7 @@
 
 const SIGMA_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 const _usedIds = new Set<string>();
+let _idCounter = 0;
 
 /** Small words that Sigma keeps lowercase in display names (unless first word) */
 const SIGMA_LOWERCASE_WORDS = new Set([
@@ -15,10 +16,19 @@ const SIGMA_LOWERCASE_WORDS = new Set([
 /** Reset the ID registry — call at the start of each conversion run */
 export function resetIds(): void {
   _usedIds.clear();
+  _idCounter = 0;
 }
 
 /** Generate a unique short random ID (base62) */
 export function sigmaShortId(len = 10): string {
+  // Corpus-only deterministic mode keeps ids inside the authoritative layout
+  // XML byte-stable as well as in JSON id fields. Production remains random.
+  if (typeof process !== 'undefined' && process.env.SIGMA_DETERMINISTIC_IDS === '1') {
+    _idCounter += 1;
+    const id = `M${_idCounter.toString(36).padStart(Math.max(len - 1, 1), '0')}`.slice(-len);
+    _usedIds.add(id);
+    return id;
+  }
   let id: string;
   do {
     id = Array.from({ length: len }, () =>

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/test.ts
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/test.ts
@@ -1,0 +1,560 @@
+// Smoke + contract tests on the bundled fixtures: node --import tsx/esm test.ts
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { applyWarehouseTransforms, convertMetabaseToSigma, recognizeSimpleNativeSql, buildFieldIndex } from './metabase.js';
+import { convertMetabaseDashboardToSigma } from './metabase-dashboard.js';
+
+const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
+const read = (f: string) => JSON.parse(readFileSync(join(FIX, f), 'utf8'));
+const wbDoc = (wb: any) => wb.document || wb;
+const wbElements = (wb: any) => wbDoc(wb).elements
+  || (wbDoc(wb).pages || []).flatMap((p: any) => p.elements || []);
+const wbControls = (wb: any) => wbElements(wb).filter((e: any) => e.kind === 'control');
+const pageHasElement = (wb: any, pageId: string, elementId: string) => {
+  const layout = String(wbDoc(wb).layout || '');
+  const page = layout.match(new RegExp(`<Page\\b[^>]*id="${pageId}"[^>]*>([\\s\\S]*?)<\\/Page>`));
+  return !!page && new RegExp(`<Element\\b[^>]*elementId="${elementId}"`).test(page[1]);
+};
+let fail = 0;
+const check = (group: string, label: string, ok: boolean) => {
+  if (ok) console.log(`✓ ${group}: ${label}`);
+  else { fail++; console.log(`✗ ${group}: ${label}`); }
+};
+
+const metadata = read('metadata.json');
+const ordersModel = read('orders-model.card.json');
+const revenueTrend = read('revenue-trend.card.json');
+const nativeCard = read('top-customers-native.card.json');
+
+// ── warehouse dialect transforms ─────────────────────────────────────────────
+{
+  const sql = 'SELECT ARRAY_AGG(REGION) AS REGIONS FROM DEMO_DB.DEMO.CUSTOMER_DIM';
+  check('warehouse', 'BigQuery array aggregation becomes a renderable string',
+    /array_to_string\(ARRAY_AGG\(REGION\), ', '\)/i.test(applyWarehouseTransforms(sql, 'bigquery')));
+  const transformed = convertMetabaseToSigma(
+    { metadata, cards: [{ ...nativeCard, dataset_query: {
+      ...nativeCard.dataset_query,
+      native: { ...nativeCard.dataset_query.native, query: sql, 'template-tags': {} },
+    }}] },
+    { connectionId: 'c', database: 'DEMO_DB', schema: 'DEMO', warehouse: 'bigquery' },
+  );
+  const statement = (transformed.model.pages[0].elements as any[])
+    .find((e: any) => e.source?.kind === 'sql')?.source?.statement;
+  check('warehouse', 'converter applies the selected warehouse transform without crashing',
+    /array_to_string/i.test(statement || ''));
+}
+
+// ── cards → data model ────────────────────────────────────────────────────────
+{
+  const r = convertMetabaseToSigma(
+    { metadata, cards: [ordersModel, revenueTrend, nativeCard] },
+    { connectionId: 'conn1', database: 'DEMO_DB', schema: 'DEMO' },
+  );
+  const els = r.model.pages[0].elements as any[];
+  const byName = (n: string) => els.find((e) => e.name === n);
+  const orderFact = byName('Order Fact');
+  const customerDim = byName('Customer Dim');
+  const joinEl = byName('Orders Model');
+  const sqlEl = els.find((e) => e.source?.kind === 'sql');
+  const derived = byName('Order Fact View');
+  const col = (el: any, n: string) => el?.columns?.find((c: any) => c.name === n);
+
+  check('dm', 'schemaVersion is 1', (r.model as any).schemaVersion === 1);
+  check('dm', 'warehouse-table elements for both referenced tables (path DEMO_DB/DEMO/TABLE)',
+    JSON.stringify(orderFact?.source?.path) === JSON.stringify(['DEMO_DB', 'DEMO', 'ORDER_FACT'])
+    && JSON.stringify(customerDim?.source?.path) === JSON.stringify(['DEMO_DB', 'DEMO', 'CUSTOMER_DIM']));
+  check('dm', 'field-id resolution: plain column = inode id + [TABLE/Display] formula',
+    orderFact?.columns?.some((c: any) => /^inode-.{22}\/SALES_AMOUNT$/.test(c.id) && c.formula === '[ORDER_FACT/Sales Amount]'));
+  check('dm', 'join element: live contract — columns key, left-outer, named sides, [Display] refs',
+    joinEl?.source?.kind === 'join'
+    && typeof joinEl?.source?.name === 'string'
+    && joinEl?.source?.joins?.[0]?.joinType === 'left-outer'
+    && typeof joinEl?.source?.joins?.[0]?.name === 'string'
+    && joinEl?.source?.joins?.[0]?.left?.connectionId !== undefined
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Key]'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.right === '[Customer Key]');
+  check('dm', 'arithmetic expression: Net Amount = ([Sales Amount] - [Discount Amount])',
+    col(joinEl, 'Net Amount')?.formula === '([Sales Amount] - [Discount Amount])');
+  check('dm', 'case → If, multi-value = → infix or chain (no IsIn, no Or() function — live-verified)',
+    col(joinEl, 'Tier Bucket')?.formula === 'If(([Loyalty Tier] = "GOLD" or [Loyalty Tier] = "PLATINUM"), "Premium", "Standard")');
+  check('dm', 'datetime-diff → DateDiff',
+    col(orderFact, 'Days Since Order')?.formula === 'DateDiff("day", [Order Date], Now())');
+  check('dm', 'breakout temporal-unit → DateTrunc calc column',
+    col(orderFact, 'Order Date (Month)')?.formula === 'DateTrunc("month", [Order Date])');
+  check('dm', 'named aggregation keeps its display-name (Total Revenue)',
+    joinEl?.metrics?.some((m: any) => m.name === 'Total Revenue' && m.formula === 'Sum([Sales Amount])'));
+  check('dm', 'unnamed aggregation derives a name (Sum of Sales Amount)',
+    orderFact?.metrics?.some((m: any) => m.name === 'Sum of Sales Amount' && m.formula === 'Sum([Sales Amount])'));
+  check('dm', 'card filter NOT applied to the shared element (warned instead)',
+    !orderFact?.filters && r.warnings.some((w) => /NOT applied to the shared/.test(w) && /DateAdd\("day", -365, Today\(\)\)/.test(w)));
+  check('dm', 'native SQL card → sql-source element with NO element-level name',
+    !!sqlEl && sqlEl.name === undefined && /SELECT/.test(sqlEl.source.statement));
+  check('dm', 'native sql columns are [Custom SQL/RAW_ALIAS] refs with names (bare refs error live)',
+    sqlEl?.columns?.some((c: any) => /^\[Custom SQL\//.test(c.formula) && typeof c.name === 'string'));
+  check('dm', 'plain text {{tag}} warns with the control to create',
+    r.warnings.some((w) => /\{\{region\}\}/.test(w) && /control/.test(w) && /"region"/.test(w)));
+  check('dm', 'dimension {{tag}} (field filter) is flagged',
+    r.warnings.some((w) => /\{\{order_date\}\}/.test(w) && /FIELD FILTER/.test(w)));
+  check('dm', 'FK metadata → relationship CUSTOMER_DIM on the fact element',
+    orderFact?.relationships?.length === 1
+    && orderFact.relationships[0].name === 'CUSTOMER_DIM'
+    && orderFact.relationships[0].targetElementId === customerDim?.id
+    && orderFact.relationships[0].keys?.[0]?.sourceColumnId && orderFact.relationships[0].keys?.[0]?.targetColumnId);
+  check('dm', 'STORE_DIM FK skipped (table not referenced — both tables must be present)',
+    !els.some((e) => e.name === 'Store Dim') && orderFact?.relationships?.length === 1);
+  check('dm', 'derived join view exists and exposes dim columns',
+    !!derived && derived.columns.some((c: any) => c.formula === '[Order Fact/CUSTOMER_DIM/Region]'));
+  check('dm', 'derived view SKIPS the relationship key column (no Customer Key passthrough)',
+    !!derived && !derived.columns.some((c: any) => c.formula === '[Order Fact/CUSTOMER_DIM/Customer Key]'));
+}
+
+// ── nested questions (source-table "card__N") ────────────────────────────────
+{
+  const nested = {
+    id: 300, name: 'Premium Orders', type: 'question', display: 'table', database_id: 2,
+    dataset_query: { type: 'query', database: 2, query: { 'source-table': 'card__100' } },
+    result_metadata: [],
+  };
+  const r = convertMetabaseToSigma({ metadata, cards: [ordersModel, nested] }, { connectionId: 'c', database: 'DEMO_DB', schema: 'DEMO' });
+  const els = r.model.pages[0].elements as any[];
+  const parent = els.find((e) => e.name === 'Orders Model');
+  const child = els.find((e) => e.name === 'Premium Orders');
+  check('nested', 'in-input nested card → element sourced from card 100\'s element',
+    !!child && child.source?.kind === 'table' && child.source?.elementId === parent?.id);
+
+  const r2 = convertMetabaseToSigma({ metadata, cards: [nested] }, { connectionId: 'c', database: 'DEMO_DB' });
+  check('nested', 'missing source card → warning + skip',
+    !(r2.model.pages[0].elements as any[]).some((e: any) => e.name === 'Premium Orders')
+    && r2.warnings.some((w) => /card 100/.test(w) && /NOT in the input set/.test(w)));
+}
+
+// ── learned rules hook (applied before built-in translation) ─────────────────
+{
+  const r = convertMetabaseToSigma(
+    { metadata, cards: [revenueTrend] },
+    { connectionId: 'c', database: 'DEMO_DB', learnedRules: [{ pattern: '\\["datetime-diff",.*"day"\\]', template: 'DaysBetween()' }] },
+  );
+  const of = (r.model.pages[0].elements as any[]).find((e) => e.name === 'Order Fact');
+  check('rules', 'learned rule overrides the built-in translation',
+    of?.columns?.some((c: any) => c.name === 'Days Since Order' && c.formula === 'DaysBetween()'));
+}
+
+// ── sandboxing detection (detect-only) ───────────────────────────────────────
+{
+  const r = convertMetabaseToSigma({
+    metadata, cards: [revenueTrend],
+    sandboxes: [{ table_id: 45, group_id: 7, attribute_remappings: { region: ['dimension', ['field', 85, null]] } }],
+  }, { connectionId: 'c', database: 'DEMO_DB' });
+  check('security', 'sandbox → security entry (row-filter, group, readable expression)',
+    (r as any).security?.length === 1
+    && (r as any).security[0].type === 'row-filter'
+    && (r as any).security[0].groups?.[0] === 7
+    && /\[Region\] = user attribute "region"/.test((r as any).security[0].expression));
+  check('security', 'security is detect-only — no filters injected into the model',
+    !(r.model.pages[0].elements as any[]).some((e: any) => e.filters?.length)
+    && r.warnings.some((w) => /SECURITY/.test(w) && /NOT ported/.test(w)));
+}
+
+// ── dashboard → workbook ─────────────────────────────────────────────────────
+{
+  const r = convertMetabaseDashboardToSigma(read('exec-overview.dashboard.json'),
+    { metadata, cardNameById: { 100: 'Orders Model' } });
+  const wb = r.workbook;
+  const doc = wbDoc(wb);
+  const els = wbElements(wb) as any[];
+  const controls = wbControls(wb);
+  const byName = (n: string) => els.find((e) => e.name === n);
+
+  check('wb', 'released code rep: document wrapper, flat elements, metadata-only pages, canonical layout',
+    doc.schemaVersion === 1 && doc.kind === 'workbook' && Array.isArray(doc.elements)
+    && doc.pages.every((p: any) => !('elements' in p))
+    && /<Page\b/.test(doc.layout) && /<Element\b/.test(doc.layout)
+    && !/<LayoutElement\b/.test(doc.layout));
+  check('wb', 'one page per dashboard tab (Overview, Detail) + hidden trailing Data page',
+    doc.pages.length === 3 && doc.pages[0].name === 'Overview' && doc.pages[1].name === 'Detail'
+    && doc.pages[2].name === 'Data' && doc.pages[2].id.startsWith('data')
+    && doc.pages[2].visibility === 'hidden');
+  check('wb', 'text dashcard → text element with the markdown in body (live contract)',
+    els.some((e) => e.kind === 'text' && /## Executive Overview/.test((e as any).body)));
+  const kpi = byName('Total Revenue');
+  check('wb', 'scalar → kpi-chart with value {columnId} (NOT {id})',
+    kpi?.kind === 'kpi-chart' && !!kpi.value?.columnId && kpi.value?.id === undefined);
+  check('wb', 'column_settings currency/decimals → Sigma format on the KPI column',
+    kpi?.columns?.some((c: any) => c.format?.formatString === '$,.0f'));
+  const line = byName('Revenue Trend');
+  check('wb', 'line → line-chart with x dim + y metric matched through result_metadata',
+    line?.kind === 'line-chart' && !!line.xAxis?.columnId && line.yAxis?.columnIds?.length === 1);
+  const lineBase = byName('Revenue Trend Base');
+  check('wb', 'range-mapped chart re-rooted through a base TABLE on the Data page (control targets need a table)',
+    lineBase?.kind === 'table' && lineBase?.source?.kind === 'data-model' && lineBase?.source?.elementId === 'Order Fact'
+    && pageHasElement(wb, doc.pages[2].id, lineBase.id)
+    && line?.source?.kind === 'table' && line?.source?.elementId === lineBase.id);
+  check('wb', 'line x column is the DateTrunc breakout rewritten through the base table',
+    line?.columns?.some((c: any) => c.formula === 'DateTrunc("month", [Revenue Trend Base/Order Date])')
+    && lineBase?.columns?.some((c: any) => c.name === 'Order Date' && c.formula === '[Order Fact/Order Date]'));
+  const bar = byName('Customers by Region');
+  check('wb', 'bar → bar-chart with orientation key OMITTED (vertical)',
+    bar?.kind === 'bar-chart' && !('orientation' in bar));
+  const row = byName('Customers by Loyalty Tier');
+  check('wb', 'row → bar-chart with orientation "horizontal" (the only valid value)',
+    row?.kind === 'bar-chart' && row.orientation === 'horizontal');
+  const pie = byName('Stores by State');
+  check('wb', 'pie → pie-chart with columnId slice + value',
+    pie?.kind === 'pie-chart' && !!pie.color?.columnId && !!pie.value?.columnId
+    && pie.color?.id === undefined && pie.value?.id === undefined);
+  const pivot = byName('Revenue by Region and Tier');
+  check('wb', 'pivot → rowsBy/columnsBy as [{columnId}] objects + values as bare id strings',
+    pivot?.kind === 'pivot-table'
+    && pivot.rowsBy?.length === 1 && typeof pivot.rowsBy[0] === 'object' && !!pivot.rowsBy[0].columnId
+    && pivot.columnsBy?.length === 1 && !!pivot.columnsBy[0].columnId
+    && pivot.values?.length === 1 && typeof pivot.values[0] === 'string');
+  check('wb', 'explicit-join card sources its own card-named join element (exact columns, no dedup suffixes)',
+    pivot?.source?.elementId === 'Revenue by Region and Tier');
+  const funnel = byName('Tier Funnel');
+  check('wb', 'funnel → native funnel-chart with columnId channels',
+    funnel?.kind === 'funnel-chart' && !!funnel.stage?.columnId && !!funnel.series?.columnId);
+  check('wb', 'nested-question dashcard → source placeholder is the model name',
+    byName('Premium Orders')?.source?.elementId === 'Orders Model');
+  check('wb', 'nested card MBQL filter → hidden bool column + element filter [true]',
+    byName('Premium Orders')?.columns?.some((c: any) => c.hidden && c.formula === '[Orders Model/Tier Bucket] = "Premium"')
+    && byName('Premium Orders')?.filters?.some((f: any) => f.kind === 'list' && f.mode === 'include' && f.values[0] === true));
+  const dateCtl = controls.find((c: any) => c.controlId === 'date_range');
+  check('wb', 'parameters → controls wired by slug (date/range → date-range mode "between", string/= → list)',
+    dateCtl?.controlType === 'date-range' && (dateCtl as any)?.mode === 'between'
+    && controls.some((c: any) => c.controlId === 'region' && c.controlType === 'list'));
+  check('wb', 'relative range default dropped with a warning (no verified Sigma spec shape)',
+    dateCtl?.value === undefined && r.warnings.some((w) => /range default "past30days"/.test(w)));
+  const barBase = byName('Customers by Region Base');
+  const regionCtl = controls.find((c: any) => c.controlId === 'region') as any;
+  check('wb', 'list parameter_mapping → control `filters` target on the chart\'s base table (NO boolean match column — list-control formula refs error live)',
+    regionCtl?.filters?.length === 1
+    && regionCtl.filters[0].source?.kind === 'table'
+    && regionCtl.filters[0].source?.elementId === barBase?.id
+    && regionCtl.filters[0].columnId === barBase?.columns?.find((c: any) => c.name === 'Region')?.id
+    && !bar?.columns?.some((c: any) => /= \[region\]/.test(String(c.formula))));
+  check('wb', 'range parameter_mapping → control `filters` target on the base table column (not boolean equality)',
+    (dateCtl as any)?.filters?.length === 1
+    && (dateCtl as any).filters[0].source?.kind === 'table'
+    && (dateCtl as any).filters[0].source?.elementId === lineBase?.id
+    && (dateCtl as any).filters[0].columnId === lineBase?.columns?.find((c: any) => c.name === 'Order Date')?.id
+    && !line?.columns?.some((c: any) => /= \[date_range\]/.test(String(c.formula))));
+  check('wb', 'element source placeholders are DM element NAMES on data-model sources (remap rewrites); mapped charts re-root through their base',
+    row?.source?.kind === 'data-model' && row?.source?.elementId === 'Customer Dim'
+    && bar?.source?.kind === 'table' && bar?.source?.elementId === barBase?.id);
+  check('wb', 'controls placed AFTER the elements they target in spec order (POST rejects forward targets)',
+    controls.every((control: any) => (control.filters || []).every((filter: any) => {
+      const targetIndex = els.findIndex((e: any) => e.id === filter.source?.elementId);
+      return targetIndex >= 0 && els.indexOf(control) > targetIndex;
+    })));
+  check('wb', 'control-scope sidecar: signals = mapped params; scope/mustReach = declared targets',
+    r.controlScope.sourceFilterSignals === 2
+    && r.controlScope.controls.length === 2
+    && JSON.stringify(r.controlScope.controls.find((c) => c.controlId === 'date_range')?.scope) === '["Revenue Trend"]'
+    && JSON.stringify(r.controlScope.controls.find((c) => c.controlId === 'region')?.mustReach) === '["Customers by Region"]');
+  check('wb', 'layout hints preserve the 1:1 24-col grid',
+    r.layout.grid === 24
+    && r.layout.pages[0].elements.some((h) => h.name === 'Revenue Trend' && h.col === 5 && h.sizeX === 10 && h.sizeY === 6));
+  check('wb', 'click_behavior flagged', r.warnings.some((w) => /click_behavior/.test(w)));
+}
+
+// ── current native visualization/channel contract ───────────────────────────
+{
+  const source = read('exec-overview.dashboard.json');
+  const clone = (dc: any, id: number, display: string, name: string, vs: any = {}) => {
+    const next = JSON.parse(JSON.stringify(dc));
+    next.id = id; next.card_id = id; next.dashboard_tab_id = null;
+    next.row = (id - 300) * 6; next.col = 0;
+    next.parameter_mappings = [];
+    next.card.id = id; next.card.display = display; next.card.name = name;
+    next.card.visualization_settings = vs;
+    return next;
+  };
+  const scalar = source.dashcards.find((d: any) => d.card?.display === 'scalar');
+  const bar = source.dashcards.find((d: any) => d.card?.display === 'bar');
+  const pivot = source.dashcards.find((d: any) => d.card?.display === 'pivot');
+  const dash = {
+    name: 'Native Viz Contract',
+    parameters: [],
+    dashcards: [
+      clone(scalar, 300, 'gauge', 'Gauge Native'),
+      clone(bar, 301, 'waterfall', 'Waterfall Native',
+        { 'graph.dimensions': ['REGION'], 'graph.metrics': ['count'] }),
+      clone(pivot, 302, 'sankey', 'Sankey Native',
+        { 'graph.dimensions': ['REGION', 'LOYALTY_TIER'], 'graph.metrics': ['sum'] }),
+      clone(bar, 303, 'map', 'Region Map Native',
+        { 'graph.dimensions': ['REGION'], 'graph.metrics': ['count'], 'map.type': 'region', 'map.region': 'us_states' }),
+      clone(scalar, 304, 'progress', 'Progress Fallback'),
+    ],
+  };
+  const r = convertMetabaseDashboardToSigma(dash, { metadata });
+  const els = wbElements(r.workbook);
+  const named = (name: string) => els.find((e: any) => e.name === name) as any;
+  check('native-viz', 'gauge emits native value.columnId',
+    named('Gauge Native')?.kind === 'gauge-chart' && !!named('Gauge Native')?.value?.columnId);
+  check('native-viz', 'waterfall emits current cartesian channels',
+    named('Waterfall Native')?.kind === 'waterfall-chart'
+    && !!named('Waterfall Native')?.xAxis?.columnId
+    && named('Waterfall Native')?.yAxis?.columnIds?.length === 1);
+  check('native-viz', 'sankey emits stages/value columnId pointers',
+    named('Sankey Native')?.kind === 'sankey-chart'
+    && named('Sankey Native')?.stages?.length === 2
+    && named('Sankey Native')?.stages.every((s: any) => !!s.columnId)
+    && !!named('Sankey Native')?.value?.columnId);
+  check('native-viz', 'region map emits region.columnId',
+    named('Region Map Native')?.kind === 'region-map'
+    && !!named('Region Map Native')?.region?.columnId
+    && named('Region Map Native')?.region?.id === undefined);
+  check('native-viz', 'progress remains a loud data-preserving table fallback',
+    named('Progress Fallback (was progress)')?.kind === 'table'
+    && r.warnings.some((w) => /Progress Fallback.*no faithful native Sigma mapping/.test(w)));
+}
+
+// ── legacy ordered_cards (sizeX/sizeY) ───────────────────────────────────────
+{
+  const r = convertMetabaseDashboardToSigma(read('legacy-grid.dashboard.json'), { metadata });
+  const els = wbElements(r.workbook) as any[];
+  check('legacy', 'ordered_cards accepted — both dashcards converted on one page',
+    wbDoc(r.workbook).pages.length === 1 && els.filter((e) => e.kind !== 'control').length === 2);
+  check('legacy', 'sizeX/sizeY geometry flows into the layout hints',
+    r.layout.pages[0].elements.some((h) => h.sizeX === 12 && h.sizeY === 6));
+  check('legacy', 'kpi value {columnId} on the legacy scalar too',
+    els.some((e) => e.kind === 'kpi-chart' && !!e.value?.columnId));
+}
+
+// ── pMBQL (modern "lib/" MBQL — 100% of a 7k-card production estate) ─────────
+{
+  const cards = ['pmbql-native', 'pmbql-native-tags', 'pmbql-structured', 'pmbql-joins', 'pmbql-expressions', 'pmbql-multistage']
+    .map((f) => read(`${f}.card.json`));
+  const r = convertMetabaseToSigma({ metadata, cards }, { connectionId: 'c', database: 'DEMO_DB', schema: 'DEMO' });
+  const els = r.model.pages[0].elements as any[];
+  const sqlEls = els.filter((e) => e.source?.kind === 'sql');
+  const ctrl = (id: string) => els.find((e) => e.kind === 'control' && e.controlId === id);
+  // pmbql-native is a SIMPLE single-SELECT → auto-remodeled to a native model (no
+  // sql element); pmbql-native-tags has variable tags → stays a custom-SQL element.
+  check('pmbql', 'simple native stage → native model; tagged native stage stays sql (1 sql element)',
+    sqlEls.length === 1
+    && r.warnings.some((w) => /Daily Revenue \(pMBQL Native\).*auto-remodeled to a NATIVE Sigma data model/.test(w)));
+  const tagged = sqlEls.find((e) => /JOIN DEMO_DB.DEMO.CUSTOMER_DIM/.test(e.source.statement));
+  check('pmbql', 'plain {{region}} kept verbatim (Sigma uses the same syntax) + text control emitted',
+    /\{\{region\}\}/.test(tagged?.source.statement || '')
+    && ctrl('region')?.controlType === 'text' && ctrl('region')?.value === 'West');
+  check('pmbql', 'number tag → number control with default',
+    ctrl('min_qty')?.controlType === 'number' && ctrl('min_qty')?.value === 1);
+  check('pmbql', 'field-filter tag neutralized to 1=1 + brace-free comment (Sigma parses {{}} in comments)',
+    /1=1 \/\* Metabase field filter 'order_date' → filter \[Order Date\]/.test(tagged?.source.statement || '')
+    && !/\{\{order_date\}\}/.test(tagged?.source.statement || ''));
+  check('pmbql', 'optional [[…]] block without a default DROPPED + warned',
+    !/\{\{tier\}\}/.test(tagged?.source.statement || '') && r.warnings.some((w) => /\[\[…\]\] block DROPPED/.test(w) && /tier/.test(w)));
+  check('pmbql', 'card tag {{#400…}} inlined as a sub-select from the referenced native card',
+    /\(\nSELECT ORDER_DATE, SUM\(SALES_AMOUNT\)/.test(tagged?.source.statement || ''));
+  const of = els.find((e) => e.name === 'Order Fact');
+  check('pmbql', 'named pMBQL aggregation (display-name in opts) → Total Revenue metric',
+    of?.metrics?.some((m: any) => m.name === 'Total Revenue' && m.formula === 'Sum([Sales Amount])')
+    && of?.metrics?.some((m: any) => m.name === 'Count' && m.formula === 'Count()'));
+  check('pmbql', 'opts-second temporal-unit breakout → DateTrunc week calc',
+    of?.columns?.some((c: any) => c.name === 'Order Date (Week)' && c.formula === 'DateTrunc("week", [Order Date])'));
+  check('pmbql', 'filters array AND-merged; pMBQL "in" → Or chain (warned on the shared element)',
+    r.warnings.some((w) => /\(\[Order Number\] = 100 or \[Order Number\] = 200\)/.test(w))
+    && r.warnings.some((w) => /\[Order Date\] >= DateAdd\("month", -6, Today\(\)\)/.test(w)));
+  const joinEl = els.find((e) => e.name === 'Orders with Customers (pMBQL Join)');
+  check('pmbql', 'pMBQL join {stages, conditions} → join source on Customer Key (live shape)',
+    joinEl?.source?.kind === 'join' && joinEl?.source?.joins?.[0]?.joinType === 'left-outer'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Key]');
+  check('pmbql', 'expression list (lib/expression-name) → calc columns: case→If, date()→DateTrunc day',
+    of?.columns?.some((c: any) => c.name === 'Size Bucket' && c.formula === 'If([Sales Amount] > 1000, "Large", "Small")')
+    && of?.columns?.some((c: any) => c.name === 'Days to Now' && c.formula === 'DateDiff("day", [Order Date], Now())')
+    && of?.columns?.some((c: any) => c.name === 'Order Day' && c.formula === 'DateTrunc("day", [Order Date])'));
+  check('pmbql', 'multi-stage card flagged + skipped (never silently mistranslated)',
+    r.warnings.some((w) => /MULTI-STAGE/.test(w) && /Average Weekly Revenue/.test(w))
+    && !els.some((e) => e.name === 'Average Weekly Revenue (pMBQL Multi-Stage)'));
+}
+
+// ── legacy_query preference (server's own down-conversion wins when present) ──
+{
+  const { normalizeCard } = await import('./pmbql-normalize.mjs');
+  const card = {
+    id: 1, name: 'lq', dataset_query: { 'lib/type': 'mbql/query', database: 2, stages: [{ 'lib/type': 'mbql.stage/native', native: 'SELECT 2' }] },
+    legacy_query: JSON.stringify({ type: 'native', database: 2, native: { query: 'SELECT 1', 'template-tags': {} } }),
+  };
+  const n = normalizeCard(card);
+  check('pmbql', 'legacy_query JSON string preferred over re-normalizing',
+    n.dataset_query.type === 'native' && n.dataset_query.native.query === 'SELECT 1');
+  const n2 = normalizeCard({ ...card, legacy_query: 'not json {' });
+  check('pmbql', 'unparseable legacy_query falls back to the normalizer',
+    n2.dataset_query.type === 'native' && n2.dataset_query.native.query === 'SELECT 2');
+}
+
+// ── pMBQL dashboard: tag wiring, conditional formats, series settings, object ─
+{
+  const r = convertMetabaseDashboardToSigma(read('pmbql-params.dashboard.json'), { metadata });
+  const els = wbElements(r.workbook) as any[];
+  const controls = wbControls(r.workbook);
+  const table = els.find((e) => e.name === 'Filtered Revenue (pMBQL Native + Tags)');
+  const bar = els.find((e) => e.name === 'Weekly Orders by Region (pMBQL)');
+  check('pmbql-wb', 'date/range dimension parameter → live date-range control (real filter target)',
+    controls.some((c: any) => c.controlId === 'order_window' && c.controlType === 'date-range'));
+  check('pmbql-wb', 'variable + field-filter template-tag targets recorded in parameterWiring',
+    (r.parameterWiring || []).some((w) => w.slug === 'region_param' && w.tag === 'region' && w.kind === 'variable')
+    && (r.parameterWiring || []).some((w) => w.slug === 'order_date_param' && w.tag === 'order_date' && w.kind === 'field-filter'));
+  check('pmbql-wb', 'tag wiring warnings AGGREGATED (one per parameter, not per mapping)',
+    r.warnings.filter((w) => /drives native template tag/.test(w)).length === 2);
+  const barBase = els.find((e) => e.name === 'Weekly Orders by Region (pMBQL) Base');
+  const owCtl = controls.find((c: any) => c.controlId === 'order_window') as any;
+  check('pmbql-wb', 'pMBQL dimension target (opts-second field) on a date/range param → base-table control filter target',
+    barBase?.kind === 'table'
+    && bar?.source?.elementId === barBase?.id
+    && owCtl?.filters?.[0]?.source?.elementId === barBase?.id
+    && !bar?.columns?.some((c: any) => /= \[order_window\]$/.test(String(c.formula))));
+  check('pmbql-wb', 'unwirable field-filter control NOT emitted (column missing from every mapped result set)',
+    !controls.some((c: any) => c.controlId === 'order_date_param')
+    && r.warnings.some((w) => /order_date_param.*NOT emitted|control "Order Date".*NOT emitted/i.test(w)));
+  check('pmbql-wb', 'variable-tag-only control NOT emitted (DM-SQL {{tag}} binding is inert, live-disproven) and listed in unreproducibleFilters',
+    !controls.some((c: any) => c.controlId === 'region_param')
+    && (r.unreproducibleFilters || []).some((u) => u.controlId === 'region_param' && /inert|pre-aggregation/.test(u.reason)));
+  check('pmbql-wb', 'table.column_formatting single rule → conditionalFormats; range rule flagged',
+    table?.conditionalFormats?.length === 1
+    && table.conditionalFormats[0].condition === '>'
+    && table.conditionalFormats[0].style?.backgroundColor === '#22c55e'
+    && r.warnings.some((w) => /gradient\/range/.test(w)));
+  check('pmbql-wb', 'series_settings title renames the series column',
+    bar?.columns?.some((c: any) => c.name === 'Revenue ($)')
+    && r.warnings.some((w) => /per-series color/.test(w)));
+  check('pmbql-wb', 'object display → flagged detail-view table',
+    els.some((e) => e.kind === 'table' && e.name === 'Order Record (object detail)')
+    && r.warnings.some((w) => /object DETAIL view/.test(w)));
+  check('pmbql-wb', 'virtual text card still passes markdown through (body field)',
+    els.some((e) => e.kind === 'text' && /## Ops Notes/.test((e as any).body)));
+}
+
+// ── control-targeting: unmapped parameters are furniture in Metabase too ─────
+{
+  const d = read('exec-overview.dashboard.json');
+  d.parameters = [...(d.parameters || []), { id: 'pX', name: 'Orphan Filter', slug: 'orphan', type: 'string/=' }];
+  const r = convertMetabaseDashboardToSigma(d, { metadata, cardNameById: { 100: 'Orders Model' } });
+  check('scope', 'parameter with zero parameter_mappings → NO control + loud warning',
+    !wbControls(r.workbook).some((c: any) => c.controlId === 'orphan')
+    && r.warnings.some((w) => /"Orphan Filter".*NO parameter_mappings/.test(w)));
+  check('scope', 'unmapped parameter not counted in sourceFilterSignals',
+    r.controlScope.sourceFilterSignals === 2);
+}
+
+// ── BigQuery estate: paths/casing/dialect (Sigma side LIVE-verified 2026-06-11
+// against conn bc534032 "BigQuery- Wells"; Metabase side fixture-shaped) ────────
+{
+  const bq = read('bq-estate.card.json');
+  // NO --database flag: project must come from metadata.details['project-id'].
+  const r = convertMetabaseToSigma(bq, { connectionId: 'connBQ' });
+  const els = r.model.pages[0].elements as any[];
+  const orders = els.find((e) => e.name === 'Data Order');
+  const customers = els.find((e) => e.name === 'Dim Customer');
+  const joinEl = els.find((e) => e.name === 'Revenue by Region (BQ join)');
+  const sqlEl = els.find((e) => e.source?.kind === 'sql');
+
+  check('bq', 'project auto-derived from details.project-id, case-preserved lowercase table tail',
+    JSON.stringify(orders?.source?.path) === JSON.stringify(['acme-data-lake', 'dbt_prod', 'data_order']));
+  check('bq', 'per-table dataset wins (estate spans datasets — no global --schema)',
+    JSON.stringify(customers?.source?.path) === JSON.stringify(['acme-data-lake', 'dbt_core', 'dim_customer']));
+  check('bq', 'warehouse column prefix matches the lowercase path tail',
+    orders?.columns?.some((c: any) => c.formula === '[data_order/Order Id]'));
+  check('bq', 'BQ-dialect native SQL verbatim (backticks + trailing comma preserved)',
+    /`acme-data-lake\.dbt_prod\.data_order`/.test(sqlEl?.source?.statement || '')
+    && /as n_orders,\s*from/.test(sqlEl?.source?.statement || ''));
+  check('bq', 'join source/relationship names case-preserved + prettified condition refs',
+    joinEl?.source?.name === 'data_order'
+    && joinEl?.source?.joins?.[0]?.name === 'dim_customer'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Id]'
+    && orders?.relationships?.some((x: any) => x.name === 'dim_customer'));
+}
+
+// ── the two pmbql-normalize.mjs copies must stay byte-identical ──────────────
+{
+  const here = dirname(fileURLToPath(import.meta.url));
+  const a = readFileSync(join(here, 'pmbql-normalize.mjs'), 'utf8');
+  const b = readFileSync(join(here, '..', '..', 'metabase-assessment', 'scripts', 'pmbql-normalize.mjs'), 'utf8');
+  check('sync', 'converter + assessment pmbql-normalize.mjs copies are byte-identical', a === b);
+}
+
+// ── native-SQL → NATIVE-MODEL recognizer (auto-remodel + safety bails) ───────
+{
+  const meta = { tables: [
+    { id: 1, name: 'ORDER_FACT', schema: 'DEMO', fields: [
+      { id: 101, name: 'CUSTOMER_KEY', base_type: 'type/Integer' },
+      { id: 102, name: 'NET_REVENUE', base_type: 'type/Float' }] },
+    { id: 2, name: 'CUSTOMER_DIM', schema: 'DEMO', fields: [
+      { id: 201, name: 'CUSTOMER_KEY', base_type: 'type/Integer' },
+      { id: 202, name: 'REGION', base_type: 'type/Text' },
+      { id: 203, name: 'LAST_NAME', base_type: 'type/Text' }] }] };
+  const fidx = buildFieldIndex(meta);
+  const ff = (name: string, fid: number) => ({ [name]: { id: 't', name, 'display-name': name, type: 'dimension', dimension: ['field', fid, null], 'widget-type': 'string/=' } });
+  const card = (q: string, tags?: any) => ({ id: 9, name: 'Native', display: 'bar',
+    dataset_query: { type: 'native', database: 2, native: { query: q, 'template-tags': tags || {} } },
+    result_metadata: [{ name: 'REGION', display_name: 'Region' }, { name: 'NET_REVENUE', display_name: 'Net Revenue' }],
+    visualization_settings: { 'graph.dimensions': ['REGION'], 'graph.metrics': ['NET_REVENUE'] } });
+  const JOIN = 'from DEMO_DB.DEMO.ORDER_FACT f join DEMO_DB.DEMO.CUSTOMER_DIM c on f.CUSTOMER_KEY = c.CUSTOMER_KEY';
+
+  const simple = card(`select c.REGION as REGION, sum(f.NET_REVENUE) as NET_REVENUE ${JOIN} where {{last_name}} group by c.REGION`, ff('last_name', 203));
+  const rm = recognizeSimpleNativeSql(simple, fidx);
+  check('remodel', 'simple SELECT+JOIN+GROUP BY → structured native model + surfaces field-filter dim',
+    !!rm && rm.query['source-table'] === 1 && rm.query.joins?.length === 1 && rm.query.aggregation?.length === 1
+    && rm.resultMetadata.some((r: any) => r.name === 'LAST_NAME' && r.field_ref[1] === 203));
+  const dmR = convertMetabaseToSigma({ metadata: meta, cards: [simple] }, { connectionId: 'c', database: 'DEMO_DB' });
+  check('remodel', 'remodeled card emits a NATIVE element (join source), NO sql element',
+    !dmR.model.pages[0].elements.some((e: any) => e.source?.kind === 'sql')
+    && dmR.model.pages[0].elements.some((e: any) => e.source?.kind === 'join'));
+  // the field filter wires to a LIVE control with a real element-filter target
+  const dash = { name: 'D', parameters: [{ id: 'p', name: 'Last Name', slug: 'last_name', type: 'string/=', sectionId: 'string' }],
+    dashcards: [{ id: 1, card_id: 9, row: 0, col: 0, size_x: 12, size_y: 8, card: simple,
+      parameter_mappings: [{ parameter_id: 'p', card_id: 9, target: ['dimension', ['template-tag', 'last_name']] }] }] };
+  const wbR = convertMetabaseDashboardToSigma(dash, { metadata: meta });
+  const lnCtrl = wbControls(wbR.workbook).find((c: any) => c.controlId === 'last_name') as any;
+  check('remodel', 'field-filter param → LIVE control with a real element-filter target (not dead furniture)',
+    !!lnCtrl && (lnCtrl.filters || []).length > 0 && !(wbR.unreproducibleFilters || []).some((u) => u.controlId === 'last_name'));
+
+  // SAFETY BAILS — never silently mistranslate
+  check('remodel', 'real WHERE predicate → bail to custom SQL (no silent filter drop)',
+    recognizeSimpleNativeSql(card(`select c.REGION as REGION, sum(f.NET_REVENUE) as NET_REVENUE ${JOIN} where f.NET_REVENUE > 100 and {{last_name}} group by c.REGION`, ff('last_name', 203)), fidx) === null);
+  check('remodel', 'LIMIT → bail', recognizeSimpleNativeSql(card('select c.REGION as REGION from DEMO_DB.DEMO.CUSTOMER_DIM c group by c.REGION limit 10'), fidx) === null);
+  check('remodel', 'CASE / CTE / subquery / window → bail',
+    recognizeSimpleNativeSql(card('select case when 1=1 then 2 end as x from DEMO_DB.DEMO.ORDER_FACT f'), fidx) === null
+    && recognizeSimpleNativeSql(card('with t as (select 1) select * from t'), fidx) === null
+    && recognizeSimpleNativeSql(card('select count(*) n from DEMO_DB.DEMO.ORDER_FACT f where id in (select id from DEMO_DB.DEMO.CUSTOMER_DIM c)'), fidx) === null);
+  check('remodel', 'variable (non-field-filter) tag → bail (needs custom-SQL substitution)',
+    recognizeSimpleNativeSql(card(`select c.REGION as REGION ${JOIN} where c.REGION = {{region}} group by c.REGION`, { region: { id: 't', name: 'region', type: 'text' } }), fidx) === null);
+  check('remodel', 'unknown table/column → bail', recognizeSimpleNativeSql(card('select x from NOPE.NOPE.NOPE n'), fidx) === null);
+  check('remodel', 'no metadata → bail (safe)', recognizeSimpleNativeSql(simple, undefined) === null);
+
+  // trailing semicolon must be stripped from custom-SQL fallback (Sigma wraps the
+  // statement as a subquery → trailing `;` is a POST syntax error). CTE → not remodeled.
+  const semi = { id: 7, name: 'Semi', display: 'table',
+    dataset_query: { type: 'native', database: 2, native: {
+      query: 'with t as (select region from DEMO_DB.DEMO.CUSTOMER_DIM) select * from t order by region;', 'template-tags': {} } },
+    result_metadata: [{ name: 'region', display_name: 'Region' }] };
+  const semiR = convertMetabaseToSigma({ metadata: meta, cards: [semi] }, { connectionId: 'c', database: 'DEMO_DB' });
+  const semiEl = semiR.model.pages[0].elements.find((e: any) => e.source?.kind === 'sql');
+  check('remodel', 'custom-SQL fallback strips trailing semicolon (no subquery-wrap break)',
+    !!semiEl && !/;\s*$/.test(semiEl.source.statement) && /order by region$/i.test(semiEl.source.statement.trim()));
+}
+
+// ── every fixture converts without throwing ──────────────────────────────────
+for (const f of readdirSync(FIX).sort()) {
+  try {
+    if (f.endsWith('.card.json')) {
+      const j = read(f);
+      // self-contained bundles ({metadata, cards}) carry their own engine metadata
+      const r = j.cards
+        ? convertMetabaseToSigma(j, { connectionId: 'c' })
+        : convertMetabaseToSigma({ metadata, cards: [j] }, { connectionId: 'c', database: 'DEMO_DB', schema: 'DEMO' });
+      // a lone flagged card (e.g. multi-stage) may legitimately produce 0 elements — but never silently
+      if (!r.model.pages[0].elements.length && !r.warnings.length) throw new Error('no elements and no warnings');
+      console.log(`✓ ${f.padEnd(36)} cards → ${r.stats.elements} elems · ${r.stats.columns} cols · ${r.stats.metrics} metrics · ${r.stats.relationships} rels (${r.warnings.length} warnings)`);
+    } else if (f.endsWith('.dashboard.json')) {
+      const r = convertMetabaseDashboardToSigma(read(f), { metadata });
+      if (!wbDoc(r.workbook).pages.length) throw new Error('no pages');
+      console.log(`✓ ${f.padEnd(36)} dashboard → ${r.stats.pages} pages · ${r.stats.kpis} kpis · ${r.stats.charts} charts · ${r.stats.pivots} pivots · ${r.stats.tables} tables · ${r.stats.texts} texts · ${r.stats.controls} controls · ${r.stats.filters} filters (${r.warnings.length} warnings)`);
+    }
+  } catch (e: any) { fail++; console.log(`✗ ${f} — ${e.message}`); }
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\nall checks green ✓');
+process.exit(fail ? 1 : 0);

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/tsconfig.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/converter/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["*.ts", "*.d.mts"]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/bq-estate.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/bq-estate.card.json
@@ -1,0 +1,69 @@
+{
+  "metadata": {
+    "engine": "bigquery-cloud-sdk",
+    "name": "Acme BigQuery",
+    "details": { "project-id": "acme-data-lake" },
+    "tables": [
+      {
+        "id": 1,
+        "name": "data_order",
+        "schema": "dbt_prod",
+        "fields": [
+          { "id": 11, "name": "order_id", "base_type": "type/Text" },
+          { "id": 12, "name": "customer_id", "base_type": "type/Integer", "fk_target_field_id": 21 },
+          { "id": 13, "name": "order_total", "base_type": "type/Float" },
+          { "id": 14, "name": "brand", "base_type": "type/Text" }
+        ]
+      },
+      {
+        "id": 2,
+        "name": "dim_customer",
+        "schema": "dbt_core",
+        "fields": [
+          { "id": 21, "name": "customer_id", "base_type": "type/Integer" },
+          { "id": 22, "name": "customer_region", "base_type": "type/Text" }
+        ]
+      }
+    ]
+  },
+  "cards": [
+    {
+      "id": 901,
+      "name": "Orders by Brand (BQ native)",
+      "display": "bar",
+      "dataset_query": {
+        "type": "native",
+        "database": 7,
+        "native": {
+          "query": "select brand, count(*) as n_orders, from `acme-data-lake.dbt_prod.data_order` group by brand order by n_orders desc"
+        }
+      },
+      "result_metadata": [
+        { "name": "brand", "display_name": "brand" },
+        { "name": "n_orders", "display_name": "n_orders" }
+      ]
+    },
+    {
+      "id": 902,
+      "name": "Revenue by Region (BQ join)",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "database": 7,
+        "query": {
+          "source-table": 1,
+          "joins": [
+            {
+              "source-table": 2,
+              "alias": "c",
+              "strategy": "left-join",
+              "condition": ["=", ["field", 12, null], ["field", 21, { "join-alias": "c" }]]
+            }
+          ],
+          "aggregation": [["sum", ["field", 13, null]]],
+          "breakout": [["field", 22, { "join-alias": "c" }]]
+        }
+      }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/exec-overview.dashboard.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/exec-overview.dashboard.json
@@ -1,0 +1,189 @@
+{
+  "id": 9,
+  "name": "Exec Overview",
+  "description": "Executive orders dashboard — tabs, parameters, mixed viz.",
+  "parameters": [
+    { "id": "p1", "name": "Date",   "slug": "date_range", "type": "date/range", "default": "past30days" },
+    { "id": "p2", "name": "Region", "slug": "region",     "type": "string/=",   "default": null }
+  ],
+  "tabs": [
+    { "id": 11, "name": "Overview" },
+    { "id": 12, "name": "Detail" }
+  ],
+  "dashcards": [
+    {
+      "id": 1, "card_id": null, "dashboard_tab_id": 11,
+      "row": 0, "col": 0, "size_x": 24, "size_y": 2,
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Executive Overview\nKey order metrics for DEMO_DB. Filters apply across the page."
+      }
+    },
+    {
+      "id": 2, "card_id": 201, "dashboard_tab_id": 11,
+      "row": 2, "col": 0, "size_x": 5, "size_y": 4,
+      "parameter_mappings": [],
+      "card": {
+        "id": 201, "name": "Total Revenue", "type": "question", "display": "scalar", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]]
+        }},
+        "result_metadata": [
+          { "name": "sum", "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "column_settings": { "[\"name\",\"sum\"]": { "number_style": "currency", "decimals": 0 } }
+        }
+      }
+    },
+    {
+      "id": 3, "card_id": 101, "dashboard_tab_id": 11,
+      "row": 2, "col": 5, "size_x": 10, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 101, "target": ["dimension", ["field", 71, null]] }
+      ],
+      "card": {
+        "id": 101, "name": "Revenue Trend", "type": "question", "display": "line", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]],
+          "breakout": [["field", 71, { "temporal-unit": "month" }]]
+        }},
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date",          "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "month" }] },
+          { "name": "sum",        "display_name": "Sum of Sales Amount", "base_type": "type/Float",    "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["sum"] }
+      }
+    },
+    {
+      "id": 4, "card_id": 203, "dashboard_tab_id": 11,
+      "row": 2, "col": 15, "size_x": 9, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 203, "target": ["dimension", ["field", 85, null]] }
+      ],
+      "card": {
+        "id": 203, "name": "Customers by Region", "type": "question", "display": "bar", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 85, null]]
+        }},
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text",    "field_ref": ["field", 85, null] },
+          { "name": "count",  "display_name": "Count",  "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "graph.dimensions": ["REGION"], "graph.metrics": ["count"],
+          "click_behavior": { "type": "crossfilter" }
+        }
+      }
+    },
+    {
+      "id": 5, "card_id": 204, "dashboard_tab_id": 11,
+      "row": 8, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 204, "name": "Customers by Loyalty Tier", "type": "question", "display": "row", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 84, null]]
+        }},
+        "result_metadata": [
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "field_ref": ["field", 84, null] },
+          { "name": "count",        "display_name": "Count",        "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["LOYALTY_TIER"], "graph.metrics": ["count"] }
+      }
+    },
+    {
+      "id": 6, "card_id": 205, "dashboard_tab_id": 11,
+      "row": 8, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 205, "name": "Stores by State", "type": "question", "display": "pie", "database_id": 2, "table_id": 47,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 47,
+          "aggregation": [["count"]],
+          "breakout": [["field", 94, null]]
+        }},
+        "result_metadata": [
+          { "name": "STATE", "display_name": "State", "base_type": "type/Text",    "field_ref": ["field", 94, null] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "pie.dimension": "STATE", "pie.metric": "count" }
+      }
+    },
+    {
+      "id": 7, "card_id": 206, "dashboard_tab_id": 12,
+      "row": 0, "col": 0, "size_x": 14, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 206, "name": "Revenue by Region and Tier", "type": "question", "display": "pivot", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "joins": [
+            { "source-table": 46, "alias": "Customer", "strategy": "left-join",
+              "condition": ["=", ["field", 75, null], ["field", 81, { "join-alias": "Customer" }]], "fields": "all" }
+          ],
+          "aggregation": [["sum", ["field", 72, null]]],
+          "breakout": [
+            ["field", 85, { "join-alias": "Customer" }],
+            ["field", 84, { "join-alias": "Customer" }]
+          ]
+        }},
+        "result_metadata": [
+          { "name": "REGION",       "display_name": "Region",              "base_type": "type/Text",  "field_ref": ["field", 85, { "join-alias": "Customer" }] },
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier",        "base_type": "type/Text",  "field_ref": ["field", 84, { "join-alias": "Customer" }] },
+          { "name": "sum",          "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "pivot_table.column_split": {
+            "rows":    [["field", 85, { "join-alias": "Customer" }]],
+            "columns": [["field", 84, { "join-alias": "Customer" }]],
+            "values":  [["aggregation", 0]]
+          }
+        }
+      }
+    },
+    {
+      "id": 8, "card_id": 207, "dashboard_tab_id": 12,
+      "row": 0, "col": 14, "size_x": 10, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 207, "name": "Tier Funnel", "type": "question", "display": "funnel", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 84, null]]
+        }},
+        "result_metadata": [
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "field_ref": ["field", 84, null] },
+          { "name": "count",        "display_name": "Count",        "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9, "card_id": 210, "dashboard_tab_id": 12,
+      "row": 8, "col": 0, "size_x": 24, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 210, "name": "Premium Orders", "type": "question", "display": "table", "database_id": 2,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": "card__100",
+          "filter": ["=", ["field", "Tier Bucket", { "base-type": "type/Text" }], "Premium"]
+        }},
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", "ORDER_NUMBER", { "base-type": "type/Integer" }] },
+          { "name": "SALES_AMOUNT", "display_name": "Sales Amount", "base_type": "type/Float",   "field_ref": ["field", "SALES_AMOUNT", { "base-type": "type/Float" }] },
+          { "name": "Net Amount",   "display_name": "Net Amount",   "base_type": "type/Float",   "field_ref": ["field", "Net Amount",   { "base-type": "type/Float" }] },
+          { "name": "Tier Bucket",  "display_name": "Tier Bucket",  "base_type": "type/Text",    "field_ref": ["field", "Tier Bucket",  { "base-type": "type/Text" }] }
+        ],
+        "visualization_settings": {}
+      }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/legacy-grid.dashboard.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/legacy-grid.dashboard.json
@@ -1,0 +1,42 @@
+{
+  "id": 5,
+  "name": "Legacy Grid",
+  "description": "Old-shape dashboard (pre-v48): ordered_cards with sizeX/sizeY.",
+  "parameters": [],
+  "ordered_cards": [
+    {
+      "id": 1, "card_id": 201,
+      "row": 0, "col": 0, "sizeX": 6, "sizeY": 4,
+      "parameter_mappings": [],
+      "card": {
+        "id": 201, "name": "Total Revenue", "display": "scalar", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]]
+        }},
+        "result_metadata": [
+          { "name": "sum", "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 2, "card_id": 203,
+      "row": 0, "col": 6, "sizeX": 12, "sizeY": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 203, "name": "Customers by Region", "display": "bar", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 85, null]]
+        }},
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text",    "field_ref": ["field", 85, null] },
+          { "name": "count",  "display_name": "Count",  "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["REGION"], "graph.metrics": ["count"] }
+      }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/metadata.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/metadata.json
@@ -1,0 +1,38 @@
+{
+  "id": 2,
+  "name": "DEMO_DB Snowflake",
+  "engine": "snowflake",
+  "tables": [
+    {
+      "id": 45, "name": "ORDER_FACT", "schema": "DEMO", "db_id": 2, "display_name": "Order Fact",
+      "fields": [
+        { "id": 70, "name": "ORDER_NUMBER",   "display_name": "Order Number",   "base_type": "type/Integer",  "semantic_type": "type/PK", "table_id": 45, "fk_target_field_id": null },
+        { "id": 71, "name": "ORDER_DATE",     "display_name": "Order Date",     "base_type": "type/DateTime", "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 72, "name": "SALES_AMOUNT",   "display_name": "Sales Amount",   "base_type": "type/Float",    "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 73, "name": "QUANTITY",       "display_name": "Quantity",       "base_type": "type/Integer",  "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 74, "name": "DISCOUNT_AMOUNT","display_name": "Discount Amount","base_type": "type/Float",    "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 75, "name": "CUSTOMER_KEY",   "display_name": "Customer Key",   "base_type": "type/Integer",  "semantic_type": "type/FK",  "table_id": 45, "fk_target_field_id": 81 },
+        { "id": 76, "name": "ORDER_STORE_KEY","display_name": "Order Store Key","base_type": "type/Integer",  "semantic_type": "type/FK",  "table_id": 45, "fk_target_field_id": 91 }
+      ]
+    },
+    {
+      "id": 46, "name": "CUSTOMER_DIM", "schema": "DEMO", "db_id": 2, "display_name": "Customer Dim",
+      "fields": [
+        { "id": 81, "name": "CUSTOMER_KEY", "display_name": "Customer Key", "base_type": "type/Integer", "semantic_type": "type/PK", "table_id": 46, "fk_target_field_id": null },
+        { "id": 82, "name": "FIRST_NAME",   "display_name": "First Name",   "base_type": "type/Text",    "semantic_type": null,      "table_id": 46, "fk_target_field_id": null },
+        { "id": 83, "name": "LAST_NAME",    "display_name": "Last Name",    "base_type": "type/Text",    "semantic_type": null,      "table_id": 46, "fk_target_field_id": null },
+        { "id": 84, "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "semantic_type": "type/Category", "table_id": 46, "fk_target_field_id": null },
+        { "id": 85, "name": "REGION",       "display_name": "Region",       "base_type": "type/Text",    "semantic_type": "type/Category", "table_id": 46, "fk_target_field_id": null }
+      ]
+    },
+    {
+      "id": 47, "name": "STORE_DIM", "schema": "DEMO", "db_id": 2, "display_name": "Store Dim",
+      "fields": [
+        { "id": 91, "name": "STORE_KEY",  "display_name": "Store Key",  "base_type": "type/Integer", "semantic_type": "type/PK", "table_id": 47, "fk_target_field_id": null },
+        { "id": 92, "name": "STORE_NAME", "display_name": "Store Name", "base_type": "type/Text",    "semantic_type": null,      "table_id": 47, "fk_target_field_id": null },
+        { "id": 93, "name": "CITY",       "display_name": "City",       "base_type": "type/Text",    "semantic_type": null,      "table_id": 47, "fk_target_field_id": null },
+        { "id": 94, "name": "STATE",      "display_name": "State",      "base_type": "type/Text",    "semantic_type": "type/State", "table_id": 47, "fk_target_field_id": null }
+      ]
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/orders-model.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/orders-model.card.json
@@ -1,0 +1,45 @@
+{
+  "id": 100,
+  "name": "Orders Model",
+  "description": "Curated orders dataset joined to customers — the Metabase model.",
+  "type": "model",
+  "display": "table",
+  "database_id": 2,
+  "table_id": 45,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "joins": [
+        {
+          "source-table": 46,
+          "alias": "Customer",
+          "strategy": "left-join",
+          "condition": ["=", ["field", 75, null], ["field", 81, { "join-alias": "Customer" }]],
+          "fields": "all"
+        }
+      ],
+      "expressions": {
+        "Net Amount": ["-", ["field", 72, null], ["field", 74, null]],
+        "Tier Bucket": ["case",
+          [[["=", ["field", 84, { "join-alias": "Customer" }], "GOLD", "PLATINUM"], "Premium"]],
+          { "default": "Standard" }
+        ]
+      },
+      "aggregation": [
+        ["aggregation-options", ["sum", ["field", 72, null]], { "name": "total_revenue", "display-name": "Total Revenue" }]
+      ]
+    }
+  },
+  "result_metadata": [
+    { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer",  "field_ref": ["field", 70, null] },
+    { "name": "ORDER_DATE",   "display_name": "Order Date",   "base_type": "type/DateTime", "field_ref": ["field", 71, null] },
+    { "name": "SALES_AMOUNT", "display_name": "Sales Amount", "base_type": "type/Float",    "field_ref": ["field", 72, null] },
+    { "name": "REGION",       "display_name": "Region",       "base_type": "type/Text",     "field_ref": ["field", 85, { "join-alias": "Customer" }] },
+    { "name": "Net Amount",   "display_name": "Net Amount",   "base_type": "type/Float",    "field_ref": ["expression", "Net Amount"] },
+    { "name": "Tier Bucket",  "display_name": "Tier Bucket",  "base_type": "type/Text",     "field_ref": ["expression", "Tier Bucket"] }
+  ],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-expressions.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-expressions.card.json
@@ -1,0 +1,36 @@
+{
+  "id": 404,
+  "name": "Order Enrichment (pMBQL Expressions)",
+  "description": "Modern-format structured card with expressions as a pMBQL clause LIST (lib/expression-name in opts): case, datetime-diff, a date() cast, and lower(). Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "expressions": [
+          ["case", { "lib/uuid": "00000000-0000-4000-8000-00000000e001", "lib/expression-name": "Size Bucket" },
+            [
+              [[">", { "lib/uuid": "00000000-0000-4000-8000-00000000e002" },
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e003", "base-type": "type/Float", "effective-type": "type/Float" }, 72], 1000],
+               "Large"]
+            ],
+            "Small"],
+          ["datetime-diff", { "lib/uuid": "00000000-0000-4000-8000-00000000e004", "lib/expression-name": "Days to Now" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e005", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71],
+            ["now", { "lib/uuid": "00000000-0000-4000-8000-00000000e006" }],
+            "day"],
+          ["date", { "lib/uuid": "00000000-0000-4000-8000-00000000e007", "lib/expression-name": "Order Day" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e008", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-joins.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-joins.card.json
@@ -1,0 +1,35 @@
+{
+  "id": 403,
+  "name": "Orders with Customers (pMBQL Join)",
+  "description": "Modern-format structured card with a pMBQL join: {stages:[{source-table}], conditions:[…], alias, strategy}. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "joins": [
+          {
+            "lib/type": "mbql/join",
+            "alias": "Customer Dim - Customer",
+            "strategy": "left-join",
+            "fields": "all",
+            "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 46 }],
+            "conditions": [
+              ["=", { "lib/uuid": "00000000-0000-4000-8000-00000000j001" },
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000j002", "base-type": "type/Integer", "effective-type": "type/Integer" }, 75],
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000j003", "base-type": "type/Integer", "effective-type": "type/Integer", "join-alias": "Customer Dim - Customer" }, 81]]
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-multistage.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-multistage.card.json
@@ -1,0 +1,35 @@
+{
+  "id": 405,
+  "name": "Average Weekly Revenue (pMBQL Multi-Stage)",
+  "description": "Modern-format TWO-stage query (aggregate over an aggregation) — normalizes to legacy source-query nesting; the converter flags it (rare but real: 14 of 7,023 cards on a production estate). Synthetic.",
+  "type": "question",
+  "display": "scalar",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "aggregation": [
+          ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000m001" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m002", "base-type": "type/Float", "effective-type": "type/Float" }, 72]]
+        ],
+        "breakout": [
+          ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m003", "base-type": "type/DateTime", "effective-type": "type/DateTime", "temporal-unit": "week" }, 71]
+        ]
+      },
+      {
+        "lib/type": "mbql.stage/mbql",
+        "aggregation": [
+          ["avg", { "lib/uuid": "00000000-0000-4000-8000-00000000m004" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m005", "base-type": "type/Float", "effective-type": "type/Float" }, "sum"]]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-native-tags.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-native-tags.card.json
@@ -1,0 +1,43 @@
+{
+  "id": 401,
+  "name": "Filtered Revenue (pMBQL Native + Tags)",
+  "description": "Modern-format native card with every template-tag kind: text + number variables, a dimension field filter (pMBQL field clause), a card ref, and an optional [[…]] block. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM DEMO_DB.DEMO.ORDER_FACT o\nJOIN DEMO_DB.DEMO.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}} AND o.QUANTITY >= {{min_qty}} [[AND c.LOYALTY_TIER = {{tier}}]]\n  AND o.ORDER_NUMBER IN (SELECT ORDER_NUMBER FROM {{#400-daily-revenue}})\nGROUP BY 1",
+        "template-tags": {
+          "region": {
+            "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+          },
+          "min_qty": {
+            "id": "tt2", "name": "min_qty", "display-name": "Min Quantity", "type": "number", "default": 1
+          },
+          "order_date": {
+            "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+            "widget-type": "date/range", "required": false,
+            "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]
+          },
+          "tier": {
+            "id": "tt4", "name": "tier", "display-name": "Loyalty Tier", "type": "text"
+          },
+          "#400-daily-revenue": {
+            "id": "tt5", "name": "#400-daily-revenue", "display-name": "#400 Daily Revenue", "type": "card", "card-id": 400
+          }
+        }
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-native.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-native.card.json
@@ -1,0 +1,24 @@
+{
+  "id": 400,
+  "name": "Daily Revenue (pMBQL Native)",
+  "description": "Modern-format (lib/type) native card — single stage, no tags. Synthetic.",
+  "type": "question",
+  "display": "line",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT ORDER_DATE, SUM(SALES_AMOUNT) AS REVENUE\nFROM DEMO_DB.DEMO.ORDER_FACT\nGROUP BY 1"
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date", "base_type": "type/DateTime" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["REVENUE"] }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-params.dashboard.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-params.dashboard.json
@@ -1,0 +1,131 @@
+{
+  "id": 500,
+  "name": "Regional Ops (pMBQL)",
+  "description": "Modern-format dashboard: parameters targeting native template tags (variable + field-filter), a pMBQL dimension target, conditional formatting, series_settings renames, and an object-detail card. Synthetic.",
+  "collection_id": 5,
+  "parameters": [
+    { "id": "p1", "name": "Region", "slug": "region_param", "type": "string/=", "default": "West" },
+    { "id": "p2", "name": "Order Window", "slug": "order_window", "type": "date/range" },
+    { "id": "p3", "name": "Order Date", "slug": "order_date_param", "type": "date/all-options" }
+  ],
+  "tabs": [],
+  "dashcards": [
+    {
+      "id": 9001,
+      "card_id": 401,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 401, "target": ["variable", ["template-tag", "region"]] },
+        { "parameter_id": "p3", "card_id": 401, "target": ["dimension", ["template-tag", "order_date"], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "table.column_formatting": [
+          { "columns": ["REVENUE"], "type": "single", "operator": ">", "value": 10000, "color": "#22c55e", "highlight_row": false },
+          { "columns": ["REVENUE"], "type": "range", "colors": ["#ffffff", "#509ee3"], "min_type": null, "max_type": null }
+        ]
+      },
+      "card": {
+        "id": 401,
+        "name": "Filtered Revenue (pMBQL Native + Tags)",
+        "display": "table",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/native",
+              "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE FROM DEMO_DB.DEMO.ORDER_FACT o JOIN DEMO_DB.DEMO.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY WHERE c.REGION = {{region}} AND {{order_date}} GROUP BY 1",
+              "template-tags": {
+                "region": { "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West" },
+                "order_date": {
+                  "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+                  "widget-type": "date/range",
+                  "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime" }, 71]
+                }
+              }
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+          { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9002,
+      "card_id": 402,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 402, "target": ["dimension", ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000d001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "series_settings": { "total_revenue": { "title": "Revenue ($)", "color": "#88BF4D" } }
+      },
+      "card": {
+        "id": 402,
+        "name": "Weekly Orders by Region (pMBQL)",
+        "display": "bar",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/mbql",
+              "source-table": 45,
+              "aggregation": [
+                ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+                ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+                  ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float" }, 72]]
+              ],
+              "breakout": [
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71]
+              ]
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+          { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9003,
+      "card_id": 406,
+      "row": 6, "col": 0, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {},
+      "card": {
+        "id": 406,
+        "name": "Order Record",
+        "display": "object",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 45 }]
+        },
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", 70, null] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9004,
+      "card_id": null,
+      "row": 6, "col": 8, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Ops Notes\nSynthetic markdown block."
+      }
+    }
+  ]
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-structured.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/pmbql-structured.card.json
@@ -1,0 +1,41 @@
+{
+  "id": 402,
+  "name": "Weekly Orders by Region (pMBQL)",
+  "description": "Modern-format structured card: named + unnamed aggregations, temporal-unit breakout, filters incl. the pMBQL-only `in` op and time-interval with opts-second clause order. Synthetic.",
+  "type": "question",
+  "display": "bar",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "aggregation": [
+          ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+          ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float", "effective-type": "type/Float" }, 72]]
+        ],
+        "breakout": [
+          ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "effective-type": "type/DateTime", "temporal-unit": "week" }, 71]
+        ],
+        "filters": [
+          ["=", { "lib/uuid": "00000000-0000-4000-8000-00000000f001" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f002", "base-type": "type/Integer", "effective-type": "type/Integer" }, 73], 1, 2, 3],
+          ["in", { "lib/uuid": "00000000-0000-4000-8000-00000000f003", "effective-type": "type/Boolean" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f004", "base-type": "type/Integer", "effective-type": "type/Integer" }, 70], 100, 200],
+          ["time-interval", { "lib/uuid": "00000000-0000-4000-8000-00000000f005", "include-current": true, "effective-type": "type/Boolean" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f006", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71], -6, "month"]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+    { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+    { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+  ],
+  "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["count", "total_revenue"] }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/revenue-trend.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/revenue-trend.card.json
@@ -1,0 +1,31 @@
+{
+  "id": 101,
+  "name": "Revenue Trend",
+  "description": "Monthly revenue, trailing 12 months.",
+  "type": "question",
+  "display": "line",
+  "database_id": 2,
+  "table_id": 45,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "expressions": {
+        "Days Since Order": ["datetime-diff", ["field", 71, null], ["now"], "day"]
+      },
+      "aggregation": [["sum", ["field", 72, null]]],
+      "breakout": [["field", 71, { "temporal-unit": "month" }]],
+      "filter": ["time-interval", ["field", 71, null], -365, "day"]
+    }
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date",          "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "month" }] },
+    { "name": "sum",        "display_name": "Sum of Sales Amount", "base_type": "type/Float",    "field_ref": ["aggregation", 0] }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["ORDER_DATE"],
+    "graph.metrics": ["sum"]
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/top-customers-native.card.json
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/fixtures/top-customers-native.card.json
@@ -1,0 +1,30 @@
+{
+  "id": 102,
+  "name": "Top Customers (Native)",
+  "description": "Hand-written SQL with a text variable and a field filter.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "native",
+    "database": 2,
+    "native": {
+      "query": "SELECT c.FIRST_NAME || ' ' || c.LAST_NAME AS CUSTOMER, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM DEMO_DB.DEMO.ORDER_FACT o\nJOIN DEMO_DB.DEMO.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}}\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 10",
+      "template-tags": {
+        "region": {
+          "id": "t1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+        },
+        "order_date": {
+          "id": "t2", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+          "widget-type": "date/range", "dimension": ["field", 71, null]
+        }
+      }
+    }
+  },
+  "result_metadata": [
+    { "name": "CUSTOMER", "display_name": "Customer", "base_type": "type/Text" },
+    { "name": "REVENUE",  "display_name": "Revenue",  "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/control-parity.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/control-parity.md
@@ -1,0 +1,99 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of a validation org found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.mjs --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, a validation org)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| Sigma MCP workbook query | **YES** — returned only the default-filtered row | **NO** — the query path exposes no control-parameter override |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/customization.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/customization.md
@@ -1,0 +1,81 @@
+# Customizing this skill — make it yours
+
+This skill is **agent-driven**: Claude reads these files and follows them. That means
+you can fine-tune the migration **by telling Claude what you want, in plain language**
+— no code required for most changes. Say it once, ask Claude to remember it, and every
+future run applies it.
+
+There are three tiers, from lightest to deepest:
+
+## Tier 1 — Preferences file (plain language, no code)
+
+`~/.metabase-to-sigma/preferences.md` — YOUR standing instructions, written in
+natural language. The agent reads it at the start of every migration run (Phase 0)
+and honors it throughout. It lives in your home directory, not the repo, so a
+`git pull` never overwrites it.
+
+How to create or extend it: just tell Claude. Examples of things customers have
+asked for — phrase them however you like:
+
+```markdown
+# My metabase-to-sigma preferences
+
+- Always alias bare aggregates in migrated SQL (count(*) AS n_orders) so chart
+  labels are readable — never leave a BigQuery f0_ column.
+- Use list controls (not segmented) even for small static value lists.
+- Our dashboards' "AU" tabs are deprecated — skip them, migrate UK pages only.
+- Name migrated workbooks "<Dashboard name> (migrated <date>)" and put
+  everything under the "Metabase Migration" folder.
+- Date controls should default to last 30 days when Metabase has no default.
+- After every workbook posts, export the PNG and show it to me before parity.
+```
+
+**The agent's side of the contract** (Claude: this is an instruction to you):
+- Read `~/.metabase-to-sigma/preferences.md` at the start of every run, restate the
+  active preferences in one line, and apply them.
+- Whenever the user corrects your output or expresses a preference mid-run
+  ("actually, make the controls list-type", "don't migrate archived cards"),
+  **offer to save it to the preferences file** so the next run gets it for free.
+- A preference can override any default in SKILL.md EXCEPT the verification gates
+  (post-and-readback, parity, visual check) — those are never skipped.
+
+## Tier 2 — Learned formula rules (per-org translation overrides)
+
+`~/.metabase-to-sigma/learned-rules.json` — regex → template rules applied BEFORE
+the built-in MBQL translator. This is for **formula translations** specific to your
+org (a custom function, a house SQL idiom, a wrapper the converter doesn't know).
+The gap-scout flow (SKILL.md "Gaps") proposes these automatically when a card hits
+an unmapped expression; you can also ask Claude to write one directly:
+
+> "Whenever you see our `fiscal_quarter(x)` function, translate it to
+> `DateTrunc(\"quarter\", DateAdd(\"month\", -1, x))` — save that as a learned rule."
+
+Rules are validated (the scout round-trips them against live Sigma before
+persisting) and survive skill updates.
+
+## Tier 3 — Converter changes (code, tests, shared back)
+
+For behavior that's structural — a new chart type, a different DM topology, an
+element-naming scheme — ask Claude to change the converter itself:
+
+> "Open converter/metabase-dashboard.ts and make funnel cards convert to a bar
+> chart sorted descending instead of a flagged table. Add a fixture test."
+
+Ground rules the agent follows:
+- Every converter change gets a fixture + test in `converter/test.ts` (run
+  `node --import tsx/esm test.ts` — must stay green).
+- Live-verify against your Sigma org with `post-and-readback` before trusting it.
+- If the change fixes something broken (not just org-specific taste), please
+  share it back — `scripts/escalate-gap.py` opens a GitHub issue on the skill
+  repo with the details pre-filled, or open a PR. Your fix becomes everyone's fix.
+
+## What goes where (quick router)
+
+| You want to change… | Tier |
+|---|---|
+| Naming, folders, which pages/cards to include, control widget choices, layout taste, run etiquette | 1 — preferences.md |
+| How a specific formula/function/SQL idiom translates | 2 — learned-rules.json |
+| Chart-type mappings, DM structure, new Metabase features, bug fixes | 3 — converter + tests |
+
+When in doubt, just describe what you want — Claude picks the tier and tells you
+where it saved it.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/design-notes.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/design-notes.md
@@ -1,0 +1,326 @@
+# Design notes — Metabase → Sigma
+
+## Status: LIVE-VALIDATED end to end (2026-06-11)
+
+Full pipeline proven against a local Metabase **v0.61.3** (jar, OpenJDK) connected
+to the same Snowflake warehouse as Sigma: 8 pilot cards + a 2-tab parameterized
+dashboard → discovery → converter → DM POST (readback clean) → workbook POST
+(readback clean) → **EXACT MCP-query parity** on every element (KPI total, 4
+regions, 3 channels, 30 months, 15 category×channel cells, pivot cells, filtered
+row counts). See §10 for the live-verified contracts that replaced the old
+"known unknowns" and the validation-loop recipe.
+
+## What maps to what
+
+| Metabase | Sigma | Carrier |
+|---|---|---|
+| Database / table | DM `warehouse-table` element | `GET /api/database/{id}/metadata` (schema + field ids) |
+| **Model** (curated dataset) | DM element (table / join / sql) | the model's own `dataset_query` |
+| Question (MBQL) used by dashboards | DM element + metrics, or workbook element sourced from the DM | `dataset_query.query` |
+| Question (native SQL) | DM **`sql` element** (Custom SQL) | `dataset_query.native.query`; `{{tags}}` → controls |
+| MBQL `joins` | DM `join` source (left/right/inner/full) | join condition field pairs |
+| FK metadata (`fk_target_field_id`) | DM **relationships** (+ derived view) | database metadata — Metabase's implicit-join graph |
+| `expressions` (custom columns) | calc columns | `translateMbqlExpr` |
+| `aggregation` (+ named wrappers) | element **metrics** | |
+| Dashboard | workbook page(s) — one page per dashboard **tab** | `dashcards` grid → 24-col Sigma layout, 1:1 |
+| Dashcard | chart/table/pivot/KPI/text element | `display` + `visualization_settings` |
+| Dashboard `parameters` | workbook **controls** + targets | `parameter_mappings` name the filtered column per card |
+| Collections | folder suggestion only (Sigma folder = POST `folderId`) | not auto-created |
+
+## Decisions (and why)
+
+1. **Field-id resolution is a hard prerequisite.** MBQL refs columns by integer
+   id. The converter REQUIRES `--metadata metadata.json`
+   (`GET /api/database/{id}/metadata`) and falls back to the card's
+   `result_metadata` names when an id is missing — with a warning, because
+   fallback names lose the table qualifier.
+2. **Models become the DM; ad-hoc questions become workbook elements.** A
+   Metabase model is the semantic-layer object — it maps to a DM element other
+   elements source. Questions that only a dashboard uses convert as workbook
+   elements wired to the DM element for their source table (keeps the DM small
+   instead of one element per question — mirrors how the tableau/qlik
+   converters treat sheet-level calcs).
+3. **Nested questions (`source-table: "card__N"`)** convert to an element
+   sourced from card N's element (`source: {kind:"table", elementId}`) when card
+   N is in the input set; otherwise flagged with the card id so discovery can
+   fetch it.
+4. **Joins: MBQL explicit joins → DM join sources; FK metadata → DM
+   relationships.** Two different Metabase features, two different Sigma
+   carriers. The derived "join view" (`buildDerivedElements`) skips the
+   relationship's own key column (cross-element passthrough of a join key
+   compiles to type `error` — learned on qlik/oac, baked into `sigma-ids.ts`).
+5. **Number formats**: `column_settings` (`number_style`, `decimals`, `suffix`)
+   are the primary signal → Sigma d3 `formatString`; name/formula heuristics
+   (`inferSigmaFormat`) only fill gaps. Mirrors the powerbi `format` lesson
+   (beads-sigma-4q7k).
+6. **Never faked**: cum-sum/offset/segment/metric refs, binning, click
+   behaviors, and progress viz → loud warnings + readable placeholders.
+   Funnel, gauge, waterfall, and sankey now map to their native Sigma kinds
+   with required `columnId` channels. See `expression-dsl.md` for formulas.
+7. **Charts**: `display` + `graph.dimensions`/`graph.metrics` (names matched
+   through `result_metadata`) drive the Sigma viz: bar/row→bar (row = horizontal
+   — Sigma's only `orientation` enum value), line→line, area→area,
+   combo→combo (`series_settings` per-series display → dual-axis string/object
+   yAxis form), scatter→scatter, pie→pie, scalar/smartscalar→kpi-chart,
+   pivot→pivot-table (`pivot_table.column_split` → rowsBy/columnsBy
+   `{columnId}` objects + bare-string values), map→region-map/point-map
+   (`map.type`), plus native funnel/gauge/waterfall/sankey.
+8. **Workbook code representation is released-shape only**: outer metadata +
+   `document`, flat `document.elements`, metadata-only pages, authoritative
+   `document.layout`, canonical `<Page>`/`<Element>` tags, and `columnId`
+   pointers. The data-model representation remains page-nested and unwrapped.
+9. **Sandboxing (RLS) is EE-only and detect-only here**: `GET /api/mt/gtap`
+   (sandboxes) + group memberships exist only on Pro/EE. When detected (or
+   provided manually), the shared `apply_sigma_rls.py` engine ports it to Sigma
+   user-attributes after the DM is posted — same opt-in/out gate as every
+   sibling skill (never silent, never slow).
+
+## Live-verified contracts (was "known unknowns" — resolved 2026-06-11, see §10)
+
+- **Native SQL column refs**: bare `[Display Name]` POSTs 200 but resolves to
+  type "error" at query time. The contract is `[Custom SQL/RAW_ALIAS]` (raw SQL
+  output alias from `result_metadata.name`) + an explicit column `name`. The
+  readback gate exists for exactly this failure class.
+- **Join-source spec shape** (the manager's `on:[…]` contract was WRONG): each
+  join is `{left, right, joinType, columns:[{left:'[Display Name]', right:…}],
+  name}` — `columns` not `on`; refs are Sigma-PRETTIFIED display names (physical
+  `[PRODUCT_KEY]` → 400 "Column reference not found"); `connectionId` is REQUIRED
+  on each side's nested source; enum is `inner|left-outer|right-outer|full-outer|
+  lookup` (bare `left` → 400). `source.name` + per-join `name` are the formula
+  prefixes (`[NAME/Col]`) for head/right columns.
+- **DM control elements**: each `controlType` variant has REQUIRED discriminant
+  fields (text/number/date need `mode`); omitting them fails the union match and
+  surfaces misleadingly as `Invalid kind: "control"`.
+- **Sigma parses `{{…}}` inside SQL comments** — a neutralized field-filter
+  comment must NOT contain the literal tag braces or the POST 400s on the
+  missing control.
+- **Text elements carry `body`**, not `text`.
+- **100% stacking**: enum is `none|stacked|normalized` — Metabase's `normalized`
+  passes through verbatim ('percent' is rejected).
+- **Cross-document DM references** are `source.kind:'data-model'` (kind 'table'
+  is same-workbook only → 400 "Dependency not found").
+- **Display-name casing is AP-style**: first AND last words always capitalize;
+  stopwords lowercase only mid-name (`IS_EMAIL_OPT_IN` → "Is Email Opt In",
+  `DAYS_TO_SHIP` → "Days to Ship"). Cross-element refs are case-SENSITIVE;
+  warehouse-table refs are case-insensitive — so a casing bug only breaks
+  derived views/relationship refs.
+- **Pivot result_metadata carries `field_ref: null`** (v0.61) — refs must be
+  reconstructed from the MBQL by name (agg cols are named sum/count/avg/…);
+  `pivot-grouping` is a Metabase-internal column to skip.
+- **Sigma does NOT honor sql-element names** (all read back "Custom SQL") —
+  remap-wb-to-dm-ids.mjs matches native-card placeholders by column-set
+  fingerprint (smallest unique superset) and REPAIRS every workbook formula ref
+  against the live DM columns ([Element Name/Actual Column Name]).
+
+## Still open
+
+- Exact `dashcards` field names on older self-hosted versions (`size_x` verified on v0.61).
+- Conditional formatting: `single` rules pass through; `range` (gradient) rules
+  are still flagged (Sigma backgroundScale shape not yet live-verified).
+- Metabase progress cards still need an approved Sigma equivalent.
+
+## 9. First production contact (2026-06, Metabase Cloud v1.61.4 — 7,023 cards / 1,548 dashboards)
+
+Empirical findings folded back into the converter + assessment:
+
+- **pMBQL is the wire format.** 100% of the estate's `dataset_query`s were
+  `{"lib/type":"mbql/query","stages":[…]}`. `pmbql-normalize.mjs` (intake, both
+  skills) converts to the legacy shape; `legacy_query` (server's own
+  down-conversion, a JSON string, present on ~70% of cards) is preferred when
+  parseable. Sniff `lib/type` per card — a list response may mix formats.
+- **Template tags are the dominant feature** (45% of cards): text 5,629 ·
+  date 2,364 · dimension 1,914 · number 1,002 · card 384 · boolean 47; 1,705
+  cards use optional `[[…]]` blocks. See `template-tags.md` for the mapping.
+- **Dashboard parameters target tags, not columns**: 13,474 of 14,600
+  `parameter_mappings` targets were `["variable",["template-tag",…]]`; 1,057
+  `dimension`; 69 `text-tag` (flagged). 53% of dashboards carry parameters;
+  17% use tabs; 6,189 virtual (text/heading) dashcards.
+- **Display histogram** (cards): table 2999 · bar 1604 · line 1176 · combo 449 ·
+  scalar 259 · pie 135 · row 130 · funnel 83 · area 67 · pivot 39 · object 37 ·
+  waterfall 15 · sankey 13 · gauge 11 · scatter 3 · progress 3.
+- **Engines**: BigQuery was the warehouse — `project.dataset.table` refs and
+  trailing-comma SELECTs pass straight through, because the converter emits
+  native SQL **verbatim** into Sigma custom SQL (same-warehouse migrations are
+  near-verbatim; cross-warehouse needs a transpile pass first).
+- **Auth**: API keys send `x-api-key` (NOT a Bearer header). Scoped keys can
+  403 on `/api/database/{id}/metadata`; `GET /api/field/{id}` still worked for
+  restricted DBs — hence the field-resolution fallback chain.
+- **Discovery at scale**: the per-item walk took >1hr; bulk `GET /api/card`
+  (110MB, streamed + split locally) + parallel dashboard GETs ≈ 1 minute.
+
+**Historical honesty note:** this production contact validated extraction, not
+the write path. Section 10 records the subsequent end-to-end Sigma validation.
+The later released workbook wrapper/flat-element uplift is covered offline and
+must be rechecked through the normal live gates.
+
+## 10. First live Sigma validation (2026-06-11, local Metabase v0.61.3 → a validation org)
+
+The repeatable validation loop, no Docker required:
+
+1. `brew install openjdk` + the Metabase jar (match the customer's major version;
+   Java 24+ needs `--sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED`
+   or the Snowflake JDBC driver's Arrow reader throws `ExceptionInInitializerError`).
+2. Headless setup: `GET /api/session/properties` → `setup-token` → `POST /api/setup`.
+3. Snowflake connection via key-pair: details `{use-password:false,
+   private-key-options:'local', private-key-path:…}` — same warehouse Sigma reads,
+   so native SQL migrates verbatim and parity is apples-to-apples.
+4. Author pilot cards via `POST /api/card` mirroring the estate's dominant
+   patterns (native SQL, template tags incl. field filters + `[[optional]]`,
+   MBQL agg/breakout, explicit join, implicit FK breakout, scalar/pie/stacked-bar/
+   pivot/cond-format displays), one 2-tab dashboard with `parameter_mappings`.
+5. Execute every card (`POST /api/card/{id}/query`) and SAVE the rows — this is
+   the parity baseline AND proves the card-results extraction path customers'
+   scoped keys may lack (reference estate's key 403'd ALL THREE execution surfaces:
+   card query, `/query/json` export, ad-hoc `/api/dataset` — plan engagements
+   accordingly: parity needs either query perms or warehouse access).
+6. Skill loop: discover → convert → post-and-readback (DM) → convert dashboard
+   → remap (now also repairs refs) → post-and-readback (workbook) → MCP query
+   each element vs the step-5 baseline.
+
+Result: EXACT parity on all 8 cards (total 110,788.35; 633 filtered rows; all
+dimension splits). OSS v0.61 serves pMBQL with `legacy_query: null` — the
+pmbql-normalize path is mandatory, not a Cloud quirk.
+
+Found-and-fixed during the gauntlet (each was a live 400 or an error-typed
+column): join-source shape ×4, control `mode`, `{{tag}}`-in-comment, sql-element
+`[Custom SQL/…]` refs, text `body`, `stacking:normalized`, `data-model` source
+kind, AP-style last-word casing, pivot `field_ref:null`, implicit-FK dim-table
+ensure, explicit-join cards sourcing their card-named element. Plus two script
+bugs any first run would hit: six scripts committed without exec bits, and
+`metabase-discover.sh` f-string escapes that crash python ≤3.11.
+
+### §10b Gold round (same day): model + nested question + combo — EXACT parity
+
+Second pilot wave on the local harness: a curated **model** (`type:"model"`,
+ORDER_FACT ⟕ CUSTOMER_DIM + expression), a **nested question** (`card__N` on the
+model, agg by joined-dim breakout — nested field refs are STRING form
+`["field","NAME",{base-type}]`), and a **combo** chart (2 aggs, per-series
+`series_settings` bar/line + right axis). All three POST clean and match
+Metabase exactly (tiers 22,212.23/32,057.13/21,624.46/31,663.30; channels
+62,316.78/842 · 31,964.18/411 · 16,507.39/228). Combo dual-axis persists via the
+bare-string vs `{columnId, type:'line'}` yAxis form.
+
+Two converter fixes from this round:
+- **Nested-card DM elements need parent passthrough columns** — a table-sourced
+  element starts EMPTY (zero queryable columns live-verified), so the element now
+  copies `[Parent Name/Col]` passthroughs for every parent column.
+- **`card__N` dashcards whose parent is NOT on the dashboard** now source the
+  card's OWN DM element by card name (a `card__N` placeholder 400s at POST);
+  passing `cardNameById` still routes to the parent model instead.
+
+### §10c BigQuery readiness (Sigma side LIVE-verified; Metabase side fixture-shaped)
+
+Same-warehouse BQ migrations need no new machinery — the differences are all
+encoded and tested (`fixtures/bq-estate.card.json` + the `bq:` test block):
+
+- **Paths are `[project, dataset, table]`**, case-preserved (BQ is case-sensitive,
+  typically lowercase). The converter no longer uppercases table names anywhere —
+  a no-op for Snowflake (whose metadata is already uppercase), required for BQ.
+- **Project auto-derives** from `metadata.details['project-id']` when `--database`
+  is omitted (Snowflake: `details.db`). **Per-table `schema` from metadata wins**
+  over `--schema` — real estates span datasets.
+- **Live-verified against a real BQ connection** (no Metabase-on-BQ needed — the
+  Sigma side is what the converter POSTs): warehouse-table element with lowercase
+  path + `[table_tail/Prettified Col]` refs, a join with lowercase source/join
+  names + prettified `[Display Name]` condition refs, and a **verbatim BQ-dialect
+  sql element (backticks + trailing comma)** all POST clean, read back 0 errors,
+  and return correct rows. Cross-project tables (`bigquery-public-data.*`) appear
+  in Sigma's catalog the same way.
+- **First live Metabase-on-BQ run, verify only**: that `/api/database/{id}/metadata`
+  `details` exposes `project-id` on the customer's auth flavor, and dataset-level
+  `schema` population. Everything Sigma-side is already proven.
+- **Cross-warehouse** (Metabase-on-BQ → Sigma-on-Snowflake) remains the one real
+  gap: the 91%-native-SQL estate would need a transpile pass before passthrough —
+  flag, don't fake.
+
+### §10d Customer-feedback round (reference estate wave 0 — a source user, 2026-06-12)
+
+Four reported issues, each reproduced on the customer's real dashboard (defs
+from the estate cache) and fixed:
+
+1. **Grain switchers** (`{{date_aggregation}}` driven by a static-list param) —
+   parameters with `values_source_type: "static-list"` now become a Sigma
+   **segmented control** (≤6 values; larger lists stay `list`) with a manual
+   value source and the Metabase default carried over. The {{tag}} in SQL stays
+   verbatim. Number defaults are coerced from Metabase's strings.
+2. **Raw aliases as chart labels** (`x_axis_type`, `count(*)`) — column display
+   names are now ALWAYS prettified (sigmaDisplayName is idempotent); formulas
+   keep the raw alias ([Custom SQL/x_axis_type]). BQ's anonymous `f0_` becomes
+   "F 0" — alias aggregates in SQL for a better label.
+3. **Controls not driving anything** — remap gains `--dm-spec`: workbook
+   controls whose controlId matches a DM {{tag}} control get
+   `parameters: [{kind:'data-model', dataModelId, controlId}]` (the OpenAPI
+   shape on BOTH spec paths). NOTE: live POST currently rejects the binding
+   ("Invalid parameter on control") even type-matched and id-vs-controlId —
+   likely the DM control must be UI-exposed as a parameter first.
+   post-and-readback now strips the bindings and retries ONCE with a loud
+   warning; sync each control in the UI (control → Sync with data source
+   parameter). Re-probe occasionally — if the platform starts accepting it,
+   the wiring is already emitted.
+4. **Stacked layout** — `cli.ts --layout-out hints.json` exports the 1:1
+   Metabase grid geometry; `apply-layout.mjs --hints hints.json` reproduces it
+   exactly (24-col, ROWSCALE=2, controls in a top band, unhinted leftovers
+   stacked below; element ids preserved on workbook CREATE so hints match).
+   Without --hints the generic per-kind layout still applies.
+
+Run order per dashboard: convert (--layout-out) → remap (--dm-spec) →
+post-and-readback → apply-layout (--hints) → assert-parity.
+
+## 11. Control-targeting standard + shared gate stack (2026-06-12 retrofit)
+
+Brought to the cross-plugin contract uniform across sigma-migration-skills' 8
+plugins. Vendored BYTE-IDENTICAL (md5 discipline): `scripts/lib/control_lint.rb`,
+`scripts/lib/layout_lint.rb`, `scripts/probe-controls.rb`,
+`scripts/assert-phase6-ran.rb`, `refs/control-parity.md`.
+
+**What the audit found** (gate 7 run against the §10 live Pilot Ops workbook):
+3 of 3 controls DEAD — Status (variable-tag: binding rejected by the org and
+stripped → decorative), Region (field-filter tag whose column isn't in the
+card's result set → never wired), Date Grain (parameter has zero
+parameter_mappings → filters nothing in Metabase either). Layout lint: clean
+(the §10d exact-grid round already passes; layouts unchanged by this retrofit).
+
+**What changed (reconciled with the §10d customer round, not clobbering it):**
+- Converter emits the `control-scope.json` sidecar (`--control-scope-out`):
+  `sourceFilterSignals` = MAPPED parameters; per-control `scope`/`mustReach`
+  from the declared `parameter_mappings` targets (Metabase targets are
+  explicit, like MSTR selectors — unmapped same-page cards are by-design).
+- ALL wirable mappings now wire as REAL control `filters` targets, replacing
+  the boolean match column `[Col] = [slug]` entirely: a list-control reference
+  inside a formula reads back as an error-typed column (live-caught by the
+  new gates on the first fixture build), and range semantics never fit an
+  equality anyway. Table dashcards are targeted directly; charts/KPIs/pivots
+  re-root through a hidden base TABLE on a trailing `Data` page (id prefixed
+  `data` — the layout-gate exemption convention), because control targets may
+  only point at table elements. Date params become date-range controls (flat
+  `mode:"between"` — datetime targets need it); list/segmented targets on
+  numeric/datetime columns bind through a hidden `Text()` cast column (the
+  silent-strip gotcha). remap-wb-to-dm-ids skips intra-workbook (base-table)
+  sources AND leaves `[controlId]` tokens unrepaired (rewriting `[region]` to
+  `[Customer Dim/Region]` made a filter always-true — also live-caught).
+- Controls are placed AFTER the elements they target in spec order.
+- Unmapped parameters and unwirable field-filters get NO control + a loud
+  warning (flag, never furniture — they do nothing in Metabase either /
+  cannot be honestly wired).
+- Variable-tag controls keep the §10d behavior (emit + `--dm-spec` binding);
+  NEW default when the org rejects the binding: post-and-readback DROPS those
+  controls (and patches the sidecar) instead of shipping decorative ones —
+  the customer's original complaint WAS "controls not driving anything".
+  `--keep-rejected-bindings` restores the strip-and-keep behavior (gate 7
+  will flag those dead until each is UI-synced to its DM parameter).
+- Sentinels: post-and-readback writes `wb-ids.json` + `posted-workbooks.jsonl`;
+  `assert-parity --check` writes `parity-final.json` (+ optional tile census);
+  post-and-readback and apply-layout run the shared lints inline;
+  `assert-phase6-ran.rb` (gates 1–7) is the GREEN gate.
+
+**Known limitation (deferred, needs an upstream standard change):** when an org
+ACCEPTS `control.parameters` DM bindings, the bound control is functional but
+spec-invisible to control_lint (the binding lives on the control element, which
+the lint doesn't treat as wiring) — gate 7 would false-positive it as dead.
+a validation org currently rejects the binding, so this path is unexercised.
+
+**Bonus live finding (same retrofit, blocked the first fixture DM POST):**
+Sigma has NO `Or()`/`And()` FUNCTIONS — `Or(a, b)` is "Invalid formula" at
+POST; `and`/`or` are infix operators only. The MBQL translator now emits
+parenthesized infix chains (multi-value `=`, and/or/not nodes, is-empty/
+not-empty, inside). `Not()`, `Between()`, `IsNull()` are functions and fine.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/expression-dsl.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/expression-dsl.md
@@ -1,0 +1,82 @@
+# Metabase expressions → Sigma formulas
+
+Unlike every other source tool in this family, Metabase expressions arrive
+**already parsed**: MBQL is nested JSON arrays (`["+", ["field", 72, null], 5]`),
+so `converter/metabase.ts` (`translateMbqlExpr`) walks a tree — no regex DSL
+parsing. The custom-expression *text* a user typed (`[Price] - [Cost]`) is never
+stored; only the MBQL tree is.
+
+Modern instances emit **pMBQL** clauses (`[op, {opts}, …args]` — opts second);
+`pmbql-normalize.mjs` rewrites them to the legacy shapes below at intake, so
+every row in this table is expressed in legacy clause order. See
+`mbql-shapes.md` § pMBQL.
+
+## Translated (automatic)
+
+| MBQL op | Sigma | Notes |
+|---|---|---|
+| `["field", id, opts]` | `[Display Name]` / `[TABLE/Display Name]` | id → name via `fieldIndex`; `join-alias` → the joined element prefix; `temporal-unit` wraps in `DateTrunc("month", x)` |
+| `["expression", "Name"]` | `[Name]` | sibling custom-column ref |
+| `+ - * /` | `+ - * /` | n-ary in MBQL → left-fold binary |
+| `["case", [[c1,v1],[c2,v2]], {"default": d}]` | `If(c1, v1, If(c2, v2, d))` | |
+| `["coalesce", a, b, …]` | `Coalesce(a, b, …)` | |
+| `["concat", a, b, …]` | `Concat(a, b, …)` | |
+| `["substring", s, start, len]` | `Mid(s, start, len)` | both 1-indexed |
+| `["trim"/"ltrim"/"rtrim", s]` | `Trim/LTrim/RTrim(s)` | |
+| `["upper"/"lower", s]` | `Upper/Lower(s)` | |
+| `["length", s]` | `Len(s)` | |
+| `["replace", s, find, repl]` | `Replace(s, find, repl)` | literal find (not regex) |
+| `["regex-match-first", s, pat]` | `RegexpExtract(s, pat)` | |
+| `["split-part", s, delim, n]` | `SplitPart(s, delim, n)` | |
+| `["round"/"floor"/"ceil"/"abs"/"sqrt"/"exp", x]` | `Round/Floor/Ceiling/Abs/Sqrt/Exp(x)` | |
+| `["text", x]` / `["float", x]` / `["integer", x]` | `Text(x)` / `Number(x)` / `Int(x)` | v50+ casts |
+| `["date", x]` | `DateTrunc("day", x)` | date(x) = day-truncated datetime |
+| `["in"/"not-in", f, a, b, …]` | `(f = a or f = b or …)` / `(f != a and …)` | pMBQL multi-value ops (also appear in server `legacy_query`) |
+| `["power", x, y]` | `Power(x, y)` | |
+| `["log", x]` | `Log(x, 10)` | Metabase `log` is base-10 |
+| `["datetime-add", d, n, "unit"]` | `DateAdd("unit", n, d)` | unit string passes through |
+| `["datetime-subtract", d, n, "unit"]` | `DateAdd("unit", -n, d)` | |
+| `["datetime-diff", a, b, "unit"]` | `DateDiff("unit", a, b)` | |
+| `["get-year"/"get-month"/"get-day"/"get-hour"/"get-quarter", d]` | `DatePart("year"/…, d)` | `get-day-of-week` → `DatePart("dayofweek", d)` |
+| `["now"]` | `Now()` | |
+| `["relative-datetime", -30, "day"]` | `DateAdd("day", -30, Today())` | inside filters |
+| `= != < <= > >=` | `= != < <= > >=` | `["=", f, v1, v2]` (multi-value) → `(f = v1 or f = v2)` — Sigma has **no `IsIn`** (and **no `Or()`/`And()` functions** — infix only, live-verified) |
+| `["between", x, lo, hi]` | `Between(x, lo, hi)` | |
+| `["and"/"or"/"not", …]` | infix `(… and …)` / `(… or …)` / `Not(…)` | |
+| `["is-null"/"not-null", x]` | `IsNull(x)` / `IsNotNull(x)` | `is-empty`/`not-empty` add `Or x = ""` for text |
+| `["starts-with"/"ends-with"/"contains", s, sub]` | `StartsWith/EndsWith/Contains(s, sub)` | `does-not-contain` → `Not(Contains(…))`; default case-insensitive in Metabase — wrapped in `Lower()` unless `{"case-sensitive": true}` |
+| `["time-interval", f, -30, "day"]` | `f >= DateAdd("day", -30, Today())` | "previous 30 days" filter idiom; `"current"` → `DateTrunc(unit, f) = DateTrunc(unit, Today())` |
+| `["inside", lat, lon, …]` | lat/lon `Between` pair | map box filter |
+
+## Aggregations
+
+| MBQL | Sigma | Notes |
+|---|---|---|
+| `["count"]` | `Count()` | row count |
+| `["sum"/"avg"/"min"/"max"/"median", f]` | `Sum/Avg/Min/Max/Median(f)` | |
+| `["distinct", f]` | `CountDistinct(f)` | |
+| `["stddev", f]` | `StdDev(f)` | sample |
+| `["var", f]` | `Variance(f)` | |
+| `["percentile", f, 0.95]` | `Percentile(f, 0.95)` | |
+| `["count-where", cond]` | `CountIf(cond)` | condition only — no field arg |
+| `["sum-where", f, cond]` | `SumIf(f, cond)` | **field first** in both |
+| `["share", cond]` | `CountIf(cond) / Count()` | ratio of matching rows; format `,.2%` |
+| `["aggregation-options", inner, {name…}]` | inner | wrapper supplies the metric's name |
+
+## Flagged — never faked (warning + readable placeholder)
+
+| MBQL | Why | What to do |
+|---|---|---|
+| `["cum-sum"/"cum-count", f]` | running totals need a window scope Sigma defines on the *consuming element* | rebuild with `CumulativeSum` in the date-grouped workbook element (proven pattern — see powerbi DateLookback note) |
+| `["offset", expr, -1]` (v50+) | lag/lead window fn | rebuild with `Lag`/window calc in the consuming element |
+| `["segment", id]` | saved-segment ref — definition lives in another object | inline the segment's own MBQL (discovery fetches `/api/segment/{id}`; auto-inline is a roadmap item) |
+| `["metric", id]` (legacy) | saved-metric ref | same — inline from `/api/legacy-metric/{id}` |
+| `binning` opts on a breakout | numeric histogram buckets | recreate with `BinFixed`/`BinCount` in the workbook element |
+| `["day-name"/"month-name"/"quarter-name", x]` | localized name lookup — no confirmed Sigma fn | rebuild with a `case`/If chain or a Sigma Text format (observed 10× on a 7k-card estate) |
+| multi-stage query (pMBQL `stages` > 1 / legacy `source-query`) | a sub-query, not an expression | rebuild as chained Sigma elements; converter flags + skips (14 of 7,023 observed) |
+| native `{{tag}}` of type `dimension` ("field filter") | expands to a whole WHERE clause at runtime | becomes a Sigma control on the target column + element filter; plain `text`/`number`/`date` tags → `=`-parameter controls (converted) |
+| `click_behavior` | cross-filter / drill links | Sigma actions — manual follow-up |
+| `smartscalar`/`trend` comparison | auto previous-period delta | KPI value converts; add a Sigma comparison manually |
+
+> MBQL `["value", v, …]` literal wrappers unwrap transparently. Unknown ops emit
+> `/* unmapped: <op> */` placeholders + a loud warning — never silent, never guessed.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/layout-visual-qa.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/layout-visual-qa.md
@@ -1,0 +1,254 @@
+# Layout Visual QA — mandatory render-and-inspect gate
+
+Shared across all `*-to-sigma` migration plugins. A workbook that POSTs cleanly (HTTP 200)
+and passes numeric/CSV parity can still be **wrong** — overlapping tiles, clipped titles, dead
+zones, orphaned filters, a render that looks nothing like the source, or a layout that reads as
+generic AI-templated output. The export API renders exactly what a user sees, so the only
+reliable check is to **render each page to PNG and actually read the image** before declaring the
+migration done.
+
+> **The rule that triggered this gate:** Sigma's grid layout has **no z-order**. Source tools
+> with floating/absolute canvases (Qlik's associative listboxes & filterpanes, Power BI free-form
+> visuals, QuickSight FreeForm, Tableau floating zones) routinely place a **filter/legend/listbox
+> on top of a chart**. Preserving those coordinates 1:1 makes the two elements render *stacked on
+> the same cell*. The build scripts now resolve this deterministically (controls lifted to their
+> own band; `decollide_bands` tiles any remaining 2-D overlap edge-to-edge) — but novel layouts
+> can still slip through, which is why this human/agent visual gate is mandatory.
+
+## Mandatory loop (run after the workbook is POSTed, before you call it done)
+
+1. **Render the FULL Sigma page** (the whole dashboard, one image — not per-element) at a
+   realistic width:
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out <WORK>/visual-qa/<page>.png --w 1600`
+   (Contract: `POST /v2/workbooks/{id}/export` → poll `/v2/query/{q}/download`. Plugins that ship
+   their own renderer — `export-chart-png.rb`, `compare.py` — use the same contract.)
+1b. **Render the FULL SOURCE dashboard** as ONE image and compare full-dashboard ↔ full-dashboard:
+   Tableau MCP `get-view-image` on the **dashboard view** (not each worksheet); Power BI page
+   export; MicroStrategy `export-dossier-pdf.py`; the equivalent source export each plugin
+   captures in discovery. Place the two full images side by side. **Compare dashboard-to-dashboard,
+   never element-by-element** — per-element screenshots (e.g. `export-chart-png.rb`) miss
+   layout/relationship defects (overlaps, dead zones, a control stranded outside its chart, wrong
+   relative sizing) and are NOT a substitute for the full-page comparison. Use per-element PNGs
+   only as a drill-down after a full-page mismatch.
+2. **Read both full PNGs** and check the Sigma render against the source AND the three rubrics
+   below (source-fidelity → structural → design-quality, in that order).
+3. **Fix** any failure (re-band, resize, move a control into its chart's container, shorten a
+   map title) by editing the spec — for large multi-page workbooks use
+   the companion **sigma-workbooks** skill's `scripts/wb-rep.rb` (full-clone path: `plugins/sigma-authoring/skills/sigma-workbooks/scripts/wb-rep.rb`; pull → edit element files → push) — then
+   **re-render and re-read**.
+4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
+   never on an HTTP 200.
+
+## 1. Source-fidelity parity (run BEFORE the quality rubrics)
+
+Clean ≠ faithful. A workbook can be perfectly laid out and still look nothing like the dashboard
+it migrated. This check compares the render against the **source's own appearance**, captured as a
+full-page source export in discovery (Tableau dashboard image, Power BI page export, MicroStrategy
+`source_dossier.pdf`, etc.). Put the Sigma page PNG and the source page side-by-side and verify,
+page-for-page:
+
+- [ ] **Same element set** — every viz on the source page exists on the Sigma page (none dropped, none invented).
+- [ ] **Same arrangement** — relative position holds (a 3-column source stays 3-column; KPIs that sit under a chart stay under it). Pixel-exact isn't required; the *grouping and reading order* are.
+- [ ] **Matching chart KIND** — source KPI → Sigma `kpi-chart` (not a 1-row table); source horizontal bar → horizontal bar; microchart/indicator → the closest Sigma equivalent (conditional-formatted table / data bars), not a generic bar. The source's declared `visualizationType` (`kpi`, `microcharts`, `combo_chart`, `grid`, …) is the spec to match.
+- [ ] **KPI shows the source's VALUE** — confirm the big number equals what the source card shows (often a latest-period stat, not a windowed Sum). A KPI that's structurally a KPI but shows the wrong metric FAILS.
+- [ ] **Controls / selector panels present** — source filter panels, attribute/metric selectors, and chapter filters have Sigma equivalents (controls or an inherited base filter). An interactive source page rebuilt as a static grid FAILS.
+- [ ] **Branding bands** — header strips, logos, greeting/title bands present, OR explicitly descoped *with the user* and recorded.
+
+A render that diverges on any unchecked box is a FAIL even when row parity is green — fix the spec
+and re-compare. **Known spec ceilings** (don't loop on them — note them as editor follow-ups): KPI
+sparklines and comparison/delta badges are UI-only (`sigma-workbooks` `kpis.md`); source-tool
+chrome (theme toggles, native nav) has no spec equivalent. When the user scopes styling down
+("layout + metrics, skip branding"), record exactly what was descoped in the final summary — never
+drop it silently.
+
+
+### 1b. STYLE CHECKLIST — required to record a visual PASS (v5.3, gate 8b)
+
+`record-visual-check.rb --verdict pass` now REQUIRES `--checklist` covering six dimensions, each
+judged against the SOURCE image (not your intent, not your memory of the fix). Round 5 proved
+gestalt self-passes ship renders an exacting owner rejects — attest each dimension separately,
+and be harsh: a "mostly" is a `fail`.
+
+- `element_titles_hidden` — no element-title chrome the source hides ("Area Ch…", "Student Bar
+  Chart"); no truncated titles anywhere.
+- `palette_match` — pick 3-5 swatches off the source (series fill, background, accent) and eyeball
+  them against the render; a teal source with navy/lavender output is a `fail`, as is a
+  categorical palette leaking onto a monochrome chart.
+- `composition_match` — same canvas grid and proportions (a wide 2-panel source must not become a
+  portrait stack); section headers sit ADJACENT to their charts; no dead zones or overflow bands.
+- `chart_shapes_match` — every tile keeps its chart family AND encoding (dot strips stay dot
+  strips, pill bars stay pill bars); verified per tile, not per page.
+- `labels_legible` — no truncated/clipped labels, values, or rows/columns; no leaked control stubs
+  or raw data-prep tables on the canvas.
+- `numbers_formatted` — percent decimals, currency, and delta chips print as the source prints
+  them.
+
+Any `fail` ⇒ the verdict is `divergent` (the recorder refuses a pass; the gate re-checks stale or
+hand-edited verdicts). `na` is only for dimensions the page genuinely lacks (e.g. no numbers).
+
+**Blind countersignature (PR-9).** Your checklist is necessary but no longer sufficient: a `pass`
+also requires `--blind-grade <workdir>/blind-grade.json` — the verdict of a FRESH context-free
+subagent that received only the two image paths + the rubric (`refs/blind-grader-brief.md`). The
+grade is sha256-bound to the images and its per-tile chart-family readings are cross-checked
+against the mechanical kind census; gate 8b refuses a self-attested pass with the remedy named.
+
+**Recording `divergent` is not free.** A recorded `divergent` verdict passes gate 8b as RECORDED
+(the comparison happened and the gaps are acknowledged), but the divergence is **budget-counted**:
+`assert-phase6-ran.rb` injects `visual-divergent` into the waiver census, where it spends the same
+exit-19 waiver budget as any quality waiver — so a divergent-visual run can still complete, but it
+cannot ride to GREEN alongside 2 other waivers, and the budget line names it. GREEN requires the
+budget to hold: fix the gaps, re-render, re-record `pass` — or accept YELLOW with the divergence
+named in the report. Full verdict-capping (`divergent` caps the run at PARTIAL) is planned as
+PLAN-v3 PR-14 and is not built yet; until then the budget is the cap.
+
+## 2. Structural rubric (read the PNG against every item)
+
+- [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or
+      listbox sits on top of a chart or KPI. (This is the #1 failure for floating-canvas sources.)
+- [ ] **No dead zones.** The page title never shares a band with a chart; bands are stacked edge
+      to edge; no giant empty tile (usually an over-tall table — size to content).
+- [ ] **Controls placed correctly.** A global filter sits in a top control band; a control scoped
+      to one chart lives *inside that chart's container*, never floating loose on the page.
+- [ ] **No clipped titles/values.** KPI bands are ≥ 5 grid rows (titles hide below that); side
+      charts are ≥ 6 columns wide (narrower truncates the title); table tiles show all rows
+      without cutting off the summary bar.
+- [ ] **Trend/comparison KPIs are tall enough to show the spark.** A KPI stacks title → value →
+      comparison → sparkline and drops the lower items first when short, so a KPI carrying a
+      sparkline or delta needs ~8+ grid rows (~240px), not 5. If you built a sparkline but the
+      render shows only the number, grow the tile's `gridRow` span and re-export before concluding
+      it failed — a too-short tile makes a real spark look missing.
+- [ ] **Even heights.** Charts in one band share an inner row span; sibling chart bands match.
+- [ ] **Right chart kind & formatting.** The rendered viz matches the source (no silently-dropped
+      log scale, data labels, `$`/`%` formats, or palette).
+
+## 3. Design-quality rubric (read AFTER the structural pass)
+
+> **Fidelity wins ties.** These checks make a *faithful* migration also look intentional rather
+> than generically AI-templated. They are tie-breakers for the converter's own **defaults** — never
+> a license to override the source. If the source dashboard deliberately uses equal-width tiles, a
+> flat KPI strip, or centered text, **keep it**; the source-fidelity rubric (§1) outranks polish.
+> Apply a design fix only where the converter picked a default and the source didn't dictate
+> otherwise. (Derived from the AI design anti-patterns catalog.)
+
+- [ ] **Focal point exists.** The page's signature element — the source's hero viz, or the primary
+      KPI — reads as the most important thing (larger span or stronger position), not one cell in a
+      uniform grid. *AI tell: every tile the same size and visual weight; "generic dashboard."*
+- [ ] **Proportion follows priority.** Two tiles share a row at equal width only when they're true
+      peers (a KPI strip, a real side-by-side comparison). A primary chart outweighs a supporting
+      one; a 50/50 split of unequal-priority content reads as indecisive. *AI tell: automatic
+      equal-width rows.*
+- [ ] **Pages don't all open the same way.** In a multi-page workbook, not every page leads with an
+      identical KPI band — each page opens with the thing it's actually for. *AI tell: every screen
+      starts with the same metric strip; feels templated.*
+- [ ] **Grid breaks where purpose changes.** Section layout shifts when the content's job shifts,
+      instead of repeating one 2–3-chart row down the whole page. *AI tell: "spreadsheet of cards."*
+- [ ] **Accent color is reserved, not sprayed.** Background tint / accent lives on the header band
+      and meaningful emphasis (state, the hero KPI) — not a pale wash on every container. When every
+      surface gets a touch of accent, nothing stands out. *AI tell: decorative accent overuse.*
+- [ ] **Status colors are tuned, not raw defaults.** Conditional-format / KPI semantic colors fit
+      the palette while preserving meaning; not unmodified saturated red/green badge defaults. *AI
+      tell: oversaturated framework-default status colors.*
+- [ ] **Typographic hierarchy.** Header → section title → KPI value → label form a clear scale (size,
+      weight, contrast); not every heading and number competing at the same visual volume. *AI tell:
+      flat typography; "feels like a form, not an application."*
+- [ ] **Alignment is intentional.** Left for text, natural for numbers; centering reserved for
+      genuine moments of emphasis, not applied to every section. *AI tell: centered text everywhere;
+      every section reads like a landing page.*
+- [ ] **Containers are for bands, not decoration.** No chart wrapped in its own card *inside* a band
+      container (card-in-card flattens hierarchy). Separate content levels with spacing, type, and
+      dividers before adding another container. *AI tell: nested cards.*
+- [ ] **Tables use the presentation style.** `table` / `pivot-table` elements carry
+      `tableStyle: {preset: presentation}` (roomier than the dense `spreadsheet` default) unless the
+      source is a true data grid; any source in-cell **data bars** are carried over (`dataBars`).
+
+## Building clean in the first place (so the gate rarely fails)
+
+Group every page into horizontal **band containers** — never a flat list of `<Element>`s:
+header band → control band → KPI band → chart rows → detail row. Verified container contract:
+
+- Spec side: a `kind: container` placeholder element per band.
+- Layout side: a `<Container>` (NOT `<Element type="grid">`, which silently drops
+  children); child `gridRow`/`gridColumn` are **container-relative** (restart at 1);
+  `gridTemplateRows="auto"`; every `elementId` must match a real spec element (mismatch =
+  silent drop); GET before a layout PUT (POST reassigns ids; PUT preserves them).
+
+| Band | Container span | Children |
+|---|---|---|
+| Header | rows `1 / 4`, style `#0F172A` + `round` | full-width title text, inner `1 / 25` |
+| Control row | 3 rows | controls side-by-side, inner row `1 / 4` |
+| KPI row | ≥ 5 rows (≥ 8 if KPIs carry a sparkline/comparison) | N KPIs side-by-side, equal col spans (true peers → equal is correct here) |
+| Chart row | 11–12 rows | 2–3 charts side-by-side, identical inner row span, each ≥ 6 cols |
+| Detail table | content + summary (~4 rows + ~0.7/row) | never a fixed 20 (dead space) |
+
+**Design defaults that keep the render off the anti-pattern list** (apply only where the source
+doesn't dictate otherwise — §3 fidelity caveat):
+
+- **Give the hero its weight.** When a page has one signature viz (the source's largest/top viz, or
+  the primary trend), span it wider than its neighbors instead of forcing it into an equal split.
+  Equal col spans are right for a KPI strip and true comparisons — not for everything.
+- **Vary multi-page openings.** Don't auto-prepend an identical KPI band to every page; lead each
+  page with its own primary content.
+- **Reserve the accent.** Tint the header band and the hero KPI, not every container. Default the
+  rest to the neutral surface.
+- **Let type carry hierarchy.** Header title > section titles > KPI values > labels — don't flatten
+  everything to one size.
+
+**Table style — default to `presentation`.** Set `tableStyle: {preset: presentation}` on every
+`table` / `pivot-table` element (roomier rows, lighter grid lines — matches how most source BI tools
+present tables and reads better than Sigma's dense `spreadsheet` default). Keep `spreadsheet` only when
+the source is explicitly a dense data grid. This is spec-authorable and round-trips but is **frequently
+dropped** in migrations — set it deliberately. While you're styling the table, carry over any source
+in-cell bars with `conditionalFormats: [{type: dataBars, columnIds: [<aggregate col id>], scheme: [<tint>, <hue>]}]`
+(also spec-authorable, also commonly dropped). The scheme must DERIVE from the source — the worksheet's
+`heat_scheme` ramp, else `[mix(dominant, white, 88%), dominant]` from the theme's categoricalScheme;
+never the Sigma default royal `#1a70f1` (round-4 defect). See sigma-workbooks `tables.md` for the full field set.
+
+## Known render caveats (not fixable via spec — keep titles short, drop redundant legends)
+
+- **point-map / region-map**: the element `name` and legend render *overlaid on the map canvas*;
+  a long title collides with legend chips. No legend/title-position knob in the OpenAPI.
+- KPI titles hide below ~5 grid rows. Container style knobs that round-trip: backgroundColor,
+  borderRadius, borderColor, borderWidth, padding (`borderColor/Width` incompatible with
+  `padding: none`).
+
+## Render 500 / CSV-export ceiling — the pivot `totals` key (bisect)
+
+A pivot-table element that carries a **`totals`** key **500s its CSV export** — a platform
+ceiling, not a data defect. Live probe matrix (v5.4, small landed table, 5 single-pivot pages):
+
+| pivot value | no `totals` | with `totals` |
+|---|---|---|
+| plain `Sum`            | CSV ✅ · PNG ✅ | CSV **500** · PNG ✅ |
+| `PercentOfTotal`       | CSV ✅ · PNG ✅ | CSV **500** · PNG ✅ |
+| ratio-of-sums (`a/b`)  | CSV ✅ · PNG ✅ | — |
+
+**The key's PRESENCE is the sole trigger** — value type is irrelevant (plain sum, PercentOfTotal,
+and ratio/division all export fine WITHOUT `totals`; both totals-bearing variants 500). Ratio /
+`PercentOfTotal` values are **NOT** a trigger. **PNG renders tolerate the `totals` key** (all five
+variants rendered), so a totals-bearing pivot still renders with hidden grand totals — but its CSV
+export (verify-anchors' pivot pooling, `collect-parity-actuals`) is dead.
+
+**Mechanism (v5.4; wording + sidecar reachability corrected v5.4.9):** generated pivots CARRY the
+`totals` key from build onward (the chart builder stamps it; style-normalize re-adds it on
+readback) — the only totals-free window is verify-anchors' strip bracket:
+- `verify-anchors.rb` brackets its live pivot CSV exports — capture + strip each pivot's `totals`
+  (one PUT), export against totals-free pivots, then restore (ensure; network-level PUT failures
+  are rescued too, not just HTTP errors). It persists the captured totals to
+  `<workdir>/anchors-restore-pivot-totals.json` BEFORE stripping and deletes it after a successful
+  restore — a hard kill or failed restore is then repaired at the ship step with full fidelity
+  (incl. `showSubtotals`), not the lossy grand-totals-only default.
+- `put-layout.rb --apply-pivot-totals` is the ship-step REPAIR pass once the gates are green
+  (`migrate-tableau.rb --finalize` runs it automatically and passes `--workdir`; run it by hand on
+  the manual/recovery path): any pivot still lacking a `totals` key gets `showGrandTotals:hidden`.
+  An optional `*-pivot-totals.json` sidecar — globbed from the `--layout` dir, the `--workdir`,
+  and the cwd — overrides per element id (e.g. preserves a source pivot's deliberately SHOWN
+  grand totals).
+- `verify-visual-tiles.rb` / `verify-dashboard-visual.rb` NAME this ceiling on a render 500 instead
+  of an opaque MISSING.
+
+**Bisect a render/export 500:** strip the `totals` key first (or run the totals-free export) — if
+it clears, this ceiling is the cause; do **not** waive the gate. Only if it persists totals-free is
+it a genuine unbounded-dimension / service issue.
+
+_Base patterns verified 2026-06-10 on a live Sigma org (three field workbooks)
+against a known-good native-layout reference workbook._

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/mbql-shapes.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/mbql-shapes.md
@@ -1,0 +1,179 @@
+# Metabase source-format shapes (card + dashboard JSON, MBQL)
+
+What the converter parses. Written from the public MBQL reference and API docs,
+then **verified against a live production estate (Metabase Cloud v1.61.4,
+7,023 cards / 1,548 dashboards)**; shapes marked ⚠ have version variants. The
+biggest production finding: modern instances return **pMBQL** ("lib/" MBQL) —
+see the section at the bottom; everything below it is the LEGACY shape the
+converter operates on after `pmbql-normalize.mjs` runs at intake.
+
+## Card JSON (`GET /api/card/{id}`)
+
+```jsonc
+{
+  "id": 123, "name": "Revenue by Month", "description": null,
+  "collection_id": 5, "database_id": 2, "table_id": 45,
+  "type": "question",            // "question" | "model" | "metric"  (⚠ v46–49: models use "dataset": true)
+  "display": "line",             // table|bar|row|line|area|combo|scatter|pie|scalar|smartscalar|gauge|progress|funnel|waterfall|map|pivot|trend
+  "dataset_query": {
+    "type": "query",             // "query" = MBQL | "native" = SQL
+    "database": 2,
+    "query": { ... MBQL, below ... },
+    "native": {                  // only when type = "native"
+      "query": "SELECT ... WHERE category = {{cat}} AND {{date_range}}",
+      "template-tags": {
+        "cat":        { "name": "cat", "display-name": "Category", "type": "text", "default": "Widget" },
+        "date_range": { "name": "date_range", "type": "dimension", "widget-type": "date/range",
+                        "dimension": ["field", 80, null] }   // "field filter" — expands to a WHERE clause
+      }
+    }
+  },
+  "result_metadata": [           // per-result column — the id→name fallback when db metadata is absent
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, {"temporal-unit": "month"}] }
+  ],
+  "visualization_settings": { ... display config, below ... }
+}
+```
+
+## MBQL query (`dataset_query.query`)
+
+```jsonc
+{
+  "source-table": 45,                  // integer table id — OR "card__123" (a nested question/model)
+  "joins": [{
+    "source-table": 50,
+    "alias": "Products",               // join alias — field refs carry {"join-alias": "Products"}
+    "strategy": "left-join",           // left-join | right-join | inner-join | full-join (default left)
+    "condition": ["=", ["field", 90, null], ["field", 91, {"join-alias": "Products"}]],
+    "fields": "all"                    // "all" | "none" | explicit field refs
+  }],
+  "expressions": {                     // custom columns — see expression-dsl.md
+    "Profit": ["-", ["field", 72, null], ["field", 73, null]]
+  },
+  "aggregation": [
+    ["sum", ["field", 72, null]],
+    ["count"],
+    ["aggregation-options", ["sum-where", ["field",72,null], ["=", ["field",81,null], "Widget"]],
+      { "name": "widget_rev", "display-name": "Widget Revenue" }]   // named aggregation wrapper
+  ],
+  "breakout": [ ["field", 80, { "temporal-unit": "month" }] ],     // group-bys
+  "filter": ["and",
+    ["=", ["field", 81, null], "Widget", "Gadget"],                 // = with >1 value ⇒ IN
+    ["time-interval", ["field", 80, null], -30, "day"],
+    ["segment", 7]                                                  // saved segment ref (flag)
+  ],
+  "order-by": [ ["desc", ["aggregation", 0]] ],
+  "limit": 100,
+  "fields": [ ["field", 72, null], ... ]                            // explicit column list (no aggregation)
+}
+```
+
+**Field refs** — the core shape: `["field", <id-int | "name-string">, opts|null]`.
+Opts: `"temporal-unit"` (`day|week|month|quarter|year|hour|…` — bucketing),
+`"join-alias"`, `"base-type"` (set when the id is a literal name, e.g. columns of
+a nested card), `"binning"` (`{"strategy":"num-bins","num-bins":10}` — numeric
+histogram). Integer ids resolve via `GET /api/database/{id}/metadata`
+(`fieldIndex`); string names resolve directly. `["expression", "Profit"]` refs a
+custom column; `["aggregation", 0]` refs an aggregation by position (order-by only).
+
+**Aggregations**: `count`, `sum`, `avg`, `distinct`, `min`, `max`, `median`,
+`stddev`, `var`, `percentile` (`["percentile", field, 0.95]`), `share` (ratio of
+rows matching a condition), `count-where`, `sum-where`, `cum-sum`, `cum-count`,
+legacy `["metric", id]`. Named via the `aggregation-options` wrapper.
+
+## Dashboard JSON (`GET /api/dashboard/{id}`)
+
+```jsonc
+{
+  "id": 9, "name": "Exec Overview",
+  "parameters": [                          // dashboard-level filters → Sigma controls
+    { "id": "abc123", "name": "Date", "slug": "date", "type": "date/range", "default": "past30days" },
+    { "id": "def456", "name": "Category", "slug": "cat", "type": "string/=" }
+  ],
+  "tabs": [ { "id": 1, "name": "Overview" } ],   // ⚠ v49+; dashcards carry dashboard_tab_id
+  "dashcards": [                                 // ⚠ pre-v48: "ordered_cards" with sizeX/sizeY
+    {
+      "id": 1, "card_id": 123,
+      "row": 0, "col": 0, "size_x": 8, "size_y": 6,   // 24-col grid → maps 1:1 to Sigma's 24-col layout
+      "dashboard_tab_id": 1,
+      "card": { ...full card JSON embedded... },
+      "parameter_mappings": [
+        { "parameter_id": "abc123", "card_id": 123,
+          "target": ["dimension", ["field", 80, null]] }   // which column this control filters on this card
+      ],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" }, "text": "## Section header"   // text/heading cards have card_id: null
+      }
+    }
+  ]
+}
+```
+
+## `visualization_settings` keys the converter reads
+
+| Key | Display | Meaning |
+|---|---|---|
+| `graph.dimensions` / `graph.metrics` | bar/line/area/combo/row/scatter/waterfall | x-axis column names / series column names (match `result_metadata.name`) |
+| `stackable.stack_type` | bar/area | `"stacked"` \| `"normalized"` (100%) |
+| `series_settings` | combo | per-series `{"display": "line"\|"bar"}` overrides |
+| `pie.dimension` / `pie.metric` | pie | slice dim + value |
+| `pivot_table.column_split` | pivot | `{"rows": [field refs], "columns": [...], "values": [...]}` → rowsBy/columnsBy/values |
+| `scalar.field` | scalar | which column is THE number |
+| `map.type` | map | `"region"` → region-map; `"pin"` → point-map |
+| `column_settings` | any | per-column `{"number_style": "currency", "decimals": 2, "suffix": …}` → Sigma format |
+| `table.columns` | table | column order + `enabled` (hidden cols) |
+
+## Things that look like data but aren't
+
+- **Text/heading dashcards** — `card_id: null` + `visualization_settings.virtual_card`
+  → Sigma `text` elements (markdown passes through).
+- **Click behavior** (`click_behavior` in viz settings — cross-filter / link) →
+  flagged, not converted (Sigma actions are a manual follow-up).
+- **`trend` / `smartscalar`** — the KPI value converts; the auto "vs previous
+  period" comparison line is flagged (rebuild with a Sigma KPI comparison).
+
+## pMBQL ("lib/" MBQL) — what modern instances ACTUALLY return
+
+**Production finding (2026-06, Metabase Cloud v1.61.4): 100% of a 7,023-card
+estate returned `dataset_query` in pMBQL form**, not the legacy shape above. A
+single card-list response may contain EITHER format depending on instance
+version — sniff the `lib/type` key, never the version string.
+
+```jsonc
+{
+  "lib/type": "mbql/query",
+  "database": 134,
+  "stages": [                                   // legacy nests source-query; pMBQL chains stages
+    {
+      "lib/type": "mbql.stage/mbql",            // or "mbql.stage/native"
+      "source-table": 8391,                     // or "source-card": N  (legacy: "card__N")
+      "aggregation": [["count", {"lib/uuid": "…"}]],
+      "breakout":    [["field", {"lib/uuid": "…", "base-type": "type/DateTime", "temporal-unit": "week"}, 124164]],
+      "filters": [                              // ARRAY (implicit AND) — legacy has a single "filter"
+        ["=", {"lib/uuid": "…"}, ["field", {…}, 124158], "AU"],
+        ["in", {"lib/uuid": "…"}, ["field", {…}, 124161], "A", "B"]   // pMBQL multi-value op
+      ],
+      "expressions": [                          // LIST of clauses — legacy is a {name: clause} map
+        ["datetime-diff", {"lib/uuid": "…", "lib/expression-name": "Cohort Age"}, …]
+      ],
+      "joins": [{ "lib/type": "mbql/join", "alias": "…", "strategy": "left-join",
+                  "stages": [{"source-table": 46}], "conditions": [ … ], "fields": "all" }]
+    }
+  ]
+}
+```
+
+Key invariant: **every pMBQL clause is `[op, {opts}, …args]` — the options map
+is ALWAYS the second element** (legacy puts it last, or third for `field`).
+Native stages carry the SQL directly: `{"lib/type": "mbql.stage/native",
+"native": "<sql>", "template-tags": {…}}` (template-tag `dimension` refs are
+pMBQL field clauses too).
+
+`converter/pmbql-normalize.mjs` (byte-identical copy in
+`metabase-assessment/scripts/`) converts all of this to the legacy shape at
+intake in BOTH skills. It prefers the card's **`legacy_query`** field when
+present — a JSON *string* containing the server's own down-conversion (~70% of
+cards on the reference estate carry it) — and falls back to the local
+normalizer. Multi-stage queries (stages > 1; 14 of 7,023 observed) normalize to
+legacy `source-query` nesting, which the converter FLAGS (rebuild as chained
+Sigma elements), never mistranslates.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/rest-api.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/rest-api.md
@@ -1,0 +1,58 @@
+# Metabase REST API — extraction surface
+
+Everything this skill needs is on Metabase's first-class REST API — open source and
+Pro/EE alike. No private endpoints. Written from the public API docs
+(`<host>/api/docs` on any instance ≥ v48) and **validated read-side against a live
+production estate (Metabase Cloud v1.61.4, 7,023 cards / 1,548 dashboards)**. The
+conversion semantics were subsequently live-validated end to end; the released
+wrapped workbook payload is regression-tested and still passes through the
+mandatory per-run POST/readback/parity gates. Modern instances return `dataset_query` in
+**pMBQL** form and often include a `legacy_query` JSON string — see
+`mbql-shapes.md` § pMBQL.
+
+## Auth (two options)
+
+| Method | How | Notes |
+|---|---|---|
+| **API key** (preferred, v49+) | Admin → Settings → **Authentication → API keys** → create key (group: Administrators for full read). Send header `x-api-key: <key>` | Durable; the right choice for an engagement |
+| **Session token** | `POST /api/session {"username": "...", "password": "..."}` → `{"id": "<token>"}`. Send header `X-Metabase-Session: <token>` | Sessions expire (default 14 days, sooner with SSO); on 401 re-login |
+
+`scripts/get-metabase-session.sh` captures either into `MB_BASE` / `MB_KEY` /
+`MB_SESSION` env vars. All requests below are plain `GET`s — read-only.
+
+## Endpoints used
+
+| Need | Endpoint | Notes |
+|---|---|---|
+| Probe / version | `GET /api/session/properties` | `version.tag` — no auth needed for basic properties |
+| Databases | `GET /api/database` | `data[]` of `{id, name, engine}` — find the warehouse conn (e.g. `snowflake`) |
+| **Schema metadata** | `GET /api/database/{id}/metadata` | tables + **fields with ids** — REQUIRED: MBQL refs fields by integer id; this is the id→column map. Each field: `{id, name, display_name, base_type, semantic_type, fk_target_field_id, table_id}`; each table: `{id, name, schema, fields[]}` |
+| Collections (folder tree) | `GET /api/collection` | flat list with `location` path (`/3/7/`); `personal_owner_id` ≠ null = personal space |
+| Collection items | `GET /api/collection/{id}/items?models=card&models=dashboard&models=dataset` | paginated (`limit`/`offset`, default 50ish); `data[]` of `{id, model, name}` |
+| **Card (question/model) def** | `GET /api/card/{id}` | the full definition incl `dataset_query` (MBQL or native), `display`, `visualization_settings`, `result_metadata` — see `refs/mbql-shapes.md` |
+| **All cards (bulk)** | `GET /api/card` | unpaginated — returns EVERY card **with its full definition** in one response (~110MB for 7k cards on the reference estate). Stream to disk, then split locally (`metabase-assessment/scripts/mb-bulk-split.py`). This beats the per-item walk by ~60× on big estates |
+| **Single field** | `GET /api/field/{id}` | field-id → `{name, display_name, table_id, base_type}`. The fallback when `/api/database/{id}/metadata` 403s on a scoped key — **worked even for restricted DBs on the reference estate**. Resolution chain: db metadata → card `result_metadata` → `GET /api/field/{id}` → names from the SQL when native |
+| **Dashboard def** | `GET /api/dashboard/{id}` | `dashcards[]` with grid geometry + embedded `card` + `parameter_mappings`; top-level `parameters[]`, `tabs[]` |
+| Search | `GET /api/search?q=...&models=card` | quick lookup by name |
+| Recent views | `GET /api/activity/recents` | thin usage signal (see assessment skill's `usage-telemetry.md`) |
+
+## Version-shape gotchas (handle both)
+
+- **`dashcards` vs `ordered_cards`** — renamed in ~v48. Old shape uses
+  `ordered_cards[].sizeX/sizeY`; new uses `dashcards[].size_x/size_y`. The
+  converter accepts both.
+- **Models**: v50+ marks them `type: "model"` on the card; v46–49 use
+  `dataset: true`. Older "metrics"/"segments" (`/api/legacy-metric`,
+  `["metric", id]` / `["segment", id]` MBQL refs) still appear in old cards;
+  v50+ adds first-class metric cards (`type: "metric"`).
+- **Dashboard grid** is **24 columns** wide on current versions (older ~v44-
+  exports used 18 — detect by max `col + size_x` if layout looks compressed).
+- **Serialization export** (YAML bundles via `/api/ee/serialization/export`) is
+  **Pro/EE-only** — do not depend on it; the REST walk above works on OSS.
+
+## Offline mode
+
+Every converter input is a plain JSON file (`card.json`, `dashboard.json`,
+`metadata.json`), so the whole pipeline runs against files on disk — a customer
+can mail you `GET` outputs without granting access. `scripts/metabase-discover.sh`
+writes exactly these files.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/template-tags.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/template-tags.md
@@ -1,0 +1,105 @@
+# Template tags → Sigma controls
+
+Native-SQL template tags are the single most common Metabase feature in the
+wild: **45% of cards** on the reference production estate (7,023 cards,
+Metabase Cloud v1.61) carry at least one tag. Tag-type distribution observed
+there: text 5,629 · date 2,364 · dimension (field filter) 1,914 · number 1,002 ·
+card 384 · boolean 47.
+
+> ## ⚠️ 2026-06-15 — PREFER native-model remodel; custom-SQL control binding is INERT
+>
+> **Live-disproven (a validation org):** a *workbook* control bound only to a DM
+> custom-SQL `{{param}}` does NOT filter — a text grain control is ignored and a
+> numeric one mis-substitutes and breaks the query (0 rows). So the
+> `{{tag}}`-kept-verbatim path below only works when the user manually wires the
+> control to the DM parameter in the Sigma UI. Two consequences in the converter:
+>
+> 1. **Simple native SQL is auto-remodeled to a NATIVE Sigma data model** — a
+>    card that is a single `SELECT` over warehouse table(s) (no CTE / subquery /
+>    CASE / window / set-op, only field-filter tags, real WHERE only on those
+>    tags) is re-expressed as a structured query and built as a table/join model
+>    (no custom SQL). Its columns are exposed, so field filters reproduce as REAL
+>    Sigma controls + element filters that actually filter — verified live (a
+>    `last_name` control flips a chart 5→1 rows). This is the path to working
+>    filters; **the mapping table below is the FALLBACK for SQL too complex to
+>    remodel.**
+> 2. **No dead furniture:** a control whose only wiring would be a DM-SQL
+>    `{{param}}` (or a field-filter column missing from the result set) is NOT
+>    emitted — it goes into the result's `unreproducibleFilters` report
+>    (controlId / name / reason / hint) so the migration surfaces exactly what
+>    still needs a manual remodel. See design-notes.md "native-model remodel".
+
+The fact behind the fallback path: **Sigma custom SQL uses the same
+`{{control-id}}` parameter syntax as Metabase**, so a plain variable tag's SQL
+needs NO rewrite — but per the warning above, that control must be wired to the
+DM parameter in the UI to actually filter.
+
+## Mapping table
+
+| Tag type | Converter behavior | Sigma artifact |
+|---|---|---|
+| `text` | `{{tag}}` kept **verbatim** in the SQL | `controlType: text` control, `controlId` = tag name, `value` = tag default |
+| `number` | verbatim | `controlType: number` control (verify on first live POST — `number-range` is the spec-verified shape; single-value number is doc-derived) |
+| `date` | verbatim | `controlType: date` control |
+| `boolean` | verbatim | `controlType: switch` control |
+| `dimension` (**field filter**) | `{{tag}}` replaced with `1=1 /* … */` + loud warning | control + element filter on the mapped column, recreated on the **consuming workbook element** |
+| `card` (`{{#N-…}}`) | inlined as `( <card N SQL> )` when card N is in the input set, native, and tag-free; otherwise flagged | — |
+| `snippet` | flagged — inline `GET /api/native-query-snippet` by hand | — |
+
+Controls are emitted as `kind: control` elements on the data-model page (the
+custom SQL lives in the DM, so the `{{tag}}` reference must resolve there).
+The tag's `display-name` becomes the control name; `default` becomes `value`.
+A `required: true` tag with no default is warned about — the element errors
+until the control has a value.
+
+## Field filters (`type: dimension`) — why `1=1`
+
+A Metabase field filter does **not** substitute a scalar: at runtime it expands
+to a **whole SQL predicate** on the mapped column (`WHERE {{order_date}}` →
+`WHERE ORDER_DATE BETWEEN … AND …`), driven by the widget type. There is no
+Sigma equivalent inside custom SQL, so the converter:
+
+1. Replaces `{{tag}}` with `1=1 /* Metabase field filter {{tag}} → filter [Col]
+   on the consuming Sigma element */` — semantically the "no value selected"
+   state, and always safe because a dimension tag can only legally appear in
+   boolean-predicate position.
+2. Resolves the tag's `dimension` field ref to the column (metadata →
+   result_metadata → `GET /api/field/{id}`) and tells you (warning + the
+   dashboard converter's `parameterWiring`) to recreate it as a Sigma control +
+   element filter on that column.
+3. If the mapped column is **not** in the card's SELECT output, the filter
+   cannot be recreated on the element — flagged as ambiguous; add the column to
+   the SQL first.
+
+## Optional `[[ … ]]` blocks
+
+Metabase includes an optional block only when its tag has a value (24% of the
+reference estate's cards use them). Sigma has no optional-clause syntax:
+
+- every tag in the block is a **field filter** → block kept active (they
+  neutralize to `1=1`, so always-on is harmless);
+- every variable tag in the block **has a default** → block kept active
+  (matches Metabase's default state) + warning;
+- otherwise → block **dropped** (matches Metabase's empty-value behavior) +
+  loud warning listing the dropped clause.
+
+## Dashboard parameters driving tags
+
+On production estates, dashboard `parameter_mappings` overwhelmingly target
+template tags, not columns (13,474 `["variable",["template-tag",…]]` +
+1,057 dimension targets of 14,600 mappings observed). The dashboard converter
+records these in the result's `parameterWiring` array and emits ONE aggregated
+warning per parameter. Consolidation is manual today: either keep the DM
+control as the single source of truth, or sync the workbook control to it.
+
+`["dimension",["template-tag",…]]` targets (a parameter driving a field-filter
+tag) are auto-wired to a hidden boolean + include-`[true]` element filter when
+the tag's column is in the card's result set.
+
+## SQL dialect passthrough
+
+The statement (after tag handling) is emitted **verbatim** into the Sigma
+custom-SQL element — the dialect passes straight through to the warehouse. A
+same-warehouse migration (e.g. BigQuery→BigQuery: `project.dataset.table` refs,
+trailing-comma SELECTs) is near-verbatim; cross-warehouse migrations need a SQL
+transpile pass first.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/apply-layout.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/apply-layout.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+// apply-layout.mjs — give a migrated Metabase workbook a CLEAN dashboard grid.
+//
+// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as tables,
+// charts squished) — so for any multi-element page we write an explicit 24-col layout:
+// controls in a top row, then content stacked full-width with per-kind heights. Layout
+// CREATE preserves element ids and the converter already emits this layout.
+// This script GETs the current document and reapplies it as the final,
+// layout-safe full-document write after any post-create repair.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/apply-layout.mjs --workbook <workbookId> [--hints layout-hints.json]
+//
+// --hints (from `cli.ts … --layout-out hints.json`) reproduces the ORIGINAL
+// Metabase dashboard geometry 1:1 (24-col grid, row/col/sizeX/sizeY per element;
+// element ids are preserved on workbook CREATE so hints match the live spec).
+// Controls aren't Metabase dashcards, so they get a top band; hinted content is
+// placed below at exact coordinates; unhinted leftovers stack at the bottom.
+// Without --hints, falls back to the generic per-kind stacked layout.
+//
+// Idempotent. Run it as the last step of the build/verify phase.
+import { readFileSync } from 'node:fs';
+import { api, parseArgs } from './lib/sigma-rest.mjs';
+import { document, workbookElements, workbookElementsWithPages, wrap } from './lib/code_rep.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.workbook) { console.error('need --workbook <workbookId> [--hints hints.json]'); process.exit(2); }
+const hints = a.hints ? JSON.parse(readFileSync(a.hints, 'utf8')) : null;
+const ROWSCALE = 2; // Metabase row unit → Sigma grid rows (proportions, rows are "auto")
+
+// per-kind row-unit heights (24-col grid; rows are "auto" so spans set relative size)
+const H = (k) => k === 'control' ? 2
+  : k === 'kpi-chart' ? 6
+  : k.endsWith('-chart') ? 10
+  : (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
+  : k === 'text' ? 3 : 10;
+
+// Exact mode: place each hinted element at its Metabase grid coordinates.
+function pageLayoutExact(page, els, hintEls) {
+  els = (els || []).filter((e) => e.id);
+  const byId = new Map(els.map((e) => [e.id, e]));
+  // name fallback queues (texts share names — consume in order)
+  const byName = new Map();
+  for (const e of els) {
+    const k = String(e.name || e.kind || '').toLowerCase();
+    if (!byName.has(k)) byName.set(k, []);
+    byName.get(k).push(e);
+  }
+  const controls = els.filter((e) => e.kind === 'control');
+  const lines = [];
+  let row = 1;
+  controls.forEach((c, i) => {
+    const perRow = Math.min(controls.length, 4);
+    const span = Math.floor(24 / perRow);
+    const col0 = 1 + (i % perRow) * span;
+    const r = row + Math.floor(i / perRow) * H('control');
+    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+    lines.push(`  <Element elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
+  });
+  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
+
+  const placed = new Set(controls.map((c) => c.id));
+  let maxRow = row;
+  for (const h of hintEls || []) {
+    let el = byId.get(h.elementId);
+    if (!el || placed.has(el.id)) {
+      const q = byName.get(String(h.name || '').toLowerCase()) || [];
+      el = q.find((e) => !placed.has(e.id));
+    }
+    if (!el || placed.has(el.id) || el.kind === 'control') continue;
+    placed.add(el.id);
+    const c0 = Math.max(1, (h.col ?? 0) + 1);
+    const c1 = Math.min(25, c0 + Math.max(h.sizeX ?? 4, 1));
+    const r0 = row + (h.row ?? 0) * ROWSCALE;
+    const r1 = r0 + Math.max((h.sizeY ?? 4) * ROWSCALE, 2);
+    lines.push(`  <Element elementId="${el.id}" gridColumn="${c0} / ${c1}" gridRow="${r0} / ${r1}"/>`);
+    if (r1 > maxRow) maxRow = r1;
+  }
+  // anything unhinted stacks full-width below the hinted grid
+  for (const e of els) {
+    if (placed.has(e.id)) continue;
+    const h = H(e.kind);
+    lines.push(`  <Element elementId="${e.id}" gridColumn="1 / 25" gridRow="${maxRow} / ${maxRow + h}"/>`);
+    maxRow += h;
+  }
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+}
+
+function pageLayout(page, els) {
+  els = (els || []).filter((e) => e.id);
+  const controls = els.filter((e) => e.kind === 'control');
+  const content = els.filter((e) => e.kind !== 'control');
+  const lines = [];
+  let row = 1;
+  // controls: up to 4 across the top
+  controls.forEach((c, i) => {
+    const perRow = Math.min(controls.length, 4);
+    const span = Math.floor(24 / perRow);
+    const col0 = 1 + (i % perRow) * span;
+    const r = row + Math.floor(i / perRow) * H('control');
+    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+    lines.push(`  <Element elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
+  });
+  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
+  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions).
+  // Exception: RUNS of consecutive kpi-charts lay out as rows of up to 3 TALL tiles
+  // (a KPI panel) — full-width singles waste a page and Sigma hides the KPI title
+  // below ~5 grid rows, so never shrink them either.
+  for (let i = 0; i < content.length; i++) {
+    const e = content[i];
+    if (e.kind === 'kpi-chart') {
+      let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
+      const run = content.slice(i, j);
+      const perRow = Math.min(run.length, 3);
+      const span = Math.floor(24 / perRow);
+      run.forEach((k, n) => {
+        const col0 = 1 + (n % perRow) * span;
+        const col1 = (n % perRow === perRow - 1) ? 25 : col0 + span;
+        const r = row + Math.floor(n / perRow) * H('kpi-chart');
+        lines.push(`  <Element elementId="${k.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('kpi-chart')}"/>`);
+      });
+      row += Math.ceil(run.length / perRow) * H('kpi-chart');
+      i = j - 1;
+      continue;
+    }
+    const h = H(e.kind);
+    lines.push(`  <Element elementId="${e.id}" gridColumn="1 / 25" gridRow="${row} / ${row + h}"/>`);
+    row += h;
+  }
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+}
+
+const got = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+if (!got.json) { console.error(`GET spec failed (HTTP ${got.status}): ${got.text.slice(0, 300)}`); process.exit(1); }
+const spec = document(got.json);
+const elements = workbookElements(got.json);
+const elementsByPage = new Map((spec.pages || []).map((page) => [page.id, []]));
+const unplaced = [];
+for (const [element, page] of workbookElementsWithPages(got.json)) {
+  if (page?.id && elementsByPage.has(page.id)) elementsByPage.get(page.id).push(element);
+  else unplaced.push(element);
+}
+// A legacy no-layout artifact has no page ownership. Keep it recoverable by
+// assigning its elements to the first metadata page before generating layout.
+if (unplaced.length && spec.pages?.[0]) elementsByPage.get(spec.pages[0].id).push(...unplaced);
+
+// Layout is one `document.layout` XML string. Pages contain metadata only;
+// element ownership comes from each <Page> block.
+const hintPageByName = new Map((hints?.pages || []).map((p) => [String(p.name || '').toLowerCase(), p.elements || []]));
+const pageBlocks = [];
+let exactPages = 0;
+for (const p of spec.pages || []) {
+  const pageElements = elementsByPage.get(p.id) || [];
+  const hintEls = hintPageByName.get(String(p.name || '').toLowerCase());
+  const xml = hintEls?.length
+    ? (exactPages++, pageLayoutExact(p, pageElements, hintEls))
+    : pageLayout(p, pageElements);
+  if (xml) pageBlocks.push(xml);
+}
+if (hints) console.error(`exact-grid pages: ${exactPages}/${(spec.pages || []).length}`);
+if (!pageBlocks.length || !elements.length) { console.log('no workbook elements — nothing to lay out'); process.exit(0); }
+spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
+
+// PUT replaces the entire workbook document and accepts only {document:{...}}.
+const put = await api('PUT', `/v2/workbooks/${a.workbook}/spec`, wrap(spec));
+if (!put.ok) { console.error(`PUT failed (HTTP ${put.status}): ${put.text.slice(0, 400)}`); process.exit(1); }
+
+// verify the layout survived readback
+const rb = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+const ok = /<Element\b/.test(document(rb.json).layout || '');
+console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
+if (!ok) { console.error('FAIL: layout did not survive readback (check elementId matches)'); process.exit(1); }
+console.error(`clean layout applied (${pageBlocks.length} page block(s))`);
+
+// shared layout lint on the laid-out readback spec (same lib gate 6 runs —
+// scripts/lib/layout_lint.rb, vendored byte-identical across plugins)
+{
+  const { writeFileSync } = await import('node:fs');
+  const { dirname, join } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+  const { spawnSync } = await import('node:child_process');
+  const tmp = `/tmp/layout-lint-${a.workbook}.spec.json`;
+  writeFileSync(tmp, JSON.stringify(rb.json, null, 2));
+  const lint = spawnSync('ruby', [join(dirname(fileURLToPath(import.meta.url)), 'lib', 'layout_lint.rb'), tmp], { stdio: 'inherit' });
+  if (lint.status !== 0) { console.error('FAIL: layout lint violations on the applied layout (see above) — fix and re-run.'); process.exit(1); }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/apply_sigma_rls.py
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/apply_sigma_rls.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Phase 1.5 (RLS decision gate) — apply a Looker RLS finding to Sigma, scripted.
+
+Sigma user attributes are FULLY API-supported (confirmed live 2026-06-10):
+  - GET  /v2/user-attributes            list (reuse-first)
+  - POST /v2/user-attributes            create
+  - POST /v2/user-attributes/{id}/users assign a value to a member
+And the Sigma RLS row-filter is fully spec-expressible (NOT UI-only): a boolean
+calc column `CurrentUserAttributeText("<attr>") = [<Field>]` on the base element
+plus an element `filters` entry `{kind:list, mode:include, values:[true]}`.
+
+This script does the whole flow, REUSE-FIRST and SAFE-BY-DEFAULT:
+  1. attribute   GET /v2/user-attributes → print a match if one already exists
+                 (by name, case-insensitive) before creating anything.
+  2. provision   --create  → POST /v2/user-attributes when nothing reusable exists.
+                 --assign   → POST /v2/user-attributes/{id}/users (needs --member-id
+                 + --value) to assign the attribute value to a member.
+  3. apply       --field <DisplayName> (+ --element-id/--dm-id) → print the RLS
+                 calc-column + element-filter spec snippet; with --apply, PATCH it
+                 into the DM element's spec (GET/PUT /v2/dataModels/{id}/spec).
+
+By default this only READS and PRINTS a plan — it mutates ONLY when you pass an
+explicit --create / --assign / --apply flag. Mirrors post_dm.py: reads
+$SIGMA_BASE_URL / $SIGMA_API_TOKEN from env (eval "$(scripts/get-token.sh)").
+Dependency-free (stdlib only).
+
+Live-validated: this exact flow produced exact 3-way parity (Looker-restricted ==
+Sigma-restricted == warehouse: $38,906.82 / 220 rows, region=West).
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  # reuse-first lookup only (default, read-only):
+  python3 apply_sigma_rls.py --attr region
+  # create the attribute if missing:
+  python3 apply_sigma_rls.py --attr region --value West --create
+  # assign a value to the querying member:
+  python3 apply_sigma_rls.py --attr region --value West --member-id <id> --assign
+  # print the RLS spec snippet for a DM element (plan only):
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid>
+  # ...and PATCH it into the DM element spec:
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid> \
+      --dm-id <dataModelId> --apply
+
+BATCH MODE (tool-agnostic) — ingest a converter's result.security[] (architecture B:
+the converter REPORTS RLS/CLS; this script provisions + applies). Handles RLS via
+user attribute / team (CurrentUserInTeam) / email, and CLS (columnSecurities):
+  # 1) convert + POST the model (converter injects NO RLS), capture dataModelId
+  # 2) write result.security to a JSON file, then:
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId>            # plan only
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId> --provision --apply
+Elements match by name (Sigma reassigns ids on POST); CLS columns match by normalized
+name. --provision creates missing attributes/teams (assign per-user values separately).
+Works for tableau/quicksight/powerbi/thoughtspot/qlik/lookml converter output alike.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL")
+TOK = os.environ.get("SIGMA_API_TOKEN")
+
+
+def api(method, path, body=None):
+    if not BASE or not TOK:
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr)
+        raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # spec endpoints return YAML
+
+
+def _short_id(prefix="rls"):
+    """A short, deterministic-enough id for a calc column / filter."""
+    import hashlib
+    return prefix + "-" + hashlib.md5(prefix.encode() + os.urandom(4)).hexdigest()[:8]
+
+
+# --- 1. reuse-first attribute lookup --------------------------------------
+def find_attribute(name):
+    """Return the existing user-attribute entry matching `name` (case-insensitive), else None."""
+    res = api("GET", "/v2/user-attributes?limit=200")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+
+def list_attributes():
+    res = api("GET", "/v2/user-attributes?limit=200")
+    return res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+
+
+# --- 3. RLS spec snippet --------------------------------------------------
+def rls_spec_snippet(attr, field, element_id):
+    """The verified row-filter shape: a boolean calc column + an element list filter showing only True."""
+    col_id = _short_id("rlscol")
+    filt_id = _short_id("rlsf")
+    calc = {
+        "id": col_id,
+        "name": f"RLS {attr}",
+        "formula": f'CurrentUserAttributeText("{attr}") = [{field}]',
+    }
+    filt = {
+        "id": filt_id,
+        "columnId": col_id,
+        "kind": "list",
+        "mode": "include",
+        "values": [True],
+    }
+    return {
+        "elementId": element_id,
+        "calcColumn": calc,
+        "filter": filt,
+        "_note": (
+            f'Add calcColumn to element "{element_id}" columns, and `filter` to that '
+            f"element's filters[]. CurrentUserAttributeText(\"{attr}\") = [{field}] is the "
+            "user-attribute mode; team mode = CurrentUserInTeam([...]); email mode = "
+            "[Email] = CurrentUserEmail()."
+        ),
+    }
+
+
+def apply_to_dm(dm_id, element_id, calc, filt):
+    """PATCH the calc column + filter into the DM element's spec (GET → mutate → PUT)."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        # spec endpoints can return YAML; we can't safely mutate that here.
+        sys.exit("DM spec came back non-JSON (YAML) — cannot auto-PATCH; apply the snippet by hand.")
+    # The spec shape nests elements under the model; search for the element by id.
+    found = _inject(spec, element_id, calc, filt)
+    if not found:
+        sys.exit(f"element id {element_id} not found in DM {dm_id} spec — check --element-id")
+    res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+    print("PUT /v2/dataModels/%s/spec ->" % dm_id,
+          json.dumps(res)[:300] if isinstance(res, dict) else str(res)[:300])
+
+
+def _inject(node, element_id, calc, filt):
+    """Recursively find an element dict whose id == element_id; add calc col + filter. Returns True if injected."""
+    if isinstance(node, dict):
+        if node.get("id") == element_id and ("columns" in node or "kind" in node or "source" in node):
+            cols = node.setdefault("columns", [])
+            if not any(c.get("id") == calc["id"] for c in cols if isinstance(c, dict)):
+                cols.append(calc)
+            filters = node.setdefault("filters", [])
+            filters.append(filt)
+            return True
+        for v in node.values():
+            if _inject(v, element_id, calc, filt):
+                return True
+    elif isinstance(node, list):
+        for v in node:
+            if _inject(v, element_id, calc, filt):
+                return True
+    return False
+
+
+
+# --- shared engine: teams, element/column resolution, CLS, batch from result.security ---
+def find_team(name):
+    res = api("GET", "/v2/teams?limit=500")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+def ensure_team(name, do_create):
+    t = find_team(name)
+    if t:
+        print(f"  REUSE team '{name}' (id={t.get('teamId') or t.get('id')}).")
+        return t.get("teamId") or t.get("id")
+    if do_create:
+        res = api("POST", "/v2/teams", {"name": name})
+        tid = res.get("teamId") or res.get("id") if isinstance(res, dict) else None
+        print(f"  CREATED team '{name}' (id={tid}). NOTE: add members via POST /v2/teams/{tid}/members.")
+        return tid
+    print(f"  (plan: team '{name}' missing — pass --provision to create it, then add members.)")
+    return None
+
+def _walk_elements(node, out):
+    if isinstance(node, dict):
+        if node.get("id") and ("columns" in node or "kind" in node):
+            out.append(node)
+        for v in node.values():
+            _walk_elements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_elements(v, out)
+    return out
+
+def _resolve_element(spec, element_id, element_name):
+    els = _walk_elements(spec, [])
+    for e in els:
+        if element_id and e.get("id") == element_id:
+            return e
+    for e in els:                                  # Sigma reassigns ids on POST → match by name
+        if element_name and (e.get("name") == element_name):
+            return e
+    # last resort: a path-tail match (warehouse-table element named by table)
+    for e in els:
+        path = (e.get("source") or {}).get("path") or []
+        if element_name and path and str(path[-1]).upper() == str(element_name).upper():
+            return e
+    return None
+
+def _norm(x):
+    """Normalize a column name for matching across raw/display forms (NET_PROFIT == Net Profit)."""
+    return __import__("re").sub(r"[^a-z0-9]", "", (x or "").lower())
+
+def _resolve_col_ids(element, names):
+    """Map raw-or-display column names -> live column ids (formula tail or name, normalized)."""
+    out = []
+    re = __import__("re")
+    for nm in (names or []):
+        cid = None
+        for c in (element.get("columns") or []):
+            cand = c.get("name") or ""
+            f = c.get("formula") or ""
+            m = re.match(r"^\[(?:[^\]/]+/)?([^\]]+)\]$", f)
+            if m:
+                cand = cand or m.group(1)
+                if _norm(m.group(1)) == _norm(nm): cid = c.get("id"); break
+            if _norm(cand) == _norm(nm): cid = c.get("id"); break
+        if cid: out.append(cid)
+        else: print(f"  WARN: CLS column '{nm}' not found on element — skipped.")
+    return out
+
+def apply_from_security(dm_id, security, do_apply, do_provision):
+    """Provision attrs/teams + apply RLS calc/filter and CLS for each result.security entry."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        sys.exit("DM spec came back non-JSON — cannot auto-apply.")
+    applied = 0
+    def _elname(e): return e.get('name') or ((e.get('source') or {}).get('path') or ['?'])[-1]
+    for rule in security:
+        el = _resolve_element(spec, rule.get("elementId"), rule.get("elementName"))
+        if not el:
+            print(f"⚠ {rule.get('kind')} on element '{rule.get('elementName')}' — not found in DM {dm_id}; skipped."); continue
+        if rule.get("kind") == "rls" and rule.get("rls"):
+            r = rule["rls"]
+            print(f"RLS → element '{_elname(el)}': {r['formula'][:80]}")
+            for attr in (r.get("userAttributes") or []):
+                ex = find_attribute(attr)
+                if ex: print(f"  REUSE attribute '{attr}'.")
+                elif do_provision:
+                    api("POST", "/v2/user-attributes", {"name": attr, "defaultValue": {"val": "", "type": "string"}})
+                    print(f"  CREATED attribute '{attr}'. NOTE: assign per-user values via POST /v2/user-attributes/{{id}}/users.")
+                else: print(f"  (plan: attribute '{attr}' — pass --provision to create; then assign per-user values.)")
+            for team in (r.get("teams") or []):
+                ensure_team(team, do_provision)
+            calc = {"id": _short_id("rlscol"), "name": r.get("name") or "RLS", "formula": r["formula"]}
+            filt = {"id": _short_id("rlsf"), "columnId": calc["id"], "kind": "list", "mode": "include", "values": [True]}
+            if do_apply:
+                el.setdefault("columns", []).append(calc)
+                el.setdefault("filters", []).append(filt); applied += 1
+        elif rule.get("kind") == "cls" and rule.get("cls"):
+            c = rule["cls"]
+            ids = _resolve_col_ids(el, c.get("restrictedColumnNames"))
+            print(f"CLS → element '{_elname(el)}': hide {c.get('restrictedColumnNames')}")
+            if do_apply and ids:
+                el.setdefault("columnSecurities", []).append({"id": _short_id("cls"), "criteria": c.get("criteria") or {"kind": "no-one-can-view"}, "restrictedColumns": ids}); applied += 1
+    if do_apply and applied:
+        res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+        print(f"PUT spec -> applied {applied} rule(s):", (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif not do_apply:
+        print("\n(plan only — pass --apply --dm-id <id> to PATCH these into the DM spec; --provision to create attributes/teams.)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Apply a Looker RLS finding to Sigma (safe-by-default).")
+    ap.add_argument("--attr", help="Sigma user-attribute name (e.g. region)")
+    ap.add_argument("--value", help="attribute value (for --create defaultValue / --assign)")
+    ap.add_argument("--description", help="description when creating the attribute")
+    ap.add_argument("--member-id", help="Sigma memberId to assign the value to (with --assign)")
+    ap.add_argument("--field", help="DM column display name to filter on (e.g. Region) — for the RLS snippet")
+    ap.add_argument("--element-id", help="DM element id the RLS calc col + filter attach to")
+    ap.add_argument("--dm-id", help="dataModelId (with --apply, to PATCH the element spec)")
+    ap.add_argument("--create", action="store_true", help="create the user attribute if no reusable match")
+    ap.add_argument("--assign", action="store_true", help="assign --value to --member-id")
+    ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
+    ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
+    ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    a = ap.parse_args()
+
+    # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
+    if a.from_security:
+        if not a.dm_id:
+            sys.exit("--from-security requires --dm-id (the posted data model).")
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        return apply_from_security(a.dm_id, security, a.apply, a.provision)
+
+    if not a.attr:
+        sys.exit("Provide --attr (single-rule mode) or --from-security <json> (batch mode).")
+    # --- 1. reuse-first --------------------------------------------------
+    existing = find_attribute(a.attr)
+    attr_id = None
+    if existing:
+        attr_id = existing.get("userAttributeId") or existing.get("id")
+        print(f"REUSE: user attribute '{a.attr}' already exists "
+              f"(id={attr_id}, default={existing.get('defaultValue')}) — reusing, NOT creating.")
+    else:
+        print(f"No existing Sigma user attribute named '{a.attr}'.")
+        if a.create:
+            body = {"name": a.attr}
+            if a.description:
+                body["description"] = a.description
+            if a.value is not None:
+                body["defaultValue"] = {"val": a.value, "type": "string"}
+            res = api("POST", "/v2/user-attributes", body)
+            attr_id = res.get("userAttributeId") or res.get("id") if isinstance(res, dict) else None
+            print(f"CREATED user attribute '{a.attr}' (id={attr_id}).")
+        else:
+            print("  (plan only — pass --create to create it.)")
+
+    # --- 2. assign -------------------------------------------------------
+    if a.assign:
+        if not attr_id:
+            sys.exit("--assign needs an attribute id — create/reuse it first (no id resolved).")
+        if not a.member_id or a.value is None:
+            sys.exit("--assign requires --member-id and --value.")
+        body = {"assignments": [{"userId": a.member_id, "value": {"val": a.value, "type": "string"}}]}
+        res = api("POST", f"/v2/user-attributes/{attr_id}/users", body)
+        print(f"ASSIGNED '{a.attr}'={a.value} to member {a.member_id}: "
+              + (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif a.value is not None and a.member_id:
+        print(f"  (plan: would assign '{a.attr}'={a.value} to member {a.member_id} — pass --assign.)")
+
+    # --- 3. RLS spec snippet --------------------------------------------
+    if a.field:
+        if not a.element_id:
+            print("\nNOTE: --field given without --element-id; printing the formula only.")
+            print(f'  calc column formula: CurrentUserAttributeText("{a.attr}") = [{a.field}]')
+        else:
+            snip = rls_spec_snippet(a.attr, a.field, a.element_id)
+            print("\nRLS spec snippet (verified shape — boolean calc col + element list filter on True):")
+            print(json.dumps(snip, indent=2))
+            if a.apply:
+                if not a.dm_id:
+                    sys.exit("--apply requires --dm-id.")
+                apply_to_dm(a.dm_id, a.element_id, snip["calcColumn"], snip["filter"])
+            else:
+                print("  (plan only — pass --apply --dm-id <id> to PATCH it into the DM element spec.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/assert-parity.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/assert-parity.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// assert-parity.mjs — the verification GATE. Two modes.
+//
+// PLAN: given a posted workbook (or data model) id, emit one Sigma query per
+// element so the agent can pull Sigma's actuals and compare to the Metabase source.
+//   node scripts/assert-parity.mjs --plan --type workbook --id <workbookId>
+//   node scripts/assert-parity.mjs --plan --type datamodel --id <dataModelId>
+//
+// CHECK: given the agent's saved query results + an expected baseline (the numbers
+// from the Metabase report / source warehouse), confirm parity within tolerance.
+//   node scripts/assert-parity.mjs --check --actual actual.json --expected expected.json [--tol 0.01]
+//     [--workdir DIR]            # write the gate sentinels here (default: dirname of --actual):
+//                                #   parity-final.json  (gate 1 of assert-phase6-ran.rb)
+//   actual.json / expected.json: { "<label>": <number>, ... }  (per-dimension or totals)
+//     [--census '<json>']        # optional tile census {zones_total, charts_built,
+//                                #   zones_unmatched, unmatched_zone_names:[]} — gate 5;
+//                                #   derive from the converter stats (dashcards vs built)
+//
+// A migration is GREEN only when --check passes AND `ruby scripts/assert-phase6-ran.rb
+// --workdir <dir> --workbook-id <id>` exits 0 (all 7 gates). Do not declare success
+// on a 200 POST alone.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { api, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+
+if (a.plan) {
+  if (!a.id || !a.type) { console.error('need --type workbook|datamodel --id <id>'); process.exit(2); }
+  const scope = a.type === 'workbook' ? 'workbook' : 'datamodel';
+  const els = elementsOf((await api('GET', a.type === 'workbook' ? `/v2/workbooks/${a.id}/elements` : `/v2/dataModels/${a.id}/elements`)).json);
+  console.log(`# Parity plan for ${a.type} ${a.id} — run each SQL statement through Sigma MCP or the query API, then compare to the Metabase source.\n`);
+  for (const e of els) {
+    console.log(`## ${e.name} (${e.kind || 'element'})  elementId=${e.id}`);
+    console.log(`scope=${scope}  ${a.type === 'workbook' ? 'workbookId' : 'dataModelId'}=${a.id}`);
+    console.log(`  sql: SELECT * FROM "${scope}"."${e.id}" LIMIT 50\n`);
+  }
+  console.log('Then save the per-element totals/dimension values to actual.json and run --check against the Metabase numbers.');
+  process.exit(0);
+}
+
+if (a.check) {
+  if (!a.actual || !a.expected) { console.error('need --actual <json> --expected <json>'); process.exit(2); }
+  const actual = JSON.parse(readFileSync(a.actual, 'utf8'));
+  const expected = JSON.parse(readFileSync(a.expected, 'utf8'));
+  const tol = Number(a.tol ?? 0.01);
+  const rows = []; let fail = 0;
+  for (const k of Object.keys(expected)) {
+    const e = Number(expected[k]), av = Number(actual[k]);
+    const ok = Number.isFinite(av) && (e === 0 ? av === 0 : Math.abs(av - e) / Math.abs(e) <= tol);
+    if (!ok) fail++;
+    rows.push(`${ok ? 'PASS' : 'FAIL'}  ${k}: expected ${e}, got ${Number.isFinite(av) ? av : '(missing)'}`);
+  }
+  console.log(rows.join('\n'));
+  console.log(fail ? `\n${fail}/${rows.length} FAILED — not parity-clean.` : `\nPARITY GREEN: ${rows.length}/${rows.length} within ±${tol * 100}%.`);
+
+  // Gate sentinel: parity-final.json (gate 1 of the shared assert-phase6-ran.rb;
+  // same contract every sigma-migration-skills plugin emits). mode='live' because
+  // SKILL.md Phase 4 REQUIRES live re-run Metabase expecteds, never a stale baseline.
+  const workdir = a.workdir || dirname(a.actual);
+  const failNames = rows.filter((r) => r.startsWith('FAIL')).map((r) => r.slice(6, r.indexOf(':')));
+  const final = {
+    status: fail ? 'FAIL' : 'PASS', mode: 'live',
+    charts_total: rows.length, charts_pass: rows.length - fail,
+    fail_names: failNames, tolerance: tol, at: new Date().toISOString(),
+  };
+  if (a.census) {
+    try { final.tile_census = JSON.parse(a.census); }
+    catch { console.error('WARN: --census is not valid JSON — tile_census omitted (gate 5 will SKIP).'); }
+  }
+  writeFileSync(join(workdir, 'parity-final.json'), JSON.stringify(final, null, 2));
+  console.error(`sentinel → ${join(workdir, 'parity-final.json')} (gate 1; now run: ruby scripts/assert-phase6-ran.rb --workdir ${workdir} --workbook-id <id>)`);
+  process.exit(fail ? 1 : 0);
+}
+
+console.error('specify --plan or --check (see header).');
+process.exit(2);

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/assert-phase6-ran.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,505 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a metabase-to-sigma conversion is actually complete.
+# The agent MUST run this script before declaring GREEN. It checks seven
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the Container bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
+#   7. Control lint (scripts/lib/control_lint.rb, shared) — no dead controls
+#      (a control with no resolving `filters` target AND no [controlId]
+#      formula reference is furniture: the "Orders Overview (from Looker)"
+#      estate shipped three of them), no ghost filter targets, and no control
+#      whose source-closure misses same-page queryable elements (the PHASEE
+#      "Action(Region) -> Monthly Revenue Trend" escape). Honors the
+#      control-scope sidecar (<workdir>/control-scope.json or
+#      --control-scope) for source-signal coverage (zero controls built from
+#      an interactive source = FAIL, the Qlik class) and per-control
+#      scope:[...] allowlists (intentional single-chart switchers like grain
+#      controls). See the lib header CONTRACT.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--skip-control-lint]    # skip gate 7 (control-wiring lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--control-scope PATH]   # control-scope.json sidecar for gate 7
+#                              # (default: <workdir>/control-scope.json)
+#     [--min-layout-elements N] default 1 — minimum positioned elements
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
+#   9  control lint violations — dead controls / ghost targets / partial
+#      reach / source filter signals with zero controls
+#      (gate 7; scripts/lib/control_lint.rb)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+require_relative 'lib/code_rep'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 1,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
+  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] parity skipped — #{summary_path} does not exist."
+  warn '       Run scripts/assert-parity.mjs --check with live Metabase expected values,'
+  warn "       then re-run this gate. See SKILL.md Phase 4."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn '       Phase 4 must verify at least one Metabase card to declare GREEN.'
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+# status=PASS requires 100% — when the caller explicitly accepts a lower
+# pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+# placeholders / cross-grain semantics), the rate is the gate, not the status.
+rate_gate_only = opts[:min_pass_rate] < 1.0
+if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+if rate_gate_only && status != 'PASS'
+  puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+       "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+else
+  puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/7: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/7: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/7: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/7: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty `document.layout`
+# XML is set, with at least --min-layout-elements canonical <Element> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/7: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        doc = Sigma::CodeRep.document(spec)
+        layout_xml = doc['layout'].to_s
+        elem_count = layout_xml.scan(/<Element\b/).length
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn '       builder (see SKILL.md Phase 3), then run:'
+          warn "         node scripts/apply-layout.mjs --workbook #{wb_id} --hints <layout-hints.json>"
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/7: layout XML has only #{elem_count} positioned <Element> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required."
+          exit 6
+        else
+          puts "[OK] gate 4/7: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/7: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/7: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/7: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/7: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/7: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts '[OK] gate 6/7: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
+      else
+        warn "[SKIP] gate 6/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7 — control-wiring lint (scripts/lib/control_lint.rb, shared)
+# A workbook can pass every gate above and still ship controls that do
+# NOTHING (dead controls: no resolving filter target, no [controlId] formula
+# reference — the "Orders Overview (from Looker)" estate escape) or controls
+# that silently skip same-page charts (the PHASEE "Action(Region) ->
+# Monthly Revenue Trend" escape). This gate mechanizes those checks on the
+# LIVE spec, plus source-signal coverage when a control-scope sidecar exists
+# (zero controls built from an interactive source = FAIL, the Qlik class).
+# ---------------------------------------------------------------------------
+if opts[:skip_control_lint]
+  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 7/7: no workbook ID resolvable for control lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 7/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/control_lint'
+    rescue LoadError
+      warn "[SKIP] gate 7/7: scripts/lib/control_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(ControlLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        scope_path = opts[:control_scope] || File.join(opts[:tab], 'control-scope.json')
+        scope = nil
+        if File.exist?(scope_path)
+          scope = JSON.parse(File.read(scope_path)) rescue nil
+          warn "[WARN] gate 7/7: #{scope_path} is not valid JSON — linting without source scope" if scope.nil?
+        end
+        violations = ControlLint.lint(spec, scope: scope)
+        if violations.any?
+          warn "[FAIL] gate 7/7: control lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the control wiring and re-PUT (dead controls -> add filters targets"
+          warn "       ({source:{elementId}, columnId}) or remove the control; partial reach ->"
+          warn "       wire the uncovered elements or annotate controlScope in control-scope.json;"
+          warn "       see scripts/lib/control_lint.rb CONTRACT), then re-run this gate."
+          warn "       Flip-test the wiring live with: ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+          warn "       Escape hatch (legacy workbooks only): --skip-control-lint."
+          exit 9
+        end
+        n_controls = ControlLint.controls_report(spec).length
+        puts "[OK] gate 7/7: control lint clean (#{n_controls} control(s); no dead controls, no ghost " \
+             "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
+      else
+        warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/escalate-gap.py
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/find-or-pick-dm.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,579 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["ANALYTICS.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+require 'digest'
+require 'time'
+require 'set'
+
+# --limit is the SPEC-FETCH BUDGET, not a cap on how many DMs are considered.
+#
+# Perf testing (2026-05-22) set limit=25 because the top score "saturated by ~25
+# DMs in this org" and wall time elbows hard after 50 (0.065s/DM → 0.25s/DM —
+# Sigma drops off a cached-spec hot path). That held only while the budget was
+# spent on the RIGHT 25: the window used to be the 25 most-recently-UPDATED DMs,
+# and recency is uncorrelated with whether a DM covers the workbook's tables. On
+# an org that has since grown to 500 DMs that meant scoring 5% of them chosen by
+# when they were last touched — a DM covering exactly the target table was never
+# scored, the picker reported "no reusable DM found", and every migration posted
+# yet another near-duplicate model. Reuse-first was effectively inert.
+#
+# Fix: rank the fetch queue by RELEVANCE (name affinity to the signature's own
+# table names) and only use updatedAt as a tiebreak, so the same budget buys the
+# plausible reuse targets. Any DM with non-zero affinity is fetched even past
+# --limit, up to --max-fetch. Truncation is always reported, never silent.
+RANKING_VERSION = 2 # bump to invalidate dm-match caches written by older ranking
+opts = { limit: 25, min_score: 0.6, max_fetch: 120 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--max-fetch N', Integer, 'Hard ceiling on spec fetches when relevance-ranked candidates exceed --limit (default 120). Name-affine DMs are fetched past --limit up to this cap.') { |v| opts[:max_fetch] = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+  p.on('--refresh', 'Force a rescan even when --out already answers this exact signature (see the re-entry cache below).') { |_| opts[:refresh] = true }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    # Derive TLS from the URI scheme (same as put-layout.rb) instead of hardcoding
+    # use_ssl: true. Production SIGMA_BASE_URL is https so behaviour is unchanged;
+    # this is what lets the candidate-ranking tests drive the picker against a
+    # loopback WEBrick stub offline (hardcoded TLS made the scan untestable, which
+    # is how the recency-window bug shipped with a green suite).
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# ── Re-entry cache (refs/performance.md) ─────────────────────────────────────
+# The orchestrator re-invokes this scan on EVERY loop re-entry (exit 10/11/13),
+# and on a large org that re-pays a full DM list + N parallel spec fetches each
+# time for an answer that cannot have changed: the recommendation is a pure
+# function of the workbook SIGNATURE and the org's DM set. So the --out file is
+# stamped with a canonical hash of the signature it was computed from —
+# same signature ⇒ reuse the recommendation without touching the API.
+# The org's DM set IS live external state, so reuse carries a 24h staleness
+# bound; --refresh forces a rescan (e.g. after posting/deleting DMs mid-run).
+def signature_sha(sig)
+  canon = {
+    'tables'   => (sig['warehouse_tables'] || []).map(&:to_s).sort,
+    'columns'  => (sig['referenced_columns'] || []).map(&:to_s).sort,
+    'measures' => (sig['measures'] || []).map { |m| "#{m['col']}/#{m['derivation']}" }.sort
+  }
+  Digest::SHA256.hexdigest(JSON.generate(canon))
+end
+SIG_SHA = signature_sha(sig)
+CACHE_MAX_AGE = 24 * 3600
+if !opts[:refresh] && !opts[:force_new] && File.exist?(opts[:out])
+  prev = (JSON.parse(File.read(opts[:out])) rescue nil)
+  prev_at = prev && (Time.parse(prev['scanned_at'].to_s) rescue nil)
+  # ranking_version participates in cache validity: a result computed by the old
+  # recency-window ranking must NOT be replayed, or the reuse fix stays invisible
+  # for 24h on exactly the orgs that need it.
+  prev_rv = prev.is_a?(Hash) ? prev['ranking_version'].to_i : 0
+  if prev.is_a?(Hash) && prev['signature_sha256'] == SIG_SHA && prev_at && (Time.now - prev_at) < CACHE_MAX_AGE &&
+     prev_rv == RANKING_VERSION
+    warn "dm-match REUSED (signature unchanged; scanned #{prev['scanned_at']}) — pass --refresh to rescan"
+    warn "best score: #{prev['score']}  →  #{prev['rationale']}"
+    exit(prev['recommended_dm_id'].nil? ? 1 : 0)
+  end
+end
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: name-affinity desc, then updatedAt desc, then name asc.
+# NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
+# every timestamp rescues to 0, and the sort silently degrades to name-ascending
+# (recently-updated DMs past the --limit window are never scanned).
+require 'time'
+
+# Cheap RELEVANCE signal computable from the list response alone (no spec fetch):
+# how much a DM's NAME overlaps the distinctive tokens of the tables this
+# workbook actually reads. Given a signature over <DB>.<SCHEMA>.PIPELINE_FACT, a DM
+# named "Pipeline Fact (migrated)" scores; an unrelated "Bench Fixture 12" scores 0.
+# This only ORDERS the fetch queue — the real scoring below is still done on the
+# fetched spec's tables/columns, so a name coincidence can never by itself produce
+# a reuse recommendation.
+STOP_TOKENS = %w[DM DATA MODEL FROM THE AND FOR TEST TMP TEMP COPY OF V1 V2 NEW OLD
+                 FACT DIM TABLE VIEW PROD DEV RAW STG PUBLIC].to_set
+def name_tokens(s)
+  s.to_s.upcase.split(/[^A-Z0-9]+/).reject { |t| t.empty? || t.length < 3 || STOP_TOKENS.include?(t) }.to_set
+end
+
+# Signature tokens: the LEAF table name carries the signal (db/schema are shared
+# by everything on the connection and would match every DM equally).
+sig_tokens = (sig['warehouse_tables'] || []).each_with_object(Set.new) do |fqn, acc|
+  leaf = fqn.to_s.split('.').reject(&:empty?).last
+  acc.merge(name_tokens(leaf))
+end
+# The source document's own name is a weaker but real signal (a prior migration of
+# the same dashboard usually named its DM after it).
+sig_tokens.merge(name_tokens(sig['tableau_workbook'])) if sig['tableau_workbook']
+
+def affinity(dm_name, sig_tokens)
+  return 0.0 if sig_tokens.empty?
+  toks = name_tokens(dm_name)
+  return 0.0 if toks.empty?
+  (toks & sig_tokens).size.to_f / sig_tokens.size
+end
+
+all_dms = all_dms.sort_by do |dm|
+  [-affinity(dm['name'], sig_tokens),
+   -(Time.parse(dm['updatedAt'].to_s).to_i rescue 0),
+   dm['name'].to_s]
+end
+
+# Spend the budget on relevance, but never let a plausible reuse target fall off
+# the end just because the budget is small: every name-affine DM is fetched, up
+# to --max-fetch.
+affine_count = all_dms.count { |dm| affinity(dm['name'], sig_tokens) > 0 }
+fetch_n = [[opts[:limit], affine_count].max, opts[:max_fetch], all_dms.size].min
+POOL_TOTAL = all_dms.size
+POOL_FETCHED = fetch_n
+POOL_TRUNCATED = fetch_n < POOL_TOTAL
+warn "found #{POOL_TOTAL} total DMs; scoring #{POOL_FETCHED} ranked by name-affinity to the signature's tables " \
+     "(#{affine_count} name-affine, budget --limit=#{opts[:limit]}, cap --max-fetch=#{opts[:max_fetch]})"
+if POOL_TRUNCATED
+  warn "  NOTE: #{POOL_TOTAL - POOL_FETCHED} DM(s) were NOT scored — a 'no reusable DM' result below means " \
+       "none was found AMONG THE #{POOL_FETCHED} SCORED, not that none exists. Raise --limit/--max-fetch to widen."
+end
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Does DM fqn `dm` cover workbook fqn `wb`, allowing for a source signature that
+# could not resolve every qualifier? True when the two are equal, or when the
+# SHORTER one's parts are a suffix of the longer's — warehouse names qualify
+# right-to-left (table, schema, database), so a signature over SCHEMA.TABLE is
+# satisfied by a DM on DB.SCHEMA.TABLE, while SCHEMA_A.T vs SCHEMA_B.T stay
+# distinct. A single bare part (just a table name) is deliberately allowed to
+# match too: it is a weaker signal, but the column match (weighted 0.7 vs the
+# table's 0.2) is what actually discriminates, and refusing it would recreate the
+# false-negative this exists to fix. CUSTOM_SQL is a sentinel, never a real path.
+def fqn_covers?(dm, wb)
+  return false if dm.nil? || wb.nil?
+  return dm == wb if dm == 'CUSTOM_SQL' || wb == 'CUSTOM_SQL'
+  d = dm.to_s.split('.')
+  w = wb.to_s.split('.')
+  return false if d.empty? || w.empty?
+  n = [d.size, w.size].min
+  d.last(n) == w.last(n)
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(POOL_FETCHED).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent on a live
+      # org — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+# POOL_FETCHED, not opts[:limit] — the fetch queue above is sized by POOL_FETCHED
+# (which can exceed --limit when name-affine candidates do). Scoring only
+# opts[:limit] here would fetch specs and then silently drop them unscored.
+all_dms.take(POOL_FETCHED).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }.
+      # Live API specs return path as an ARRAY (["DB","SCHEMA","TABLE"]) — join it,
+      # else normalize_fqn sees the array's to_s and table-match never fires.
+      raw = src['path']
+      fqn = raw.is_a?(Array) ? raw.join('.') : (raw || [src['database'], src['schema'], src['name']].compact.join('.'))
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if the workbook's tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  #
+  # Matched by ARITY-AWARE SUFFIX, not string equality. A source signature often
+  # cannot resolve the DATABASE: QuickSight's dataset JSON carries only Schema +
+  # Name (the database lives in the separate DataSource object), so its signature
+  # emits "SCHEMA.TABLE" while every Sigma DM spec stores the full
+  # ["DB","SCHEMA","TABLE"] path. Comparing the joined strings then fails on an
+  # arity mismatch alone — measured live: three data models built FROM
+  # <db>.<schema>.<table> scored table_match 0.0 against a signature over
+  # <schema>.<table>, with column_match 1.0 and zero missing columns.
+  #
+  # That is not cosmetic. table_match 0.0 => covers_tables false => is_superset
+  # false => the wide-tie guard fires and reuse is REFUSED forever, and the score
+  # is capped around 0.7 so it can never clear the auto-pick bar. It is the reason
+  # QuickSight reuse never fired even once the relevance ranking put the right
+  # candidates in front of the scorer, and therefore the reason every migration
+  # posted another duplicate model.
+  #
+  # A shorter FQN matches a longer one when its parts are a SUFFIX of the longer's
+  # (table, then schema, then db — the qualification order), so SCHEMA.TABLE
+  # matches DB.SCHEMA.TABLE while SCHEMA_A.T and SCHEMA_B.T stay distinct.
+  shared_tables = tableau_tables.select { |wt| dm[:tables].any? { |dt| fqn_covers?(dt, wt) } }
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    # Same arity-aware rule as shared_tables above — a plain set difference would
+    # report a table as MISSING that the suffix match just resolved, and that
+    # string is what the "MISSING source table(s)" rationale prints to the operator.
+    'missing_tables'    => tableau_tables - shared_tables,
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
+# candidate (a) clears the auto-pick threshold AND (b) is a COLUMN-SUPERSET of
+# the workbook's references — table_match 1.0 AND column_match 1.0 (every
+# referenced column present in the DM).
+#
+# Column coverage, not just table coverage, is the safety invariant. The old gate
+# required only table_match 1.0 on the theory that "every table present ⇒ every
+# column resolvable through the element set" — but that is FALSE when a DM merely
+# scores well on table names: a DM can source all the workbook's tables yet still
+# be missing referenced columns (col_match < 1.0, e.g. 0.8) and auto-pick anyway
+# (0.2·1.0 + 0.7·0.8 ≈ 0.76 ≥ threshold), then fail the pre-POST ref gate. Require
+# the full column-superset so a DM missing ANY referenced column is NOT silently
+# reused — it can still be RECOMMENDED for human opt-in below.
+#
+# KNOWN RESIDUAL (role-playing dimensions): column-NAME coverage cannot express
+# "the master needs table T joined under TWO aliases" (e.g. DATE_DIM as both Order
+# Date and Return Date). A DM with T once can be a full column-superset yet lack
+# the second alias; the pre-POST ref gate still catches it (exit-4 handoff). A
+# self-heal (auto-rebuild fresh on ref-gate failure of an auto-picked DM) is the
+# proper fix for that case — tracked separately.
+#
+# We deliberately DO NOT block on a score tie here. A tie among table-covering
+# candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
+# exactly what reuse-first exists to collapse — so we take the top (the
+# deterministic tie-break already prefers a name match, then the fewest extra
+# columns, over the most-recently-updated set). A column-SUPERSET (every
+# referenced column present, column_match 1.0) is the safest case and always
+# qualifies. Callers should reuse `recommended_dm_id` only when `auto_picked`.
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+best_covers_tables   = best && best['table_match'].to_f >= 1.0
+best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
+# A WIDE tie among table-covering look-alikes (>=3 within the tie window) is
+# duplicate-DM sprawl we CANNOT safely disambiguate by score — silently collapsing
+# it can reuse a bloated look-alike that lacks the workbook's joined structure
+# (verified 2026-07-02: a 5-way 0.876 tie of demo DMs auto-collapsed, dropping 8/9
+# visuals + falling back to the agent path). Unless the top is a confident pick
+# (exact source-name match OR a full column-superset), refuse to auto-pick so the
+# caller builds a fresh, correctly-structured DM (and, interactively, surfaces the
+# tie). Narrow ties (<=2) still collapse as before — reuse-first for the common case.
+tie_window_count     = best ? candidates.count { |c| (best['score'] - c['score'].to_f) < auto_pick_tie_window } : 0
+# The tie guard only means something when the tied scores are actually REUSE
+# CANDIDATES. Without the min_score floor, a pile of IRRELEVANT DMs (all scoring
+# ~0.0 because they share no tables or columns) trips it and gets reported as
+# "N near-identical DMs tie — duplicate-DM sprawl", which is both wrong and
+# actively misleading: nothing is duplicated, the picker simply found nothing.
+# Now widened relevance ranking surfaces more zero-score DMs, so this matters.
+ambiguous_wide_tie   = tie_window_count >= 3 && best && best['score'].to_f >= opts[:min_score] &&
+                       !best_name_matches && !best_is_superset
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_is_superset && !ambiguous_wide_tie)
+
+# Standard recommend path keeps the old semantics (printed for human opt-in).
+recommended_via_std  = best && best['score'] >= opts[:min_score] && !ambiguous_wide_tie
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    kind = best_is_superset ? 'column-superset' : 'covers all source tables'
+    tie  = tie_with_second ? " (collapsing a #{best['score']}-score tie — duplicate-DM sprawl)" : ''
+    "AUTO-PICKED at score #{best['score']} — #{kind}#{tie}. #{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif ambiguous_wide_tie
+    "AMBIGUOUS: #{tie_window_count} near-identical DMs tie at ~#{best['score']} (duplicate-DM sprawl) and none is an exact source-name match or full column-superset — NOT auto-reusing a look-alike (it may lack the workbook's joined structure). Build a fresh DM, or force one with --reuse-dm <id>. Tied: #{candidates.first([tie_window_count, 4].min).map { |c| c['dm_name'] }.join('; ')}"
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && !best_covers_tables
+    "score #{best['score']} clears the bar but the candidate is MISSING source table(s) #{best['missing_tables'].join(', ')} — not a safe reuse — build a new DM"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    "no candidate above min-score across the #{POOL_FETCHED} DM(s) scored; build a new DM"
+  end
+
+# NO SILENT CAPS: whenever we decline to recommend reuse AND the budget stopped us
+# short of the whole org, say so in the rationale itself — the agent/operator reads
+# this string, and "build a new DM" must never imply "the org has nothing reusable"
+# when only part of it was scored. (Appended to whichever branch fired above.)
+if recommended_dm_id.nil? && POOL_TRUNCATED
+  rationale += " [scanned #{POOL_FETCHED} of #{POOL_TOTAL} DM(s) scored, ranked by name-affinity — " \
+               "#{POOL_TOTAL - POOL_FETCHED} NOT scored; raise --limit/--max-fetch to scan wider]"
+end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  # Re-entry cache stamp (see the header block): same signature within 24h ⇒
+  # the next invocation reuses this file instead of re-scanning the org.
+  'signature_sha256'        => SIG_SHA,
+  # Ranking generation this result was computed under; the cache refuses to replay
+  # a result from an older ranking (see RANKING_VERSION).
+  'ranking_version'         => RANKING_VERSION,
+  'scanned_at'              => Time.now.utc.iso8601,
+  'scanned_dm_count'        => candidates.size,
+  # NO SILENT CAPS: a "no reusable DM" verdict is only as broad as the pool that
+  # was actually scored. Callers (and the agent reading this file) must be able to
+  # tell "none exists" apart from "none among the N we could afford to score".
+  'candidate_pool'          => {
+    'total_in_org' => POOL_TOTAL,
+    'scored'       => POOL_FETCHED,
+    'truncated'    => POOL_TRUNCATED,
+    'ranked_by'    => 'name-affinity to signature tables, then updatedAt desc, then name asc'
+  },
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'ambiguous_wide_tie'      => ambiguous_wide_tie,
+  'tie_count'               => tie_window_count,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/gap-scout.md
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,71 @@
+# gap-scout subagent — guide for the main agent
+
+When the Metabase converter can't translate an expression into a Sigma formula, it
+**flags** it (never fakes it). For a flagged expression that you want to actually
+resolve, spawn a separate subagent — the **gap scout** — to find a Sigma
+translation that validates against the customer's real Sigma site, and persist it.
+
+The scout writes successful rules to `~/.metabase-to-sigma/learned-rules.json` (the
+customer's home dir, NOT the skill repo, so a `git pull` never clobbers them). The
+converter CLI loads them via `loadLearnedRules()` and applies them *before* the
+built-in translator (`applyLearnedRules` in `converter/metabase.ts`), so a customer's
+discovered rule wins.
+
+## When to spawn
+
+After conversion emits a warning for an untranslated construct — typically:
+- **cum-sum / cum-count / offset** aggregations (window/running calcs)
+- **`["segment", id]` / legacy `["metric", id]`** refs (saved-filter/metric inlining)
+- **binned breakouts** (`{"binning": …}` — numeric histogram buckets)
+- **dimension-type field-filter** `{{tags}}` in native SQL cards
+- any `unmapped: <op>` warning from `translateMbqlExpr`
+
+Spawn ONE scout per distinct feature; run them in parallel where possible — they're
+independent.
+
+## How to spawn (from the main agent)
+
+Use the Agent tool with `subagent_type: 'general-purpose'`. Self-contained prompt:
+
+```
+You are a translation scout. Your job: propose a Sigma formula that replaces a
+Metabase expression, validate it against Sigma's API, and persist the rule if it works.
+
+INPUTS
+- Metabase feature: <e.g. "running-total">
+- Sample expressions: <2-5 examples from the module/report>
+- A real warehouse table on the customer's Sigma connection to test against:
+  --connection <connectionId>  --table-path <DB.SCHEMA.TABLE>
+- Sigma folder id: <folder-id>
+
+PROCEDURE
+1. Read refs/expression-dsl.md (the Metabase→Sigma mapping table) and
+   refs/format-shapes.md. Note Sigma window funcs (SumOver/CountOver/…) silently
+   error in data-model calc columns — prefer a non-window form or flag it.
+2. Propose ONE candidate Sigma formula using a column that exists on --table-path.
+3. Validate + persist:
+   eval "$(scripts/get-token.sh)"
+   node scripts/scout-validate-and-persist.mjs \
+     --feature '<feature>' \
+     --pattern '<Metabase regex, capture groups for column refs>' \
+     --template '<Sigma template using $1,$2 for captures>' \
+     --test-formula '<the candidate with a REAL column from --table-path>' \
+     --connection <connectionId> --table-path <DB.SCHEMA.TABLE> \
+     --folder <folder-id> --description '<one line>' --hint '<caveat>'
+4. Parse the JSON result:
+   - status=validated → success; rule is now in ~/.metabase-to-sigma/learned-rules.json
+   - status=escalated → try a different candidate (≤3 attempts). The last result
+     carries `escalation.dry_run_cmd`. Do NOT file anything yourself.
+
+OUTPUT
+One paragraph: feature, candidate, status (validated / escalated / abandoned-after-N),
+and — if escalated — the `escalation.dry_run_cmd` so the main agent can offer the
+user a tracking issue.
+```
+
+## Opt-in issue filing
+
+If the scout escalates (no formula validated), it returns a ready-to-run
+`scripts/escalate-gap.py … ` command (DRY-RUN by default). **Show it to the user and
+ask** before filing — only run it with `--yes` on their go-ahead. It routes
+converter gaps to the data-model repos (MCP + browser) with dedupe.

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/get-metabase-session.sh
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/get-metabase-session.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# get-metabase-session.sh — set up Metabase REST auth for discovery/extraction.
+#
+#   AUTH (two options — far friendlier than most BI tools):
+#   • API key (PREFERRED, Metabase v49+): Admin → Settings → Authentication →
+#     API keys → create a key in a group with read access to the content you're
+#     migrating (Administrators = read-everything). Durable; use for engagements.
+#   • Session token: POST /api/session with username/password. Sessions expire
+#     (max ~14 days, sooner under SSO); on HTTP 401 just re-run this script.
+#     SSO-only logins (no password) must use an API key.
+#
+# USAGE:
+#   export MB_BASE="https://metabase.example.com"     # no trailing slash, no /api
+#   # EITHER:
+#   export MB_KEY="mb_…"                               # the API key
+#   # OR:
+#   export MB_USER="you@example.com" MB_PASS="…"       # exchanged for a session
+#   eval "$(scripts/get-metabase-session.sh)"
+#   mb_get "/api/session/properties" | head            # smoke test (prints version)
+#
+# Emits a shell function `mb_get` on stdout (eval it). Read-only helper — only GETs.
+set -euo pipefail
+: "${MB_BASE:?set MB_BASE=https://<your-metabase-host>}"
+MB_BASE="${MB_BASE%/}"
+
+if [ -n "${MB_KEY:-}" ]; then
+  AUTH_HDR="x-api-key: $MB_KEY"
+elif [ -n "${MB_USER:-}" ] && [ -n "${MB_PASS:-}" ]; then
+  tok=$(curl -s "$MB_BASE/api/session" -H 'Content-Type: application/json' \
+    -d "{\"username\": \"$MB_USER\", \"password\": \"$MB_PASS\"}" |
+    python3 -c 'import sys,json;print(json.load(sys.stdin).get("id") or "")')
+  if [ -z "$tok" ]; then
+    echo "echo 'Metabase login failed — check MB_USER/MB_PASS (SSO-only users need an API key, MB_KEY).' >&2; false"
+    exit 0
+  fi
+  AUTH_HDR="X-Metabase-Session: $tok"
+else
+  echo "echo 'Set MB_KEY (preferred, v49+) or MB_USER+MB_PASS.' >&2; false"
+  exit 0
+fi
+
+cat <<EOF
+export MB_BASE='$MB_BASE'
+export MB_AUTH_HDR='$AUTH_HDR'
+mb_get() {
+  # mb_get "/api/…" → prints body; nonzero on HTTP>=400 (401 = key revoked / session expired)
+  local p="\$1" code
+  code=\$(curl -s -o /tmp/mb_last.json -w '%{http_code}' "\$MB_BASE\$p" \\
+    -H 'Accept: application/json' -H "\$MB_AUTH_HDR")
+  if [ "\$code" -ge 400 ]; then
+    echo "Metabase GET \$p -> HTTP \$code (401 = re-auth; 403 = key's group lacks access)" >&2
+    cat /tmp/mb_last.json >&2; echo >&2; return 1
+  fi
+  cat /tmp/mb_last.json
+}
+EOF

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/get-token.sh
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/get-token.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+# Security (A2): only transmit Sigma credentials to an https:// sigmacomputing.com
+# host. A poisoned SIGMA_BASE_URL would otherwise exfiltrate the client id/secret.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+_sbu_scheme="${SIGMA_BASE_URL%%://*}"
+_sbu_rest="${SIGMA_BASE_URL#*://}"; _sbu_hostport="${_sbu_rest%%/*}"
+_sbu_host="${_sbu_hostport##*@}"; _sbu_host="${_sbu_host%%:*}"
+_sbu_host="$(printf '%s' "$_sbu_host" | tr 'A-Z' 'a-z')"
+if [ "${SIGMA_ALLOW_INSECURE_BASE_URL:-}" = "1" ]; then
+  echo "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation ($SIGMA_BASE_URL)" >&2
+else
+  [ "$_sbu_scheme" = "https" ] || { echo "FATAL: SIGMA_BASE_URL must use https:// (got '$SIGMA_BASE_URL') — refusing to send credentials." >&2; exit 1; }
+  case "$_sbu_host" in
+    sigmacomputing.com|*.sigmacomputing.com) : ;;
+    *) echo "FATAL: SIGMA_BASE_URL host '$_sbu_host' is not a sigmacomputing.com host — refusing to send credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." >&2; exit 1 ;;
+  esac
+fi
+
+# Pre-flight credential sanity (POSTMORTEM 2026-06-18): the #1 hard blocker was a
+# settings.json where SIGMA_CLIENT_SECRET had been pasted with a COPY of
+# SIGMA_CLIENT_ID. Sigma then returns the opaque "client secret provided is
+# invalid" and nothing else runs. Catch the obvious paste-errors here with a
+# specific, actionable message before the round-trip.
+if [ "$SIGMA_CLIENT_SECRET" = "$SIGMA_CLIENT_ID" ]; then
+  echo "FATAL: SIGMA_CLIENT_SECRET is identical to SIGMA_CLIENT_ID — you pasted the" >&2
+  echo "client ID into both fields. The secret is a SEPARATE, longer value shown only" >&2
+  echo "once when the API key was created. Fix it in ~/.sigma-migration/env (and in" >&2
+  echo "~/.claude/settings.json if it lives there too), then re-run." >&2
+  exit 1
+fi
+
+# NB: `| tr -d '\n'` is mandatory. GNU coreutils `base64` (Git Bash on Windows,
+# Linux CI) wraps output at 76 columns, injecting newlines that corrupt the
+# multi-line Authorization header and make Sigma reject a VALID credential.
+# `tr -d` (not `base64 -w0`, which BSD/macOS `base64` lacks) is cross-platform.
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64 | tr -d '\n')
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    echo "  base : $SIGMA_BASE_URL" >&2
+    echo "  id   : ${#SIGMA_CLIENT_ID} chars   secret: ${#SIGMA_CLIENT_SECRET} chars" >&2
+    echo "  (a valid Sigma secret is ~128 chars — if the secret is the same length as" >&2
+    echo "   the id, you likely pasted the id into both fields.)" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+# Security: the emitted line is consumed via `eval "$(scripts/get-token.sh)"`, so a
+# token from a poisoned/MITM'd endpoint could otherwise inject shell. Reject any
+# non-token characters, then emit shell-quoted (%q) so eval can never execute it.
+case "$TOKEN" in
+  *[!A-Za-z0-9._~+/=-]*)
+    echo "FATAL: access_token contains unexpected characters — refusing to emit (possible poisoned SIGMA_BASE_URL)." >&2
+    exit 1 ;;
+esac
+
+printf 'export SIGMA_API_TOKEN=%q\n' "$TOKEN"

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.mjs
@@ -1,0 +1,157 @@
+// Shape adapter for the Sigma WORKBOOK code representation.
+// Verified live 2026-08-03/04: nested `document` required on write (including
+// /v2/workbooks/spec/verify); flat bodies 400. The DATA-MODEL code-rep surface is
+// NOT changing — do not use this on /v2/dataModels/.../spec payloads.
+
+// Workbook elements are flat document collections; `overlays` and `panels` live
+// beside them. `settings` (theme/navigation) and `agents` belong inside
+// `document` too. Omitting any of these sweeps it onto the metadata envelope,
+// where it is invalid and silently dropped on write.
+export const DOC_KEYS = [
+  'schemaVersion', 'pages', 'elements', 'overlays', 'panels',
+  'kind', 'layout', 'settings', 'agents',
+];
+
+// REMOVED from the API. The workbook theme is now settings.theme.name /
+// settings.theme.overrides (published OpenAPI: createWorkbookSpec has zero
+// occurrences of themeName/themeOverrides). The individual override keys are
+// unchanged - only the container path moved. document() folds the legacy pair
+// forward so specs and fixtures written before the move still produce a valid body.
+export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+
+const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
+
+export function document(response) {
+  if (!isObj(response)) return {};
+  const doc = isObj(response.document)
+    ? response.document
+    : Object.fromEntries(Object.entries(response).filter(([k]) => DOC_KEYS.includes(k)));
+  return foldLegacyTheme(doc, response);
+}
+
+// themeName/themeOverrides -> settings.theme.{name,overrides}. Returns the input
+// untouched when no legacy key is present (the common, already-correct path).
+function foldLegacyTheme(doc, source) {
+  const name = doc.themeName || source.themeName;
+  const overrides = doc.themeOverrides || source.themeOverrides;
+  const hasOv = isObj(overrides) && Object.keys(overrides).length > 0;
+  const hasLegacyKey = LEGACY_THEME_KEYS.some((k) => k in doc);
+  if (!name && !hasOv && !hasLegacyKey) return doc;
+
+  const out = Object.fromEntries(
+    Object.entries(doc).filter(([k]) => !LEGACY_THEME_KEYS.includes(k)),
+  );
+  const settings = { ...(out.settings || {}) };
+  const theme = { ...(settings.theme || {}) };
+  if (name && !theme.name) theme.name = name;
+  if (hasOv) theme.overrides = { ...(theme.overrides || {}), ...overrides };
+  if (Object.keys(theme).length === 0) return out;
+  settings.theme = theme;
+  out.settings = settings;
+  return out;
+}
+
+// Emitter helper - set the workbook theme in the CURRENT shape. Builders should
+// call this instead of assigning the removed themeName/themeOverrides pair.
+export function setTheme(doc, { name = null, overrides = null } = {}) {
+  const hasOv = isObj(overrides) && Object.keys(overrides).length > 0;
+  if (!name && !hasOv) return doc;
+  doc.settings = doc.settings || {};
+  doc.settings.theme = doc.settings.theme || {};
+  if (name) doc.settings.theme.name = name;
+  if (hasOv) {
+    doc.settings.theme.overrides = { ...(doc.settings.theme.overrides || {}), ...overrides };
+  }
+  return doc;
+}
+
+// Read the theme from either shape.
+export function theme(spec) {
+  const t = (document(spec).settings || {}).theme || {};
+  return { name: t.name ?? null, overrides: t.overrides || {} };
+}
+
+export function metadata(response) {
+  if (!isObj(response)) return {};
+  return Object.fromEntries(
+    Object.entries(response).filter(
+      ([k]) => k !== 'document' && !DOC_KEYS.includes(k) && !LEGACY_THEME_KEYS.includes(k),
+    ),
+  );
+}
+
+export function workbookElements(spec) {
+  const doc = document(spec);
+  if (Array.isArray(doc.elements)) return doc.elements.filter(isObj);
+  return (Array.isArray(doc.pages) ? doc.pages : [])
+    .filter(isObj)
+    .flatMap((page) => (Array.isArray(page.elements) ? page.elements.filter(isObj) : []));
+}
+
+export function workbookPageElementIds(spec) {
+  const result = {};
+  const layout = String(document(spec).layout || '');
+  const pagePattern = /<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)<\/Page>/gs;
+  for (const match of layout.matchAll(pagePattern)) {
+    result[match[1]] = [...new Set(
+      [...match[2].matchAll(
+        /<(?:Element|Container|TabbedContainer|LayoutElement|GridContainer)\b[^>]*\belementId="([^"]*)"/g,
+      )].map((element) => element[1]),
+    )];
+  }
+  return result;
+}
+
+export function workbookPageByElement(spec) {
+  const doc = document(spec);
+  const pages = Array.isArray(doc.pages) ? doc.pages.filter(isObj) : [];
+  const pagesById = Object.fromEntries(pages.filter((page) => page.id).map((page) => [page.id, page]));
+  const result = {};
+  for (const [pageId, elementIds] of Object.entries(workbookPageElementIds(doc))) {
+    const page = pagesById[pageId] || { id: pageId, name: pageId };
+    for (const elementId of elementIds) result[elementId] ||= page;
+  }
+  return result;
+}
+
+export function workbookElementsWithPages(spec) {
+  const pageByElement = workbookPageByElement(spec);
+  return workbookElements(spec).map((element) => [
+    element,
+    pageByElement[element.id || element.elementId],
+  ]);
+}
+
+function flattenElements(doc) {
+  if (!isObj(doc) || !Array.isArray(doc.pages)) return doc;
+  const nested = [];
+  const pages = doc.pages.map((page) => {
+    const copy = { ...page };
+    if (Array.isArray(copy.elements)) nested.push(...copy.elements);
+    delete copy.elements;
+    return copy;
+  });
+  const elements = [];
+  const seen = new Set();
+  for (const element of [...(Array.isArray(doc.elements) ? doc.elements : []), ...nested]) {
+    const id = isObj(element) ? element.id : null;
+    if (id && seen.has(id)) continue;
+    if (id) seen.add(id);
+    elements.push(element);
+  }
+  return { ...doc, pages, elements };
+}
+
+export function canonicalizeLayout(layoutXml) {
+  return String(layoutXml || '')
+    .replace(/<([/]?)LayoutElement\b/g, '<$1Element')
+    .replace(/<([/]?)GridContainer\b/g, '<$1Container');
+}
+
+export function wrap(doc, extra = {}) {
+  const flattened = flattenElements(doc);
+  const canonical = isObj(flattened) && 'layout' in flattened
+    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
+    : flattened;
+  return { ...extra, document: canonical };
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.rb
@@ -1,0 +1,203 @@
+# shared/lib/code_rep.rb
+# Shape adapter for the Sigma WORKBOOK code representation
+# (POST /v2/workbooks/spec, GET|PUT /v2/workbooks/{id}/spec, POST /v2/workbooks/spec/verify).
+#
+# Verified live 2026-08-03/04: this surface nests non-metadata fields under a top-level
+# `document` key and REJECTS the old flat body with HTTP 400 — including on /verify.
+# Sigma engineering confirmed 2026-08-03 that the DATA-MODEL code-rep surface is NOT
+# changing, so this adapter is deliberately workbook-only and always writes the nested
+# shape. Do NOT use it on /v2/dataModels/.../spec payloads — that API ignores `document`
+# and will 400 on a missing top-level `schemaVersion`.
+#
+# Reads stay tolerant of the legacy flat shape because flat artifacts still exist on
+# disk (committed workbook snapshots, fixtures) even though the API no longer returns them.
+module Sigma
+  module CodeRep
+    # The non-metadata fields that live INSIDE `document`. Confirmed by live readback.
+    # `elements`, `overlays`, and `panels` are workbook-document collections,
+    # alongside page metadata and the required layout. `settings`
+    # (theme/navigation) and `agents` belong here too. Omitting any of these
+    # sweeps them onto the metadata envelope, where they are invalid and are
+    # silently dropped on write.
+    DOC_KEYS = %w[
+      schemaVersion pages elements overlays panels kind layout settings agents
+    ].freeze
+
+    # REMOVED from the API. The workbook theme is now `settings.theme.name` and
+    # `settings.theme.overrides` (published OpenAPI: createWorkbookSpec — there
+    # are zero occurrences of themeName/themeOverrides in it). The individual
+    # override keys are unchanged (categoricalScheme, colorOverrides, hasCards,
+    # borderRadius, elementBorder, titleFont, tableStyles, …) — only the
+    # container path moved. document() folds the legacy pair forward so specs
+    # and fixtures written before the move still produce a valid body.
+    LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+
+    class << self
+      # Read path: accepts the live nested shape OR a legacy flat artifact.
+      def document(response)
+        return {} unless response.is_a?(Hash)
+        inner = response['document']
+        doc = inner.is_a?(Hash) ? inner : response.select { |k, _| DOC_KEYS.include?(k) }
+        fold_legacy_theme(doc, response)
+      end
+
+      def metadata(response)
+        return {} unless response.is_a?(Hash)
+        response.reject do |k, _|
+          k == 'document' || DOC_KEYS.include?(k) || LEGACY_THEME_KEYS.include?(k)
+        end
+      end
+
+      # Emitter helper — set the workbook theme on a document hash in the CURRENT
+      # shape. Builders should call this instead of assigning the removed
+      # themeName/themeOverrides pair. Returns the same hash for chaining.
+      def set_theme(doc, name: nil, overrides: nil)
+        return doc unless name || (overrides.is_a?(Hash) && !overrides.empty?)
+        settings = (doc['settings'] ||= {})
+        theme    = (settings['theme'] ||= {})
+        theme['name'] = name if name
+        if overrides.is_a?(Hash) && !overrides.empty?
+          theme['overrides'] = (theme['overrides'] || {}).merge(overrides)
+        end
+        doc
+      end
+
+      # Read the theme back out of either shape (nested settings.theme, or a
+      # legacy flat themeName/themeOverrides artifact). Returns {name:, overrides:}.
+      def theme(spec)
+        d = document(spec)
+        t = d.dig('settings', 'theme') || {}
+        { 'name' => t['name'], 'overrides' => t['overrides'] || {} }
+      end
+
+      # Write path: every live workbook code-rep endpoint requires the wrapper
+      # and flat document.elements. Flatten legacy page-nested artifacts and
+      # canonicalize legacy layout tags at this boundary so older converter
+      # output remains postable during migration; emitters always send the
+      # live-verified <Element>/<Container> vocabulary.
+      def wrap(document_hash, extra: {})
+        extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
+      end
+
+      # Read compatibility for pre-2026-08-08 artifacts. LayoutElement and
+      # GridContainer are rejected by the live workbook verify endpoint, so
+      # they must never cross an emission boundary unchanged.
+      def canonicalize_layout(layout_xml)
+        layout_xml.to_s
+                  .gsub(%r{<(/?)LayoutElement\b}, '<\1Element')
+                  .gsub(%r{<(/?)GridContainer\b}, '<\1Container')
+      end
+
+      # WORKBOOK-ONLY shape helpers. Workbook elements are a flat document
+      # collection; pages contain metadata only. Page membership is encoded by
+      # the required layout's <Page> blocks. Keep these helpers in CodeRep so
+      # callers cannot accidentally apply this shape to data-model specs, whose
+      # pages[*].elements nesting is unchanged.
+      def workbook_elements(spec)
+        doc = document(spec)
+        els = doc['elements']
+        return els.select { |el| el.is_a?(Hash) } if els.is_a?(Array)
+
+        # Transitional read compatibility for saved pre-release workbook
+        # artifacts. Current API payloads must still emit flat elements (wrap
+        # enforces that); this fallback only prevents readers from silently
+        # dropping elements while old local readbacks are being replaced.
+        Array(doc['pages']).flat_map do |page|
+          page.is_a?(Hash) ? Array(page['elements']).select { |el| el.is_a?(Hash) } : []
+        end
+      end
+
+      # { page_id => [element_id, ...] }, in layout order.
+      def workbook_page_element_ids(spec)
+        doc = document(spec)
+        doc['layout'].to_s
+                     .scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m)
+                     .each_with_object({}) do |(page_id, body), out|
+          # Restrict ownership to actual layout nodes. A generic elementId
+          # scan can accidentally claim ids from unrelated nested attributes.
+          # Legacy aliases remain readable, but all writes canonicalize them.
+          out[page_id] = body.scan(
+            %r{<(?:Element|Container|TabbedContainer|LayoutElement|GridContainer)\b[^>]*\belementId="([^"]*)"}
+          ).flatten.uniq
+        end
+      end
+
+      # { element_id => page metadata hash }. Layout is authoritative; pages
+      # that appear only in layout still receive a minimal {id,name} descriptor.
+      def workbook_page_by_element(spec)
+        doc = document(spec)
+        pages = doc['pages'].is_a?(Array) ? doc['pages'].select { |pg| pg.is_a?(Hash) } : []
+        pages_by_id = pages.each_with_object({}) { |pg, out| out[pg['id']] = pg if pg['id'] }
+        workbook_page_element_ids(doc).each_with_object({}) do |(page_id, element_ids), out|
+          page = pages_by_id[page_id] || { 'id' => page_id, 'name' => page_id }
+          element_ids.each { |element_id| out[element_id] ||= page }
+        end
+      end
+
+      # [[element, page_metadata_or_nil], ...] for flat workbook elements.
+      def workbook_elements_with_pages(spec)
+        page_by_element = workbook_page_by_element(spec)
+        workbook_elements(spec).map do |el|
+          [el, page_by_element[el['id'] || el['elementId']]]
+        end
+      end
+
+      private
+
+      def canonicalize_document(doc)
+        return doc unless doc.is_a?(Hash) && doc.key?('layout')
+        doc.merge('layout' => canonicalize_layout(doc['layout']))
+      end
+
+      # Emit only the current API shape. Elements are workbook-global in the
+      # payload; layout XML retains their page placement. Existing flat
+      # elements win ordering, while legacy page-nested elements are appended
+      # once by id.
+      def flatten_elements(doc)
+        return doc unless doc.is_a?(Hash)
+        pages = doc['pages']
+        return doc unless pages.is_a?(Array)
+
+        flattened_pages = []
+        nested_elements = []
+        pages.each do |page|
+          page_copy = page.dup
+          nested_elements.concat(Array(page_copy.delete('elements')))
+          flattened_pages << page_copy
+        end
+        existing_elements = Array(doc['elements'])
+        elements = []
+        seen = {}
+        (existing_elements + nested_elements).each do |element|
+          key = element.is_a?(Hash) && element['id']
+          next if key && seen[key]
+          seen[key] = true if key
+          elements << element
+        end
+
+        doc.merge('pages' => flattened_pages, 'elements' => elements)
+      end
+
+      # themeName/themeOverrides -> settings.theme.{name,overrides}. Non-mutating:
+      # only builds a new hash when a legacy key is actually present, so the
+      # common (already-correct) path returns the input untouched.
+      def fold_legacy_theme(doc, source)
+        name      = doc['themeName']      || source['themeName']
+        overrides = doc['themeOverrides'] || source['themeOverrides']
+        has_ov    = overrides.is_a?(Hash) && !overrides.empty?
+        return doc unless name || has_ov || doc.key?('themeName') || doc.key?('themeOverrides')
+
+        out      = doc.reject { |k, _| LEGACY_THEME_KEYS.include?(k) }
+        settings = (out['settings'] || {}).dup
+        theme    = (settings['theme'] || {}).dup
+        theme['name'] ||= name if name
+        theme['overrides'] = (theme['overrides'] || {}).merge(overrides) if has_ov
+        return out if theme.empty?
+
+        settings['theme'] = theme
+        out['settings'] = settings
+        out
+      end
+    end
+  end
+end

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/control_lint.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,450 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Four checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#   (d) conflicting cross-page control defaults — the severe D11 special
+#       case. Two-or-more controls on DIFFERENT pages whose `filters`
+#       target the SAME source element on the SAME column (or a textual
+#       formula-alias of it) with non-empty, DISJOINT default value sets.
+#       Sigma AND-composes every control that filters a shared source
+#       element, so disjoint defaults form an impossible filter → the
+#       master returns ZERO rows → every element sourced from it reads
+#       EMPTY workbook-wide, silently (no error at build or POST). Fires
+#       only when both defaults are non-empty AND disjoint AND hit the
+#       same in-spec element+column on different pages, so the common
+#       default-all case (values: []) never trips it.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on a live Sigma org):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+require_relative 'code_rep'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, page_id:, kind:, name:, srcel:} } for every
+  # flat workbook element. Page membership comes only from required layout XML;
+  # pages[] is metadata and does not own elements.
+  def elements(spec)
+    out = {}
+    Sigma::CodeRep.workbook_elements_with_pages(spec).each do |el, pg|
+      eid = el['id'] || el['elementId']
+      next unless eid
+      out[eid] = { el: el, page: pg && (pg['name'] || pg['id']),
+                   page_id: pg && pg['id'],
+                   kind: (el['kind'] || el['type']).to_s,
+                   name: el['name'], srcel: source_element_id(el) }
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && info[:page_id] && i[:page_id] == info[:page_id] &&
+          QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  # --- check (d) helpers: conflicting cross-page control defaults ------------
+  # Default selected values of a control. Sigma control fields are FLAT: a list
+  # control carries its defaults in a `values` ARRAY (default-all builds emit
+  # `values: []`). Tolerate `value`/`defaultValue` scalar/array forms other
+  # converters may use. Empty/absent => no default => the caller skips it (this
+  # is the guard that keeps the common default-all case from ever firing (d)).
+  def default_values(el)
+    return el['values'] if el['values'].is_a?(Array)
+    %w[value defaultValue].each do |k|
+      return Array(el[k]) if el.key?(k) && !el[k].nil?
+    end
+    []
+  end
+
+  # { table_element_id => { normalized_formula => [columnId, ...] } }.
+  # Groups a TABLE element's columns by whitespace-normalized formula so the
+  # id-duplication workaround (one logical column emitted under two ids — e.g.
+  # m-website-type / m-website-type-overview, both formula [Custom SQL/Website
+  # Type]) collapses to ONE alias key. Only kind:table elements carry the
+  # columns[] to alias; chart/other targets fall back to the raw columnId at the
+  # call site.
+  def column_alias_groups(spec)
+    out = {}
+    Sigma::CodeRep.workbook_elements(spec).each do |el|
+      next unless el.is_a?(Hash) && el['kind'].to_s == 'table' && el['id']
+      by_formula = Hash.new { |h, k| h[k] = [] }
+      (el['columns'] || []).each do |c|
+        next unless c.is_a?(Hash) && c['id'] && c['formula'].is_a?(String)
+        by_formula[c['formula'].strip.gsub(/\s+/, ' ')] << c['id']
+      end
+      out[el['id']] = by_formula
+    end
+    out
+  end
+
+  # (d) conflicting cross-page control defaults. See the header for the full
+  # rationale. Conservative by construction: an entry is only recorded when the
+  # control has a non-empty default AND a filter target that resolves to a real
+  # in-spec element; a pair only violates when it spans two pages against the
+  # same (element, column-alias) with DISJOINT defaults.
+  def conflicting_default_violations(spec, elems)
+    alias_groups = column_alias_groups(spec)
+    entries = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      defaults = default_values(el)
+      next if defaults.empty?
+      Array(el['filters']).each do |t|
+        next unless t.is_a?(Hash)
+        target = t.dig('source', 'elementId')
+        cid    = t['columnId']
+        next unless target && cid
+        next unless elems.key?(target) # ghost target — owned by check (a)
+        alias_key = (alias_groups[target] || {}).find { |_f, ids| ids.include?(cid) }&.first || cid
+        entries << { eid: eid, control_id: el['controlId'] || eid,
+                     page: info[:page], page_id: info[:page_id],
+                     target: target, alias_key: alias_key, defaults: defaults.to_set }
+      end
+    end
+
+    violations = []
+    entries.group_by { |e| [e[:target], e[:alias_key]] }.each_value do |group|
+      next if group.map { |e| e[:page_id] }.compact.uniq.size < 2
+      group.combination(2).each do |a, b|
+        next if !a[:page_id] || !b[:page_id] || a[:page_id] == b[:page_id]
+        next if (a[:defaults] & b[:defaults]).any? # overlapping => satisfiable, not impossible
+        ca  = "control #{label(elems, a[:eid])} [#{a[:control_id]}]"
+        cb  = "control #{label(elems, b[:eid])} [#{b[:control_id]}]"
+        col = a[:alias_key] == b[:alias_key] ? a[:alias_key] : "#{a[:alias_key]} / #{b[:alias_key]}"
+        violations << "conflicting cross-page control defaults: #{ca} on page #{a[:page].inspect} " \
+                      "defaults to #{a[:defaults].to_a.inspect} and #{cb} on page #{b[:page].inspect} " \
+                      "defaults to #{b[:defaults].to_a.inspect}, but BOTH filter the SAME shared element " \
+                      "#{label(elems, a[:target])} on the same column (#{col}) with DISJOINT default value " \
+                      'sets. Sigma AND-composes every control that targets a shared source element, so the ' \
+                      'composed filter matches ZERO rows on that source — every element sourced from it reads ' \
+                      'EMPTY workbook-wide, with no error at build or POST. Fix by EITHER (1) giving each page ' \
+                      'its own independently-sourced master element (a distinct filter-target elementId per ' \
+                      'page) so the controls no longer compose against one source, OR (2) making the per-page ' \
+                      'defaults overlap (a non-empty intersection) or default-all (values: []) so the composed ' \
+                      'filter is satisfiable'
+      end
+    end
+    violations.uniq
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      # BUT suppress when every scope entry is an already-surfaced gap
+      # (needs-wiring / needs-materialization): the builder DID account for each
+      # source signal in the coverage ledger — e.g. a dashboard whose only
+      # "filter" is an orphan/unreferenced parameter that legitimately becomes no
+      # placeable control. That's a surfaced gap, not the silent static-workbook
+      # miss this rule targets. A genuinely silent miss has signals but NO scope
+      # entries explaining them → still fails.
+      signals = scope['sourceFilterSignals'].to_i
+      scoped = Array(scope['controls'])
+      all_surfaced_gaps = scoped.any? &&
+                          scoped.all? { |c| %w[needs-wiring needs-materialization].include?(c['status'].to_s) }
+      if signals.positive? && rows.empty? && !all_surfaced_gaps
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    # Snapshot before rows.each consumes scope_by_cid via delete — used to tell a
+    # wholesale controlId DRIFT (a from-scratch rewrite: none of the spec's
+    # controls match ANY sidecar id) from genuine per-filter drops.
+    orig_scope_cids = scope_by_cid.keys.dup
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (d) conflicting cross-page control defaults — shared source + disjoint
+    # per-page defaults = impossible AND-composed filter = workbook-wide zero rows.
+    violations.concat(conflicting_default_violations(spec, elems))
+
+    # (c) annotated controls that never made it into the spec ------------------
+    # A scope entry flagged as an ALREADY-SURFACED gap (needs-wiring: an orphan/
+    # unreferenced parameter the builder intentionally does not place as a dead
+    # control; needs-materialization: a calc-bound filter whose column isn't on
+    # the model yet) is recorded in the controls-coverage ledger, NOT silently
+    # dropped — so its absence from the spec is expected, not a "not migrated"
+    # failure. Only a control the builder recorded as EMITTED but that's missing
+    # from the spec is a real bug the source filter was lost.
+    surfaced_gap = %w[needs-wiring needs-materialization].freeze
+    unmatched = scope_by_cid.reject { |_cid, c| surfaced_gap.include?(c['status'].to_s) }
+    spec_cids = rows.map { |r| r[:control_id] }.compact
+    # WHOLESALE DRIFT: the sidecar has real unmatched entries AND none of the
+    # spec's controls match ANY original sidecar id. That is the controlId-drift
+    # signature of a from-scratch wb-spec REWRITE (kebab auto-build ids vs. hand-
+    # authored ids) — not N lost filters. Collapse to ONE actionable hint that
+    # names the true cause instead of a violation per orphaned entry (the field
+    # run drew 14 spurious "missing control"s from exactly this). Still FAILS
+    # (exit non-zero) — this never weakens the gate, only its message.
+    drift = unmatched.any? && spec_cids.any? && spec_cids.none? { |cid| orig_scope_cids.include?(cid) }
+    if drift
+      violations << "control-scope drift: NONE of the spec's #{spec_cids.size} control(s) match any of " \
+                    "the #{orig_scope_cids.size} controlId(s) in control-scope.json (unmatched: " \
+                    "#{unmatched.keys.map(&:inspect).join(', ')}). This is the signature of a from-scratch " \
+                    'wb-spec REWRITE, not lost filters. FIX: patch the auto-built wb-spec in place (keep its ' \
+                    'controlIds) rather than re-authoring it; OR if these controls are genuinely renamed/new, ' \
+                    'regenerate control-scope.json so its controlIds match the posted spec.'
+    else
+      unmatched.each do |cid, c|
+        violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                      "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                      'has no control with that controlId — the source filter was not migrated'
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/layout_lint.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <Container>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level Container) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#   (f) sub-minimum tile height — an element whose gridRow span is below its
+#       kind's minimum (KIND_MIN_ROWS). Sigma renders chart/KPI tiles BLANK
+#       under ~3-4 grid rows — in the live page AND in page/element PNG
+#       exports (hit twice in a 2026-07 live migration). Element kinds come
+#       from the spec's flat document elements; layout-only container shells (no spec
+#       kind) are skipped. A child's span is measured in its own container's
+#       row units (matched-inner-span convention: inner rows track page rows).
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+require_relative 'code_rep'
+
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+  # Per-kind minimum gridRow spans (check f). KEEP IN SYNC with
+  # SigmaLayout::KIND_MIN_ROWS (lib/layout.rb) — this lib is vendored
+  # standalone across plugins, so it carries its own copy. 'chart' covers
+  # every *-chart kind without an explicit entry.
+  KIND_MIN_ROWS = {
+    'kpi-chart'   => 4,  # value + label need ~4 rows to render at all
+    'chart'       => 8,  # axis/labels suppressed and tile blanks below ~8
+    'table'       => 10, # header row + a few data rows
+    'pivot-table' => 10,
+    'control'     => 2,  # one input strip; 2 rows keeps the label visible
+    'text'        => 2,
+    'divider'     => 1,  # hairline rule — stroke centers in the cell
+    'button'      => 2   # control-sized pill
+  }.freeze
+
+  module_function
+
+  # Minimum gridRow span for a Sigma element kind (see KIND_MIN_ROWS).
+  def min_rows_for(kind)
+    k = kind.to_s
+    return KIND_MIN_ROWS[k] if KIND_MIN_ROWS.key?(k)
+    return KIND_MIN_ROWS['chart'] if k.end_with?('-chart')
+    KIND_MIN_ROWS['text']
+  end
+
+  # All [element, page] pairs in the workbook document. Elements are flat;
+  # page metadata is joined through the required layout's <Page> membership.
+  # Layout-only container shells are naturally skipped because they are not in
+  # document.elements.
+  def named_elements(spec)
+    Sigma::CodeRep.workbook_elements_with_pages(spec)
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(Container|GridContainer|Element|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      container = %w[Container GridContainer].include?(tag)
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if container && close == '>'
+        endm = s.match(%r{</#{tag}>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [container ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level Containers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
+  # NESTING-AWARE Container extraction. The old version matched the FIRST
+  # </Container> after an open tag, so an OUTER band's body was truncated
+  # at its first nested container's close — the band then appeared to hold
+  # only that fragment's leaves and false-failed the fill check on every
+  # container-tree layout (live-caught: the whole-page content container
+  # "held" only the region control). Children are the container's DIRECT
+  # Elements PLUS its direct child containers' spans (a nested
+  # container's own leaves live in a different local column space, but the
+  # container itself covers its gridColumn span in the parent's grid).
+  def containers(page_xml)
+    out = []
+    stack = []
+    span = lambda do |tag|
+      [tag[/elementId="([^"]*)"/, 1],
+       tag[/gridColumn="\s*(\d+)/, 1].to_i, tag[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+       tag[/gridRow="\s*(\d+)/, 1].to_i, tag[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+    end
+    page_xml.to_s.scan(
+      %r{</(?:Container|GridContainer)>|<(?:Container|GridContainer)\b[^>]*?/?>|<(?:Element|LayoutElement)\b[^>]*?/?>}m
+    ) do
+      tag = Regexp.last_match(0)
+      if tag.match?(%r{\A</(?:Container|GridContainer)})
+        c = stack.pop
+        out << c if c
+      elsif tag.match?(%r{\A<(?:Container|GridContainer)\b})
+        stack.last[:children] << span.call(tag) unless stack.empty?
+        c = { eid: tag[/elementId="([^"]*)"/, 1], cols: grid_col_count(tag),
+              r0: tag[/gridRow="\s*(\d+)/, 1].to_i,
+              r1: tag[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+              children: [] }
+        tag.end_with?('/>') ? (out << c) : (stack << c)
+      else # Element — a direct child of the innermost open container
+        stack.last[:children] << span.call(tag) unless stack.empty?
+      end
+    end
+    out.concat(stack) # tolerate unclosed tags rather than dropping them
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    spec = Sigma::CodeRep.document(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      page_name = pg && (pg['name'] || pg['id'])
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{page_name || '(unplaced: missing from layout)'}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      # A top-level control is fine when it sits in the control region ABOVE the
+      # first section band (the standard "filter over a banded grid" pattern the
+      # exemplar hand migrations use). It's only orphaned when it floats AT or
+      # BELOW the first band — i.e. lost among the banded chart content.
+      if body.match?(%r{<(?:Container|GridContainer)\b})
+        first_band_r0 = entries.select { |k,| k == :container }.map { |e| e[2] }.min
+        entries.each do |kind, eid, r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          next if first_band_r0 && r0.positive? && r0 < first_band_r0
+          violations << "orphan control: #{eid} sits OUTSIDE every Container on page #{page_id} " \
+                        'and is not in the control region above the first band — place it in the ' \
+                        'control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        # A control-only band is sparse BY DESIGN: source dashboards render a
+        # narrow parameter/filter row with the rest of the band empty, and
+        # stretching a lone dropdown to 60% width would be a fidelity bug, not
+        # a fix. (The orphan-control check above still catches controls parked
+        # OUTSIDE any band.)
+        next if kids.any? && kids.all? { |k| el_kind[k[0]] == 'control' }
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
+        end
+        fill = covered.count(true).to_f / ncols
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (f) sub-minimum tile height --------------------------------------------
+      tiles = entries.select { |k, _e, _r0, _r1| k == :element }
+                     .map { |_k, eid, r0, r1| [eid, r0, r1] }
+      bands.each do |b|
+        b[:children].each { |ceid, _c0, _c1, r0, r1| tiles << [ceid, r0, r1] }
+      end
+      tiles.each do |eid, r0, r1|
+        kind = el_kind[eid]
+        next if kind.nil? || kind == 'container' # layout-only shells
+        min = min_rows_for(kind)
+        span = [r1 - r0, 0].max
+        next if span >= min
+        violations << format('tile below minimum height: element %s (%s) on page %s spans %d grid row(s) ' \
+                             '(< %d required for %s) — Sigma renders sub-minimum tiles BLANK in the page ' \
+                             'and in PNG exports; grow the tile (see SigmaLayout::KIND_MIN_ROWS)',
+                             eid, kind, page_id, span, min, kind)
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/preflight_lint.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/preflight_lint.rb
@@ -1,0 +1,496 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Preflight lint for a workbook spec — catches the two enterprise-class failure modes
+# BEFORE POST, with a precise message instead of the opaque "Invalid kind: control"
+# or a silently-detail-rendered table.
+#
+#   ruby preflight_lint.rb <workbook-spec.json>
+#     exit 0  = clean
+#     exit 1  = violations (printed, one per line)
+#
+# Checks:
+#   T1  a `table` with aggregate column(s) + dimension(s) but NO `groupings`
+#       → renders raw detail rows (the 9.6M-row / $0 / duplicate-dim enterprise bug).
+#   T2  a `groupings.calculations` column that is a PASSTHROUGH of an aggregate
+#       (re-aggregates to "multiple values"); calc cols must be Sum(...)/etc.
+#   C1  a `control` missing id / controlId / controlType.
+#   C2  any control nesting its value fields under a bogus `value` OBJECT
+#       (control fields are FLAT top-level) → the opaque `Invalid kind: control`.
+#       NOTE: a scalar `value:` is legitimate (slider handle position); only an
+#       OBJECT value is the trap. Also: a `source`, if present, must be double-nested.
+#   C3  a list/segmented/hierarchy control wired to NOTHING — neither a `source`
+#       (value-list) nor `filters` (target columns). A filters-only list control
+#       is VALID (live-verified), so source is NOT independently required.
+#   K1  a kpi-chart whose `value.columnId` column's formula is a BARE reference
+#       to a sibling column ([X] with no function call) — compiles clean but
+#       renders NULL (live: the call-center WoW badges). Inline the aggregate.
+#   S1  `style.backgroundColor` on a kpi-chart or bar-chart — blanks the tile in
+#       PNG export and garbles thousands separators (live: call-center KPIs,
+#       supermart mini bars). Use container styling instead.
+#   C5  a control with selectionMode:"single" carrying `values` (array) instead
+#       of scalar `value` — the filter AND the default silently drop.
+#   C6  a control with an unknown controlType, or the docs-only `top-n` type that
+#       the live tenant 400s — mirrors Sigma spec/verify offline (canary 2026-07-11).
+#   C7  a control missing a REQUIRED field for its type: `mode` on
+#       switch/checkbox/text/number/date/slider; `low`/`high` on range-slider;
+#       an unbounded `number-range` (control OR element filter) whose `min` AND
+#       `max` are BOTH present-and-null — the {min:null,max:null} shape an
+#       UNRESTRICTED Tableau quantitative quick-filter used to emit, which 400s
+#       the whole POST (issue #422 — recurred across workbooks). A
+#       number-range with the keys OMITTED is a valid unbounded control
+#       (refs/workbook-layout.md); only null-VALUED bounds are the trap.
+#   C8  `includeNulls` on a controlType where it is off-schema.
+#   N1  an element or column whose `name` is empty/whitespace-only — breaks
+#       parity header matching and blank-renders axes (title hiding belongs on
+#       the element, not the name).
+#
+# WARN-level (printed, never fail the lint — `lint_warnings(spec)`):
+#   P1  a `conditionalFormats` entry with includeValues:false — silently
+#       disables the format (live-verified: visual-vocabulary waffle).
+#   I1  heuristic: If() whose FIRST argument is a bare column ref with no
+#       comparison operator — integer/bit predicates fail at render with
+#       "Invalid Query"; suggest an explicit `= 1` comparison.
+#   A1  a control carrying a DROPPED_BY_API field — the Workbook Spec API
+#       ACCEPTS it (200 on POST/PUT) and SILENTLY DROPS it on readback, so it
+#       never takes effect (Sigma product gap — issues #415/#417). Unlike the
+#       C-class violations, these do NOT 400: they are silently ignored.
+#       DROPPED_BY_API members flagged `conditional` (e.g. `filters`, #456) are
+#       NOT warned here — they persist in the normal case and drop only under a
+#       specific condition, so A1 (a presence check) would false-fire on every
+#       control. Their drop is caught EMPIRICALLY post-POST by the control-field
+#       census (lib/control_field_census.rb).
+#   A2  a date-range control whose startDate/endDate default is a BARE date
+#       ("2026-01-01") or a zoneless timestamp — accepted then silently
+#       dropped (#415); only full ISO-8601 UTC timestamps
+#       ("2026-01-01T00:00:00Z") round-trip.
+require 'json'
+require_relative 'code_rep'
+
+AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
+PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
+LISTY = %w[list segmented hierarchy].freeze
+# C6/C7/C8: controlType shape rules — mirror Sigma's server-side spec/verify
+# OFFLINE, so the control-grammar 400s (each of which otherwise costs a full
+# orchestrator round-trip to discover) are caught pre-POST. Canary-verified
+# server-side 2026-07-11 (see refs/composition-recipe.md).
+CONTROL_TYPES = %w[checkbox switch text text-area number number-range date date-range
+                   list segmented hierarchy slider range-slider legend drill].freeze
+# controlTypes that REQUIRE a `mode` operator — absent/empty → Sigma 400s the spec.
+MODE_REQUIRED = %w[switch checkbox text number date slider].freeze
+MODE_HINT = {
+  'switch' => "'True/False' | 'True/All'", 'checkbox' => "'True/False' | 'True/All'",
+  'text' => "an operator, e.g. 'equals'", 'number' => "'=' | '>=' | '<='",
+  'date' => "'=' | '>=' | '<='", 'slider' => "'=' | '>=' | '<='"
+}.freeze
+# `includeNulls` is schema-valid ONLY on these types (stray elsewhere = off-schema).
+INCLUDE_NULLS_OK = %w[text number number-range date date-range slider range-slider].freeze
+# A1: the DROPPED_BY_API contract table — control fields the Workbook Spec API
+# accepts with 200 on POST/PUT but SILENTLY DROPS on readback (GET returns the
+# control without them; they never take effect on the live control). This is a
+# Sigma product gap, NOT a spec-grammar error: the C-class checks above catch
+# shapes that 400, this family is silently ignored. Human-readable contract
+# table: sigma-workbooks reference/specification/controls.md ("Dropped-by-API
+# fields"). Sources: issues #415 (date-range startDate/endDate — see A2), #417
+# (list-control editor toggles), and #456 (list-control filter TARGET binding),
+# all round-trip-confirmed in the field.
+# field => { 'types' => affected controlTypes (informational — the drop is
+# observed regardless of type), 'workaround' => the sanctioned alternative,
+# 'conditional' => (optional) true when the field PERSISTS in the normal case
+# and drops only under a specific condition — such members are documented here
+# for the contract but are NOT A1-warned on mere presence (A1 is a presence
+# check; it would false-fire on every control). Their drop is caught
+# empirically post-POST by the control-field census instead. }.
+DROPPED_BY_API = {
+  'showNullOption' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => "filter nulls at the control's OPTION-SOURCE instead: point the control's " \
+                    'value-list `source` at a hidden helper element that carries an IsNotNull(<col>) ' \
+                    'filter (build-charts-from-signals emits this automatically for null-excluding ' \
+                    'Tableau filters — field-validated)'
+  },
+  'allowMultipleSelection' => {
+    'types' => %w[list],
+    'workaround' => 'use `selectionMode: "single"|"multiple"` — that field DOES persist'
+  },
+  'excludeValues' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'use `mode: "exclude"` with `values` = the excluded members — that shape DOES persist'
+  },
+  'showClearButton' => {
+    'types' => %w[list segmented hierarchy],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showSearchBox' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showHistogram' => {
+    'types' => %w[list slider range-slider],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'showExpandedList' => {
+    'types' => %w[list],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  'required' => {
+    'types' => %w[list text number date date-range],
+    'workaround' => 'no spec equivalent — configure in the Sigma UI control editor post-publish (record it in POSTPUBLISH_GUIDE.md)'
+  },
+  # #456: the list-control filter TARGET binding itself (which column(s) the
+  # control filters). UNLIKE the always-drop editor toggles above, `filters`
+  # USUALLY round-trips — it is silently dropped only in a specific condition
+  # (the target column is numeric/datetime, or the target can't resolve), where
+  # the readback keeps the `filters` KEY but strips its columnId/source so the
+  # control filters NOTHING. Hence `conditional: true` — A1 must NOT warn on its
+  # mere presence (every valid control carries filters). Detection is EMPIRICAL:
+  # the post-POST control-field census (lib/control_field_census.rb) flags a
+  # posted target that binds nothing on readback. A raw NUMERIC list target is
+  # already routed through a Text() decode by build-charts-from-signals (see A3
+  # below); a target that still can't bind goes to POSTPUBLISH_GUIDE.md.
+  'filters' => {
+    'types' => %w[list segmented hierarchy],
+    'conditional' => true,
+    'workaround' => 'the target DOES persist when it points at a TABLE element on a STRING column ' \
+                    '(filters:[{source:{kind:table,elementId:<table>}, columnId:<col>}]); a NUMERIC/DATETIME ' \
+                    'target is silently stripped (reads back filters:null) — cast it with a hidden Text([<col>]) ' \
+                    'decode column and bind BOTH the filter target and the value-source to the decode ' \
+                    '(build-charts-from-signals routes integer dims automatically; see A3). If it still ' \
+                    "can't bind, route to POSTPUBLISH_GUIDE.md — never ship a control that filters nothing"
+  }
+}.freeze
+# A2: the ONLY startDate/endDate string form observed to round-trip on a
+# date-range control is a full ISO-8601 timestamp WITH timezone (UTC `Z` is
+# what Sigma echoes back). Bare dates ("2026-01-01") are accepted then
+# silently dropped (#415). Relative {op,unit,value} hashes (custom mode) are
+# fine and not checked here.
+ISO_UTC_DATETIME = /\A\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})\z/.freeze
+# I1: If( whose first argument is a bare [ref] immediately followed by `,` or
+# `)` — i.e. no comparison operator. `If([x] = 1, ...)` does NOT match.
+# v5.4: If( ONLY — Sigma's Switch(expr, case1, val1, …, default) is MATCH-form,
+# so a bare [col] first argument is the matched SUBJECT, fully legitimate (the
+# builder's own SORT_ORD ordering columns are exactly this shape and I1
+# flagged them as false positives twice in the field).
+BARE_PREDICATE = /\b(If)\s*\(\s*(\[[^\]]+\])\s*[,)]/i
+
+def lint(spec)
+  spec = Sigma::CodeRep.document(spec)
+  errs = []
+  cols_by_id = {}
+  elements = Sigma::CodeRep.workbook_elements(spec)
+  elements.each do |el|
+    (el['columns'] || []).each { |c| cols_by_id[c['id']] = c }
+  end
+  elements.each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+      cols = el['columns'] || []
+
+      # N1: whitespace-only names (element + columns). A " " name "hides" the
+      # title but breaks verify-warehouse/parity header matching, blank-renders
+      # axes, and collapses parity keys. Hide titles on the ELEMENT instead.
+      if el.key?('name') && el['name'].to_s.strip.empty?
+        errs << "N1 element '#{el['id'] || '(no id)'}' (#{kind}): `name` is empty/whitespace-only — whitespace names break parity header matching and blank axis renders — use a real name (title hiding belongs on the element, not the name)."
+      end
+      cols.each do |c|
+        next unless c.key?('name') && c['name'].to_s.strip.empty?
+        errs << "N1 column '#{c['id'] || '(no id)'}' on element '#{name}': `name` is empty/whitespace-only — whitespace names break parity header matching and blank axis renders — use a real name (title hiding belongs on the element, not the name)."
+      end
+
+      # K1: a kpi-chart's value column must inline the FULL aggregate expression.
+      # A bare sibling ref ([Total Calls]) compiles clean and renders NULL.
+      if kind == 'kpi-chart'
+        vcid = el.dig('value', 'columnId')
+        vcol = cols.find { |c| c['id'] == vcid }
+        if vcol && vcol['formula'].to_s =~ PLAIN_REF
+          errs << "K1 kpi-chart '#{name}': value column '#{vcid}' formula is a bare sibling ref (`#{vcol['formula']}`) — kpi-chart value columns must inline the full aggregate expression — bare sibling refs compile clean but render null."
+        end
+      end
+
+      # S1: element-level backgroundColor on kpi/bar tiles breaks the export
+      # renderer (live UI fine, PNG export blank + garbled separators).
+      if %w[kpi-chart bar-chart].include?(kind) && el.dig('style', 'backgroundColor')
+        errs << "S1 #{kind} '#{name}': style.backgroundColor (#{el.dig('style', 'backgroundColor').inspect}) — backgroundColor on kpi/bar blanks the tile in PNG export and garbles number separators — use container styling instead."
+      end
+
+      if kind == 'table'
+        agg = cols.select { |c| c['formula'].to_s =~ AGG }
+        dim = cols.select { |c| c['formula'].to_s =~ PLAIN_REF }
+        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+        if agg.any? && dim.any? && !grouped
+          errs << "T1 table '#{name}': has aggregate column(s) #{agg.map { |c| c['name'] }.inspect} + dimension(s) but NO `groupings` → will render raw detail rows, not an aggregated summary. Add groupings:[{groupBy:[<dim id>], calculations:[<agg id>...]}]."
+        end
+        # T2: a grouping calculation that points at a passthrough-of-aggregate column
+        (el['groupings'] || []).each do |g|
+          (g['calculations'] || []).each do |cid|
+            f = (cols_by_id[cid] || {})['formula'].to_s
+            # a calc that is a plain ref to another column whose own formula is an aggregate
+            if f =~ PLAIN_REF
+              # can't always resolve cross-element; flag bare passthroughs that look like measures
+              errs << "T2 table '#{name}': grouping calculation '#{cid}' is a passthrough (`#{f}`) — a grouped calculation must be an aggregate expression (Sum([...]) etc.), not a passthrough of an already-aggregated column (renders 'multiple values')." if cols_by_id[cid] && (cols_by_id[cid]['name'].to_s =~ /total|sum|count|avg|revenue|profit|tcv|amount/i)
+            end
+          end
+        end
+      end
+
+      # C7 (element filters): a number-range ELEMENT filter with min AND max
+      # BOTH present-and-null is the same {min:null,max:null} 400 shape as the
+      # control case — the exact defect an UNRESTRICTED Tableau quantitative
+      # quick-filter produced (issue #422). The builder now skips
+      # emitting it, but hard-block any that slip through from any code path so
+      # it can never reach POST again. Keys OMITTED = valid unbounded; only
+      # null-VALUED bounds are flagged.
+      (el['filters'] || []).each_with_index do |flt, i|
+        next unless flt.is_a?(Hash) && flt['kind'] == 'number-range'
+        next unless flt['min'].nil? && flt['max'].nil? && (flt.key?('min') || flt.key?('max'))
+        errs << "C7 element '#{name}': number-range filter[#{i}] has min:null and max:null — an unbounded range Sigma 400s at POST (#422). An UNRESTRICTED quantitative filter is 'all values': drop the filter (it hides nothing) instead of shipping null bounds."
+      end
+
+      if kind == 'control'
+        %w[id controlId controlType].each do |f|
+          errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
+        end
+        errs << "C1 control '#{name}': `id` and `controlId` must be DISTINCT." if !el['id'].to_s.empty? && el['id'] == el['controlId']
+
+        # C2: control value fields are FLAT top-level — never nested under a `value` OBJECT.
+        # (Live-verified: a nested value:{...} yields the opaque "Invalid kind: control" for
+        #  list / date-range / number-range / slider alike.) A SCALAR value: is legitimate
+        #  (the slider handle position), so only flag `value` when it is a Hash.
+        errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
+
+        # A COLUMN-BOUND source ({kind:source}) must be double-nested
+        # ({kind:source, source:{kind:table,elementId}, columnId}). A MANUAL
+        # value-list source ({kind:manual, valueType, values, labels}) — emitted
+        # for segmented parameter controls (e.g. an enterprise measure-switcher) — is a
+        # self-contained list and is correct as-is; Sigma accepts it (live-verified
+        # 2026-06-25). Only flag the column-bound form when it isn't double-nested.
+        if el['source'].is_a?(Hash) && el['source']['kind'] == 'source' && !el['source']['source'].is_a?(Hash)
+          errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
+        end
+
+        # C3: a list-type control must be wired to SOMETHING — a `source` (value-list) and/or
+        # `filters` (target columns). A filters-only list control is VALID (live-verified), so we
+        # require source OR filters, never both, and never the bare mode/selectionMode/values.
+        if LISTY.include?(el['controlType'])
+          has_source  = el['source'].is_a?(Hash)
+          has_filters = el['filters'].is_a?(Array) && !el['filters'].empty?
+          unless has_source || has_filters
+            errs << "C3 control '#{name}': list-type control has neither `source` (value-list) nor `filters` (target columns) — it controls nothing. Add filters:[{source:{kind:table,elementId}, columnId}] and/or a double-nested source."
+          end
+        end
+
+        # C5: single-select controls take a SCALAR `value`, never a `values`
+        # array — with values:[...] both the filter and the default silently
+        # drop on PUT (probe-isolated live, twice).
+        if el['selectionMode'].to_s == 'single' && el['values'].is_a?(Array)
+          scalar = el['values'].first
+          errs << "C5 control '#{name}': selectionMode \"single\" carries `values` (array) — the filter and the default silently drop. Use a scalar instead: replace `values: #{el['values'].inspect}` with `value: #{scalar.inspect}`."
+        end
+
+        # C6/C7/C8: controlType grammar — mirrors Sigma spec/verify offline.
+        ct = el['controlType'].to_s
+        unless ct.empty?
+          if ct == 'top-n'
+            errs << "C6 control '#{name}': controlType \"top-n\" is docs-only — the live tenant 400s it (probed 2026-07-11). Use a top-N rank-filter on the ELEMENT, not a control."
+          elsif !CONTROL_TYPES.include?(ct)
+            errs << "C6 control '#{name}': unknown controlType \"#{ct}\". Valid: #{CONTROL_TYPES.join(', ')}."
+          end
+          # C7: operator-bearing controls require a `mode`.
+          if MODE_REQUIRED.include?(ct) && el['mode'].to_s.empty?
+            errs << "C7 control '#{name}': controlType \"#{ct}\" requires a `mode` (#{MODE_HINT[ct]}) — absent, Sigma 400s the spec."
+          end
+          # C7: a range-slider without track bounds silently filters every row out.
+          if ct == 'range-slider' && (el['low'].nil? || el['high'].nil?)
+            errs << "C7 control '#{name}': controlType \"range-slider\" needs flat `low`/`high` track bounds — bare emits a 0..0 slider that filters all rows out."
+          end
+          # C7: a number-range control whose min AND max are BOTH present-and-null
+          # is the unbounded {min:null,max:null} shape Sigma 400s at POST (#422 —
+          # an UNRESTRICTED Tableau quantitative quick-filter). Keys OMITTED is a
+          # valid unbounded number-range (refs/workbook-layout.md); only
+          # null-VALUED bounds are the trap, so require at least one bound key be
+          # present-and-null before flagging (never flag the valid keys-omitted form).
+          if ct == 'number-range' && el['min'].nil? && el['max'].nil? && (el.key?('min') || el.key?('max'))
+            errs << "C7 control '#{name}': controlType \"number-range\" with min:null and max:null is an unbounded range Sigma 400s at POST (#422) — an UNRESTRICTED quantitative filter is 'all values': emit NO min/max keys (valid unbounded number-range) or concrete bounds, never null bounds."
+          end
+          # C8: includeNulls only valid on a specific subset.
+          if el.key?('includeNulls') && !INCLUDE_NULLS_OK.include?(ct)
+            errs << "C8 control '#{name}': `includeNulls` is off-schema for controlType \"#{ct}\" (valid only on: #{INCLUDE_NULLS_OK.join(', ')})."
+          end
+        end
+      end
+  end
+  errs
+end
+
+# A3 (PR-18): a `Text([ref])` decode of a single column reference — the shape
+# the integer-dim decode routing emits and this lint verifies. Deliberately does
+# NOT match `ToText(` (not a Sigma function).
+A3_TEXT_DECODE = /\AText\s*\(\s*\[[^\]]+\]\s*\)\s*\z/i
+A3_LISTY = %w[list segmented hierarchy].freeze
+
+# WARN-level findings (P1/I1/A3): printed by the CLI but never fail the lint —
+# P1 is a live-verified silent no-op, I1 a heuristic with known false positives
+# (a string-matching Switch([Region], "East", ...) is legitimate), A3 flags an
+# integer-coded dimension control shipped WITHOUT a Text() decode helper.
+#
+# `scope` (optional) is the parsed control-scope.json sidecar. When a control is
+# marked `integer_dim:true` there (build-charts stamps it from the .twb datatype
+# + shelf role), A3 KNOWS the bound column is integer-coded and can warn even
+# when the raw column's type is invisible in the spec. Without a scope, A3 still
+# catches the precise "decode column exists but the control targets the raw
+# column instead" mis-wire from the spec alone.
+def lint_warnings(spec, scope: nil)
+  spec = Sigma::CodeRep.document(spec)
+  warns = []
+  Sigma::CodeRep.workbook_elements(spec).each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+
+      # P1: conditionalFormats with includeValues:false is a silent no-op.
+      (el['conditionalFormats'] || []).each_with_index do |cf, i|
+        next unless cf.is_a?(Hash) && cf['includeValues'] == false
+        warns << "P1 #{kind} '#{name}': conditionalFormats[#{i}] has includeValues:false — includeValues:false silently disables the format — verified live. Keep includeValues:true."
+      end
+
+      # I1: If()/Switch() over a bare column ref (no comparison) — integer/bit
+      # predicates fail at render ("Invalid Query"). Suggest an explicit = 1.
+      (el['columns'] || []).each do |c|
+        c['formula'].to_s.scan(BARE_PREDICATE) do |fn, ref|
+          warns << "I1 column '#{c['name'] || c['id']}' on element '#{name}': #{fn}(#{ref}, ...) uses a bare column ref as the predicate — integer predicates fail at render ('Invalid Query'). Use an explicit comparison, e.g. #{fn}(#{ref} = 1, ...)."
+        end
+      end
+
+      # N2: a column display name containing '/' is ambiguous against the
+      # [Element/Column] path syntax every cross-element formula ref uses —
+      # downstream refs to it split on the slash and resolve a fragment
+      # (Sigma-side 'dependency not found', false PASS/FAIL in ref checks),
+      # and converters DROP such columns from derived elements. WARN, not a
+      # violation: a slash-named column nothing references cross-element is
+      # harmless, so failing the POST for it would be a false stop.
+      ((el['columns'] || []) + (el['metrics'] || [])).each do |c|
+        next unless c.is_a?(Hash) && c['name'].to_s.include?('/')
+        warns << "N2 column '#{c['name']}' on element '#{name}': display name contains '/' — ambiguous against " \
+                 "the [Element/Column] reference path syntax; cross-element refs to it mis-resolve and derived " \
+                 'elements drop it. Rename the column (remove the slash) before wiring anything to it.'
+      end
+
+      next unless kind == 'control'
+      ct = el['controlType'].to_s
+
+      # A1: fields the Workbook Spec API accepts then silently drops (#415/#417).
+      DROPPED_BY_API.each do |field, info|
+        # `conditional` members (e.g. `filters`, #456) persist in the normal case
+        # and drop only under a specific condition — a presence check would
+        # false-fire on every control; the post-POST census catches their drop.
+        next if info['conditional']
+        next unless el.key?(field)
+        warns << "A1 control '#{name}': `#{field}` (controlType \"#{ct}\") is accepted by POST/PUT (200) " \
+                 'but SILENTLY DROPPED on readback — it will never take effect (silently ignored, NOT a 400 ' \
+                 'like the C-class violations; Sigma product gap, issue #417). ' \
+                 "Workaround: #{info['workaround']}."
+      end
+
+      # A2: date-range default in a non-persisting string form (#415).
+      if ct == 'date-range'
+        %w[startDate endDate].each do |f|
+          v = el[f]
+          next unless v.is_a?(String) && !v.strip.empty? && v !~ ISO_UTC_DATETIME
+          warns << "A2 control '#{name}': date-range `#{f}` #{v.inspect} is a bare/zoneless date — accepted " \
+                   'by POST/PUT (200) but SILENTLY DROPPED on readback; the control ships with NO default ' \
+                   '(silently ignored, not a 400 — Sigma product gap, issue #415). Workaround: emit a full ' \
+                   "ISO-8601 UTC timestamp (e.g. \"#{v[0, 10]}T00:00:00Z\"), the only string form observed to " \
+                   'round-trip; then confirm via the post-POST control-field audit, and if it still drops, set ' \
+                   'the default in the Sigma UI (record it in POSTPUBLISH_GUIDE.md).'
+        end
+      end
+  end
+
+  # A3 (PR-18): integer-coded dimension control without a Text() decode helper.
+  # A Sigma list/segmented/hierarchy control sources STRING option values, so a
+  # filter target on a raw INTEGER column is accepted (200) then SILENTLY
+  # stripped — the readback carries filters:null and the control filters nothing
+  # (control-parity.md "list-control targets on NUMERIC columns are silently
+  # stripped"). The fix is a `Text([<col>])` decode column the control binds to.
+  # This catches a REGRESSION of the auto-decode routing. Advisory only.
+  all_els = Sigma::CodeRep.workbook_elements(spec)
+  els_by_id = all_els.each_with_object({}) { |e, h| (id = e['id'] || e['elementId']) && (h[id] = e) }
+  # controlId -> scope record (integer_dim / decode annotations).
+  scope_by_cid = {}
+  if scope.is_a?(Hash)
+    Array(scope['controls']).each { |c| scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId'] }
+  end
+  resolve_target = lambda do |t|
+    return nil unless t.is_a?(Hash)
+    eid = t.dig('source', 'elementId')
+    tgt_el = els_by_id[eid]
+    return nil unless tgt_el
+    (tgt_el['columns'] || []).find { |c| c['id'] == t['columnId'] }
+  end
+  all_els.each do |el|
+    next unless (el['kind'] || el['type']).to_s.include?('control')
+    next unless A3_LISTY.include?(el['controlType'].to_s)
+    name = el['name'] || el['id'] || '(unnamed)'
+    cid  = el['controlId']
+    targets = Array(el['filters'])
+    target_cols = targets.map { |t| resolve_target.call(t) }.compact
+    has_decode = target_cols.any? { |c| c['formula'].to_s =~ A3_TEXT_DECODE }
+    sc = scope_by_cid[cid] || {}
+    decode_status = sc.dig('decode', 'status').to_s
+
+    # Signal 1 — scope marks this control integer_dim but the spec ships no
+    # decode target. manual-required is an ACCOUNTED gap (routed to the
+    # POSTPUBLISH guide) — surface it, but as the softer "add it by hand" note.
+    if sc['integer_dim'] && !has_decode
+      if %w[manual-required partial-manual].include?(decode_status)
+        warns << "A3 control '#{name}': integer-coded dimension control whose decode could NOT be auto-built " \
+                 "(#{decode_status}) — Sigma silently strips a raw numeric list-filter target. Add a `Text([<col>])` " \
+                 'decode column on the target element by hand and bind the control to it (routed to POSTPUBLISH_GUIDE.md).'
+      else
+        warns << "A3 control '#{name}': integer-coded dimension control (control-scope integer_dim:true) with NO " \
+                 '`Text([<col>])` decode helper among its filter targets — Sigma accepts the raw numeric target (200) ' \
+                 'then SILENTLY strips it (readback filters:null); the control filters nothing. Add a Text() decode ' \
+                 'column and repoint the control to it (build-charts-from-signals routes this automatically — a miss ' \
+                 'here is a regression).'
+      end
+      next
+    end
+
+    # Signal 2 — spec-only mis-wire: a decode column EXISTS on the target element
+    # but the control still targets the RAW column. Precise, no false positives:
+    # only fires when a sibling `Text([<target col name>])` is present.
+    next if has_decode
+    targets.each do |t|
+      raw = resolve_target.call(t)
+      next unless raw
+      sibs = (els_by_id[t.dig('source', 'elementId')]['columns'] || [])
+      decode_sib = sibs.find { |c| c['formula'].to_s.strip.casecmp?("Text([#{raw['name']}])") }
+      next unless decode_sib
+      warns << "A3 control '#{name}': a `Text()` decode column (#{decode_sib['name'].inspect}) exists on the target " \
+               "element but the control targets the RAW column #{raw['name'].inspect} — a raw numeric list-filter " \
+               "target is silently stripped by Sigma. Repoint this filter target (and the control's value-source) " \
+               "at #{decode_sib['id'].inspect}."
+    end
+  end
+
+  warns
+end
+
+if __FILE__ == $PROGRAM_NAME
+  path = ARGV[0] or abort('usage: preflight_lint.rb <workbook-spec.json> [control-scope.json]')
+  spec = JSON.parse(File.read(path))
+  # A control-scope.json next to the spec (or passed as ARGV[1]) lets A3 use the
+  # .twb-derived integer_dim signal; without it A3 still catches decode mis-wires.
+  scope_path = ARGV[1] || File.join(File.dirname(path), 'control-scope.json')
+  scope = (JSON.parse(File.read(scope_path)) if File.exist?(scope_path.to_s)) rescue nil
+  errs = lint(spec)
+  warns = lint_warnings(spec, scope: scope)
+  if errs.empty?
+    puts "preflight lint: clean#{warns.any? ? " (#{warns.size} warning(s))" : ''}"
+    warns.each { |w| warn "  ⚠ #{w}" }
+    exit 0
+  end
+  warn "preflight lint: #{errs.size} violation(s)#{warns.any? ? ", #{warns.size} warning(s)" : ''}"
+  errs.each { |e| warn "  ✗ #{e}" }
+  warns.each { |w| warn "  ⚠ #{w}" }
+  exit 1
+end

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma-rest.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma-rest.mjs
@@ -1,0 +1,51 @@
+// Minimal Sigma REST helper for the metabase-to-sigma verify scripts.
+// Reads SIGMA_BASE_URL + SIGMA_API_TOKEN from env — run `eval "$(scripts/get-token.sh)"` first.
+// Tolerates YAML responses (Sigma's /spec POST returns YAML) when pulling an id.
+
+export function sigmaEnv() {
+  const base = process.env.SIGMA_BASE_URL, token = process.env.SIGMA_API_TOKEN;
+  if (!base || !token) {
+    console.error('Missing SIGMA_BASE_URL / SIGMA_API_TOKEN. Run: eval "$(scripts/get-token.sh)"');
+    process.exit(2);
+  }
+  return { base: base.replace(/\/$/, ''), token };
+}
+
+export async function api(method, path, body) {
+  const { base, token } = sigmaEnv();
+  const res = await fetch(base + path, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
+  });
+  const text = await res.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* YAML or empty */ }
+  return { status: res.status, ok: res.ok, text, json };
+}
+
+// Sigma POST /spec returns JSON ({"workbookId":...}) OR YAML (workbookId: ...). Pull either.
+export function extractId(r, field) {
+  if (r.json && r.json[field]) return r.json[field];
+  const m = r.text.match(new RegExp(`${field}:\\s*"?([0-9a-f-]{36})`, 'i'));
+  return m ? m[1] : null;
+}
+
+// Tiny --flag parser: returns { flag: value | true }.
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const k = argv[i].slice(2);
+    const next = argv[i + 1];
+    out[k] = (next == null || next.startsWith('--')) ? true : (i++, next);
+  }
+  return out;
+}
+
+// DM/workbook element listings come back under a few shapes — normalize to [{id,name,kind}].
+export function elementsOf(json) {
+  const list = json?.entries || json?.elements || (Array.isArray(json) ? json : []);
+  return (Array.isArray(list) ? list : []).map((e) => ({
+    id: e.elementId || e.id, name: e.name || e.elementName || '', kind: e.kind || e.type,
+  })).filter((e) => e.id);
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma_rest.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,300 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.auth_token`             — age-aware: re-mints automatically when
+#                                       the token is older than TOKEN_TTL_SECONDS
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Token-freshness semantics (field lesson: sessions repeatedly hit 401s at
+# ~+25min-past-expiry because `auth_token` kept returning the stale env token):
+#   - A token minted by THIS process carries an in-memory minted_at stamp; when
+#     it ages past TOKEN_TTL_SECONDS (50 min), auth_token re-mints proactively.
+#   - The mint time is also surfaced as SIGMA_TOKEN_MINTED_AT (iso8601) so
+#     child processes inherit the token's AGE along with the token itself.
+#   - A token loaded from <WORK>/auth.json is aged by the file's mtime
+#     (get_token.py writes it at mint time, so mtime == mint time).
+#   - A bare env SIGMA_API_TOKEN with no known age is honored as-is
+#     (age-unknown) — the request helper's 401 handler re-mints ONCE and
+#     retries, then fails loudly.
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+require 'time'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env, encoding: 'UTF-8') do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+# File-based token handoff (shell-neutral, kills the `eval "$(get-token.sh)"`
+# bash idiom that PowerShell/cmd cannot run). scripts/get_token.py writes
+# <WORK>/auth.json = {"SIGMA_API_TOKEN": ..., "SIGMA_BASE_URL": ...}. Read it
+# here so any shell/agent can mint once (python) and every downstream Ruby
+# script picks the token up. Precedence: explicit env ALWAYS wins → auth.json →
+# (later) client-credential self-mint via refresh_token!. auth.json is
+# .gitignored and holds a live bearer token — never print it.
+if ENV['SIGMA_API_TOKEN'].nil?
+  _auth_candidates = [ENV['SIGMA_WORKDIR'], Dir.pwd].compact
+                        .map { |d| File.join(d, 'auth.json') }
+  _auth_path = _auth_candidates.find { |p| File.exist?(p) }
+  if _auth_path
+    begin
+      _auth = JSON.parse(File.read(_auth_path, encoding: 'bom|utf-8'))
+      if _auth['SIGMA_API_TOKEN']
+        ENV['SIGMA_API_TOKEN'] ||= _auth['SIGMA_API_TOKEN']
+        # get_token.py writes auth.json at mint time, so the file's mtime IS
+        # the token's mint time — record it so auth_token can age the token
+        # out proactively instead of discovering staleness via a mid-phase 401.
+        ENV['SIGMA_TOKEN_MINTED_AT'] ||= File.mtime(_auth_path).utc.iso8601
+      end
+      ENV['SIGMA_BASE_URL'] ||= _auth['SIGMA_BASE_URL'] if _auth['SIGMA_BASE_URL']
+    rescue JSON::ParserError
+      # A corrupt auth.json must not wedge the run — fall through to self-mint.
+    end
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  # Sigma bearer tokens live ~60 minutes. Any token older than this is treated
+  # as stale and re-minted proactively (50 min leaves a safety margin), so long
+  # phases stop tripping over mid-run 401s from a token that quietly expired.
+  TOKEN_TTL_SECONDS = 50 * 60
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @minted_at = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  # Security (A2): only transmit Sigma credentials to an https://
+  # sigmacomputing.com host. A poisoned SIGMA_BASE_URL would otherwise
+  # exfiltrate the client id/secret. Opt out (self-hosted/dev) with
+  # SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+  def self.validate_base_url!(base)
+    if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+      warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"; return
+    end
+    u = (URI.parse(base) rescue nil); host = u&.host&.downcase
+    abort "FATAL: SIGMA_BASE_URL must use https:// (got '#{base}') — refusing to send Sigma credentials." unless u&.scheme == 'https'
+    abort "FATAL: SIGMA_BASE_URL host '#{host}' is not a sigmacomputing.com host — refusing to send Sigma credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless host == 'sigmacomputing.com' || host&.end_with?('.sigmacomputing.com')
+  end
+
+  # Return a token that is safe to use RIGHT NOW.
+  #   - No token anywhere → mint one.
+  #   - Known mint time (this process minted it, a parent surfaced
+  #     SIGMA_TOKEN_MINTED_AT, or auth.json's mtime) and age > TTL → re-mint
+  #     (requires SIGMA_CLIENT_ID; without creds the stale token is returned
+  #     and the 401 path surfaces the failure loudly).
+  #   - Age unknown (bare env SIGMA_API_TOKEN) → honored as-is; the request
+  #     helper's 401 handler re-mints once and retries.
+  def auth_token
+    tok = @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN']
+    return refresh_token! if tok.nil? || tok.empty?
+    return refresh_token! if token_stale? && ENV['SIGMA_CLIENT_ID']
+    tok
+  end
+
+  # When the current token was minted, if known. The in-memory stamp (set by
+  # refresh_token! in this process) wins; else SIGMA_TOKEN_MINTED_AT (iso8601,
+  # set by a parent process's mint or by the auth.json bootstrap from mtime).
+  # nil = age unknown.
+  def token_minted_at
+    m = @token_mutex.synchronize { @minted_at }
+    return m if m
+    ts = ENV['SIGMA_TOKEN_MINTED_AT'].to_s
+    return nil if ts.empty?
+    begin
+      Time.parse(ts)
+    rescue ArgumentError
+      nil
+    end
+  end
+
+  def token_stale?
+    minted = token_minted_at
+    !minted.nil? && (Time.now - minted) > TOKEN_TTL_SECONDS
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      Sigma.validate_base_url!(base_url)
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      now = Time.now
+      @token_mutex.synchronize do
+        @token_override = tok
+        @minted_at = now
+      end
+      # Surface the refreshed token — and its mint time, so child processes
+      # inherit the token's AGE and re-mint on schedule too — to child
+      # processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      ENV['SIGMA_TOKEN_MINTED_AT'] = now.utc.iso8601
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  # Exhaustively read a paginated LIST endpoint: GET `path` with limit=1000
+  # (the documented API maximum; the server default is 50) and follow
+  # `nextPage` tokens until exhausted, returning the concatenated `entries`.
+  # Unpaginated single-page responses reached END OF SUPPORT on 2026-06-02 —
+  # a bare first-page GET now silently truncates at the default page size
+  # (field case: a 599-column workbook whose error-column audit saw only the
+  # first page). `path` may already carry a query string. The nextPage token
+  # is opaque (URL-encoded on reuse); a repeated token or a non-Hash body ends
+  # the loop defensively rather than spinning — and the repeated-token stop
+  # names itself on stderr, because a silent defensive stop is invisible
+  # truncation, the exact bug class this helper exists to remove.
+  #
+  # An optional block receives each page's parsed body as it arrives; callers
+  # use it for page-level observability (e.g. announcing a multi-page fetch on
+  # stderr) without re-implementing the loop.
+  # Sigma's list endpoints use TWO different pagination conventions, and the
+  # cursor field name and the query-param name must be matched as a PAIR:
+  #   `nextPage`      -> send back as `page=`        (most /v2 list endpoints)
+  #   `nextPageToken` -> send back as `pageToken=`   (e.g. the columns endpoint,
+  #                                                   /v2/connections/tables/{inodeId}/columns)
+  # Handling only the first convention is a SILENT TRUNCATION, not an error: the
+  # second-convention endpoints simply never expose `nextPage`, so the loop ends
+  # after page 1 and returns exactly the server's default page size (50) with no
+  # warning. Measured live on a real 149-column table: 50 of 149 columns
+  # returned, which surfaced downstream as 99 phantom "missing" columns in the
+  # domo column pre-flight — and, far worse, would let assert-phase6-ran.rb's
+  # error-column audit inspect only the first 50 columns of a wide table and
+  # still report clean (bead 0h11; same class as bf1f, different endpoint).
+  # Mixing the pair is its own trap: feeding a `nextPageToken` back as `page=`
+  # makes the server re-serve page 1 forever, so the repeated-cursor guard below
+  # is what keeps a half-fix from becoming an infinite loop.
+  def list_entries(path, limit: 1000, http: nil)
+    entries = []
+    cursor = nil
+    cursor_param = nil
+    seen = {}
+    pages = 0
+    loop do
+      qs = "limit=#{limit.to_i}"
+      qs += "&#{cursor_param}=#{URI.encode_www_form_component(cursor)}" if cursor
+      data = request(:get, "#{path}#{path.include?('?') ? '&' : '?'}#{qs}", http: http)
+      break unless data.is_a?(Hash)
+      pages += 1
+      yield data if block_given?
+      entries.concat(data['entries'] || [])
+
+      # Read whichever cursor this endpoint actually returned, and remember the
+      # param it must be sent back as.
+      if !data['nextPage'].nil? && !data['nextPage'].to_s.empty?
+        cursor = data['nextPage']
+        cursor_param = 'page'
+      elsif !data['nextPageToken'].nil? && !data['nextPageToken'].to_s.empty?
+        cursor = data['nextPageToken']
+        cursor_param = 'pageToken'
+      else
+        break
+      end
+
+      if seen[cursor]
+        warn "#{path}: server repeated #{cursor_param} cursor #{cursor.inspect} — " \
+             "stopping after #{pages} page(s) to avoid an infinite loop (list may be incomplete)"
+        break
+      end
+      seen[cursor] = true
+    end
+    entries
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,97 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+    import time
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    if ".au." in sigma_base: return "au"
+    if ".eu." in sigma_base: return "eu"
+    if ".uk." in sigma_base: return "uk"
+    if ".ca." in sigma_base: return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """First 8 hex chars of SHA256(client_id). Unique per org, not reversible."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises.
+
+    What IS sent:
+      tool            — e.g. "metabase-to-sigma"
+      sigma_region    — derived from API base URL (e.g. "au")
+      org_id_hash     — SHA256(SIGMA_CLIENT_ID)[0:8], unique per org, not reversible
+      duration_seconds
+      success         — True/False
+      skill_version
+
+    What is NOT sent:
+      workbook names, IDs, or URLs
+      SQL queries or column names
+      dashboard or card titles
+      user email or name
+      any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        print("  → telemetry unavailable (skipped)\n")

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/metabase-discover.sh
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/metabase-discover.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Metabase REST discovery helper (converter-side; the assessment skill has the
+# full estate walker). Read-only GETs.
+#
+#   export MB_BASE="https://<host>"           # plus MB_KEY or MB_USER/MB_PASS
+#   eval "$(scripts/get-metabase-session.sh)"
+#
+#   metabase-discover.sh collections                 # collection tree (id, name, location)
+#   metabase-discover.sh items     <collectionId>    # cards/dashboards/models in a collection
+#   metabase-discover.sh card      <cardId>          # full card JSON (question/model)  → stdout
+#   metabase-discover.sh dashboard <dashboardId>     # full dashboard JSON              → stdout
+#   metabase-discover.sh databases                   # list databases (find the warehouse conn)
+#   metabase-discover.sh metadata  <databaseId>      # schema metadata (FIELD IDS — converter needs this)
+set -euo pipefail
+if ! command -v mb_get >/dev/null 2>&1 && [ -z "${MB_AUTH_HDR:-}" ]; then
+  echo "Run: eval \"\$(scripts/get-metabase-session.sh)\" first" >&2; exit 1
+fi
+req() { curl -s "$MB_BASE$1" -H 'Accept: application/json' -H "$MB_AUTH_HDR"; }
+cmd="${1:-}"; id="${2:-}"
+case "$cmd" in
+  collections)
+    req "/api/collection" | python3 -c '
+import sys,json
+for c in json.load(sys.stdin):
+    if isinstance(c, dict):
+        kind = "personal" if c.get("personal_owner_id") else "shared"
+        cid, loc, name = str(c.get("id")), c.get("location") or "/", c.get("name")
+        print(f"{cid:>6}  {kind:8}  {loc:12}  {name}")' ;;
+  items)
+    req "/api/collection/$id/items?models=card&models=dashboard&models=dataset&limit=200" | python3 -c '
+import sys,json
+d=json.load(sys.stdin)
+for i in d.get("data", []):
+    model, iid, name = i.get("model", "?"), str(i.get("id")), i.get("name")
+    print(f"{model:10} {iid:>6}  {name}")
+t=d.get("total"); n=len(d.get("data", []))
+if t and t > n: print(f"… {t-n} more — paginate with &offset={n}", file=sys.stderr)' ;;
+  card)      req "/api/card/$id" ;;
+  dashboard) req "/api/dashboard/$id" ;;
+  databases)
+    req "/api/database" | python3 -c '
+import sys,json
+d=json.load(sys.stdin); rows=d.get("data") if isinstance(d, dict) else d
+for db in rows or []:
+    did, eng, name = str(db.get("id")), db.get("engine", "?"), db.get("name")
+    print(f"{did:>4}  {eng:12}  {name}")' ;;
+  metadata)  req "/api/database/$id/metadata" ;;
+  *) echo "usage: metabase-discover.sh {collections | items <id> | card <id> | dashboard <id> | databases | metadata <dbId>}" >&2; exit 1 ;;
+esac

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/metabase-dm-signature.py
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/metabase-dm-signature.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""metabase-dm-signature.py — build a DM-reuse signature from the Metabase converter output.
+
+Feeds scripts/find-or-pick-dm.rb (Phase 1.5) so the migration REUSES an existing
+Sigma data model that already covers the same warehouse tables instead of
+creating a 4th near-identical one. Mirrors powerbi-to-sigma's
+pbi-dm-signature.py. Emits the signature shape find-or-pick-dm expects:
+
+  { "workbook":         "<bundle name>",          # generic label
+    "tableau_workbook": "<bundle name>",          # shared picker compatibility
+    "warehouse_tables":   ["DB.SCHEMA.TABLE", ...],
+    "referenced_columns": ["Col", ...],
+    "measures":           [{"col": "Col", "derivation": "Sum|CountDistinct|..."}] }
+
+Input = the Phase-1 converter output (the Sigma data-model JSON `cli.ts` printed
+for the Data Module — dm.json, BEFORE it is POSTed). Walks every element:
+`source.path` (warehouse-table) → tables, column `name`/formula tail → columns,
+element `metrics` → measures. Custom-SQL elements surface as a CUSTOM_SQL
+sentinel, same as the picker uses for candidate DMs. Pure (no network).
+
+Usage: python3 scripts/metabase-dm-signature.py --dm-spec dm.json --out dm-signature.json
+"""
+import argparse, json, re, sys
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dm-spec", required=True, help="Phase-1 converter output (Sigma DM JSON)")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    spec = json.load(open(a.dm_spec))
+
+    elements = spec.get("elements") or [e for p in spec.get("pages", []) for e in p.get("elements", [])]
+    tables, cols, measures = [], [], []
+    for el in elements:
+        src = el.get("source") or {}
+        kind = src.get("kind")
+        if kind in ("warehouse-table", "table"):
+            path = src.get("path")
+            fqn = ".".join(path) if isinstance(path, list) else \
+                  (path or ".".join(p for p in [src.get("database"), src.get("schema"), src.get("name")] if p))
+            if fqn:
+                tables.append(str(fqn).upper())
+        elif kind == "sql":
+            tables.append("CUSTOM_SQL")
+        for c in el.get("columns", []):
+            name = c.get("name")
+            if not name:
+                m = re.search(r"\[.*?([^/\]]+)\]", str(c.get("formula", "")))
+                name = m.group(1) if m else None
+            if name:
+                cols.append(name)
+        for m in el.get("metrics", []):
+            measures.append({"col": m.get("name", ""),
+                             "derivation": m.get("aggregation") or m.get("derivation")})
+
+    label = spec.get("name") or "Metabase card bundle"
+    sig = {"workbook": label,
+           "tableau_workbook": label,
+           "warehouse_tables": sorted(set(tables)),
+           "referenced_columns": sorted(set(cols)),
+           "measures": measures}
+    json.dump(sig, open(a.out, "w"), indent=2)
+    print(f"[metabase-dm-signature] {len(elements)} element(s): {len(sig['warehouse_tables'])} table(s), "
+          f"{len(sig['referenced_columns'])} col(s), {len(measures)} measure(s) -> {a.out}",
+          file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/pick-destination.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/pick-destination.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Shared destination picker for the *-to-sigma migration skills (Node port).
+// Produces the folderId where a migrated data model + workbook should land.
+// The SKILL drives the *asking*; this script lists candidates and creates folders.
+//
+//   node pick-destination.mjs list
+//       -> { workspaces:[{id,name}], folders:[{id,name,parentId,parentName}], myDocuments }
+//   node pick-destination.mjs create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+//       -> { id, name, parentId }
+//
+// Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set; else minted from
+// SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function loadNeutralEnv() {
+  if (process.env.SIGMA_CLIENT_ID || process.env.SIGMA_API_TOKEN) return;
+  const p = path.join(os.homedir(), '.sigma-migration', 'env');
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#') || !t.includes('=')) continue;
+    const idx = t.indexOf('=');
+    const k = t.slice(0, idx).trim();
+    const v = t.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+}
+
+const BASE = () => (process.env.SIGMA_BASE_URL || 'https://aws-api.sigmacomputing.com').replace(/\/$/, '');
+let TOK = null;
+async function token() {
+  if (process.env.SIGMA_API_TOKEN) return process.env.SIGMA_API_TOKEN;
+  loadNeutralEnv();
+  const body = new URLSearchParams({ grant_type: 'client_credentials',
+    client_id: process.env.SIGMA_CLIENT_ID, client_secret: process.env.SIGMA_CLIENT_SECRET });
+  const r = await fetch(BASE() + '/v2/auth/token', { method: 'POST', body });
+  return (await r.json()).access_token;
+}
+async function call(method, p, body) {
+  if (!TOK) TOK = await token();
+  const r = await fetch(BASE() + p, { method,
+    headers: { Authorization: 'Bearer ' + TOK, 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined });
+  const raw = await r.text();
+  if (!r.ok) { console.error(`${method} ${p} -> ${r.status} ${raw.slice(0, 300)}`); process.exit(1); }
+  return raw ? JSON.parse(raw) : {};
+}
+async function myDocumentsId() {
+  try {
+    const uid = (await call('GET', '/v2/whoami'))?.userId;
+    if (!uid) return null;
+    const entries = (await call('GET', `/v2/members/${uid}/files?typeFilters=folder&limit=500`))?.entries || [];
+    const hit = entries.find(e => e.name === 'My Documents' || e.path === 'My Documents');
+    return hit ? hit.id : null;
+  } catch { return null; }
+}
+async function cmdList() {
+  const ws = ((await call('GET', '/v2/workspaces?limit=500')).entries || [])
+    .map(w => ({ id: w.workspaceId || w.id, name: w.name }));
+  const wsName = Object.fromEntries(ws.map(w => [w.id, w.name]));
+  const folders = ((await call('GET', '/v2/files?typeFilters=folder&limit=500')).entries || [])
+    .filter(f => f.permission === 'edit')
+    .map(f => ({ id: f.id, name: f.name, parentId: f.parentId, parentName: wsName[f.parentId] || null }));
+  console.log(JSON.stringify({ workspaces: ws, folders, myDocuments: await myDocumentsId() }, null, 2));
+}
+async function cmdCreate(argv) {
+  let name = null, parent = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--name') { name = argv[++i]; }
+    else if (argv[i] === '--parent') { parent = argv[++i]; }
+  }
+  if (!name) { console.error('pick-destination create: --name is required'); process.exit(1); }
+  if (!parent) parent = await myDocumentsId();
+  const body = { type: 'folder', name };
+  if (parent) body.parentId = parent;
+  const res = await call('POST', '/v2/files', body);
+  console.log(JSON.stringify({ id: res.id, name: res.name, parentId: res.parentId }, null, 2));
+}
+const cmd = process.argv[2] || 'list';
+if (cmd === 'list') await cmdList();
+else if (cmd === 'create') await cmdCreate(process.argv.slice(3));
+else { console.error('usage: pick-destination.mjs [list | create --name NAME [--parent ID]]'); process.exit(1); }

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/post-and-readback.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/post-and-readback.mjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// post-and-readback.mjs — POST a Metabase-converted DM or workbook spec, then read it
+// back and FAIL LOUDLY on any error-typed column (a spec can POST 200 yet have
+// formulas that don't resolve at query time — those surface as type "error").
+//
+// Workbook POSTs additionally run the SHARED layout + control lints on the
+// readback spec (scripts/lib/layout_lint.rb / control_lint.rb — vendored
+// byte-identical across the sigma-migration-skills plugins; gate 6/7 of
+// assert-phase6-ran.rb re-checks the same thing later). The control lint picks
+// up the control-scope.json sidecar next to --spec (or --control-scope PATH).
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/post-and-readback.mjs --type datamodel|workbook --spec spec.json --folder <folderId> \
+//     [--name N] [--out map.json] [--control-scope scope.json]
+//     [--keep-rejected-bindings]   # legacy behavior: if the org rejects
+//                                  # control→DM-parameter bindings, keep the
+//                                  # (now-decorative) controls and only strip
+//                                  # the binding. Default is to DROP them: a
+//                                  # control that provably drives nothing is
+//                                  # the exact furniture gate 7 exists to block
+//                                  # (the customer-feedback issue was "controls
+//                                  # not driving anything"). The DM {{tag}}
+//                                  # controls still carry the filter — re-add a
+//                                  # workbook control synced to the DM
+//                                  # parameter in the UI when the org enables it.
+//
+// Prints { dataModelId|workbookId, errors:[...] } and exits non-zero if any error
+// columns (exit 1) or lint violations (exit 4 = control, exit 5 = layout).
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { api, extractId, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+import { document, metadata, workbookElements, wrap } from './lib/code_rep.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.type || !a.spec || !a.folder) { console.error('need --type datamodel|workbook --spec <spec.json> --folder <folderId>'); process.exit(2); }
+const idField = a.type === 'datamodel' ? 'dataModelId' : 'workbookId';
+const postPath = a.type === 'datamodel' ? '/v2/dataModels/spec' : '/v2/workbooks/spec';
+const colsPath = (id) => a.type === 'datamodel' ? `/v2/dataModels/${id}/columns` : `/v2/workbooks/${id}/columns`;
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const WORKDIR = dirname(a.spec);
+const scopePath = a['control-scope'] || join(WORKDIR, 'control-scope.json');
+
+const spec = JSON.parse(readFileSync(a.spec, 'utf8'));
+const name = a.name || spec.name || `metabase ${a.type} ${Date.now()}`;
+// Workbook writes require the released code-representation envelope. Data-model
+// writes deliberately remain flat; that API does not accept `document`.
+const body = a.type === 'workbook'
+  ? wrap(document(spec), { ...metadata(spec), folderId: a.folder, name })
+  : { folderId: a.folder, ...spec, name };
+let post = await api('POST', postPath, body);
+// Control→DM-parameter bindings (remap --dm-spec) can be rejected by orgs where
+// data-model parameter targeting isn't enabled. Default: DROP the affected
+// controls entirely (a control that provably drives nothing is furniture — the
+// control lint would rightly fail it) and patch the control-scope sidecar.
+// --keep-rejected-bindings keeps them with only the binding stripped (legacy;
+// gate 7 WILL flag them dead until you sync each control in the UI:
+// control → Settings → "Sync with data source parameter").
+if (!post.ok && /Invalid parameter on control/.test(post.text)) {
+  const bound = (c) => c?.kind === 'control' && c.parameters;
+  const dropped = [];
+  if (a['keep-rejected-bindings']) {
+    let stripped = 0;
+    const strip = (c) => { if (bound(c)) { delete c.parameters; stripped++; } };
+    for (const element of workbookElements(body)) strip(element);
+    if (stripped) {
+      console.error(`WARN: org rejected control→data-model parameter bindings — stripped ${stripped} and retrying (--keep-rejected-bindings). These controls POST but DRIVE NOTHING until you sync each to its DM control in the UI; the control lint (gate 7) will flag them dead until then.`);
+      post = await api('POST', postPath, body);
+    }
+  } else {
+    for (const element of workbookElements(body)) if (bound(element)) dropped.push(element.controlId);
+    const droppedElementIds = new Set(
+      (body.document.elements || []).filter((element) => bound(element)).map((element) => element.id),
+    );
+    body.document.elements = (body.document.elements || []).filter((element) => !bound(element));
+    if (droppedElementIds.size && typeof body.document.layout === 'string') {
+      body.document.layout = body.document.layout.replace(
+        /<Element\b[^>]*\belementId="([^"]*)"[^>]*\/>/g,
+        (node, elementId) => droppedElementIds.has(elementId) ? '' : node,
+      );
+    }
+    if (dropped.length) {
+      console.error(`WARN: org rejected control→data-model parameter bindings — DROPPED ${dropped.length} control(s) [${dropped.join(', ')}] and retrying. The filters still live on the DM's {{tag}} controls; re-add a workbook control synced to the DM parameter in the UI when the org enables data-model parameter targeting (or re-run with --keep-rejected-bindings to keep decorative controls and sync them by hand).`);
+      // patch the control-scope sidecar so gate 7 doesn't expect the dropped controls
+      if (existsSync(scopePath)) {
+        try {
+          const scope = JSON.parse(readFileSync(scopePath, 'utf8'));
+          scope.controls = (scope.controls || []).filter((c) => !dropped.includes(c.controlId));
+          const specControls = workbookElements(body).filter((e) => e.kind === 'control').length;
+          if (!specControls) {
+            scope.note = `sourceFilterSignals zeroed by post-and-readback: the org rejected control→DM-parameter bindings for [${dropped.join(', ')}] — the signals are non-portable here; the DM {{tag}} controls carry the filters.`;
+            scope.sourceFilterSignals = 0;
+          }
+          writeFileSync(scopePath, JSON.stringify(scope, null, 2));
+          console.error(`patched ${scopePath} (removed ${dropped.length} sidecar entr${dropped.length === 1 ? 'y' : 'ies'})`);
+        } catch { console.error(`WARN: could not patch ${scopePath} — fix it by hand before gate 7.`); }
+      }
+      post = await api('POST', postPath, body);
+    }
+  }
+}
+const id = extractId(post, idField);
+if (!id) { console.error(`POST failed (HTTP ${post.status}): ${post.text.slice(0, 500)}`); process.exit(1); }
+console.error(`POST ok → ${idField}=${id}`);
+
+// Gate-2 sentinel (assert-phase6-ran.rb orphan check): every POSTed workbook is
+// recorded; >1 unique id without a cleanup marker blocks GREEN.
+if (a.type === 'workbook') {
+  appendFileSync(join(WORKDIR, 'posted-workbooks.jsonl'), JSON.stringify({ id, name: body.name, at: new Date().toISOString() }) + '\n');
+  writeFileSync(join(WORKDIR, 'wb-ids.json'), JSON.stringify({ workbookId: id }, null, 2));
+}
+
+// Silent-error guard: scan resolved column types; type "error" = formula didn't resolve.
+const cols = await api('GET', colsPath(id));
+const errors = [];
+const list = cols.json?.entries || cols.json?.columns || (Array.isArray(cols.json) ? cols.json : []);
+for (const c of (Array.isArray(list) ? list : [])) {
+  const t = c.type?.type || c.columnType || c.type;
+  if (String(t).toLowerCase() === 'error') errors.push(c.name || c.columnName || c.columnId);
+}
+const elements = elementsOf((await api('GET', a.type === 'datamodel' ? `/v2/dataModels/${id}/elements` : `/v2/workbooks/${id}/elements`)).json);
+const result = { [idField]: id, elements, errors };
+if (a.out) writeFileSync(a.out, JSON.stringify(result, null, 2));
+console.log(JSON.stringify(result, null, 2));
+if (errors.length) { console.error(`FAIL: ${errors.length} error-typed column(s): ${errors.join(', ')}`); process.exit(1); }
+console.error(`readback clean: ${elements.length} element(s), 0 error columns`);
+
+// ── shared lint pass (workbooks): layout_lint + control_lint on the READBACK spec
+if (a.type === 'workbook') {
+  const rb = await api('GET', `/v2/workbooks/${id}/spec`);
+  const rbPath = join(WORKDIR, 'workbook-readback.spec.json');
+  writeFileSync(rbPath, rb.json ? JSON.stringify(rb.json, null, 2) : rb.text);
+  const run = (script, args) => spawnSync('ruby', [join(SCRIPTS, 'lib', script), ...args], { stdio: 'inherit' });
+  // layout lint: pre-apply-layout this only catches raw-id display names; the
+  // full check re-runs in apply-layout.mjs and as gate 6.
+  const lay = run('layout_lint.rb', [rbPath]);
+  if (lay.status !== 0) { console.error('FAIL: layout lint violations on the readback spec (see above).'); process.exit(5); }
+  const ctl = run('control_lint.rb', existsSync(scopePath) ? [rbPath, scopePath] : [rbPath]);
+  if (ctl.status !== 0) {
+    console.error('FAIL: control lint violations on the readback spec (see above). Fix the wiring');
+    console.error('      (refs/control-parity.md repair recipes) or annotate intent in control-scope.json, then re-run.');
+    process.exit(4);
+  }
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/probe-controls.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,468 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on a live Sigma org):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# POOLED EXPORTS (W2.12): the K×2 serial export round-trips (baseline + flip
+# per control, plus leak checks) now run --pool wide (default 5) through
+# ExportPool.pooled_element_exports — TRANSPORT ONLY: which elements are
+# exported, the row-set signatures, and every PASS/FAIL/SKIP verdict are
+# computed here exactly as before, from the same raw CSVs. A pooled export
+# that fails is retried serially at its call site (fail-open); --no-pool
+# forces the serial path outright, and a twin vendored WITHOUT
+# scripts/lib/export_pool.rb (the probe-controls manifest targets are a
+# superset of export_pool's — e.g. domo) degrades to the serial seam at load
+# instead of dying on the require. Evidence lands under --out per the
+# version-keyed raw contract: the untouched wire CSVs plus
+# probe-evidence.json binding each file's sha256 to the workbook's
+# latestDocumentVersion at probe time — verdicts are recomputed from those
+# bytes on every run, never reused.
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#     [--no-pool]                    # serial exports (fallback transport)
+#     [--pool N]                     # pooled export width (default 5)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'date'
+require 'optparse'
+require 'digest'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+begin
+  require 'export_pool'
+rescue LoadError
+  # This script's manifest targets are a SUPERSET of export_pool.rb's (e.g.
+  # domo vendors probe-controls.rb but not scripts/lib/export_pool.rb). The
+  # pool is TRANSPORT ONLY (W2.12), so a twin without the lib degrades to the
+  # serial export seam below instead of dying at load: --no-pool is implied
+  # and --pool is a no-op. Verdict logic is identical on both transports.
+end
+HAVE_POOL = defined?(ExportPool) ? true : false
+
+# Workbook code-rep document wrapper (#608) — same vendoring rule as
+# assert-phase6-ran.rb's gate 4/6/7/7b fix. GET /v2/workbooks/{id}/spec now
+# nests pages/layout/schemaVersion/kind under a top-level `document` key
+# (verified live 2026-08-03/04); without unwrapping, ControlLint.elements /
+# controls_report see no top-level `pages` and this probe aborts with "no
+# controls found" on every live workbook. This script's manifest targets are
+# currently a SUBSET of code_rep.rb's (see shared/manifest.json), so every
+# vendored copy carries it — the rescue below fails toward the legacy flat
+# read (WARNed, not silent) rather than crashing a stale checkout.
+begin
+  require 'code_rep'
+rescue LoadError
+end
+CODE_REP_LOADED = defined?(Sigma::CodeRep) ? true : false
+unless CODE_REP_LOADED
+  warn '[WARN] scripts/lib/code_rep.rb not vendored alongside this script (re-vendor;' \
+       ' md5 discipline) — reading the RAW (possibly document-nested) spec, which may' \
+       ' report 0 controls on a live nested readback.'
+end
+
+opts = { values: {}, controls: [], timeout: 90, pool: 5 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+  p.on('--no-pool', 'serial exports (fallback transport)') { opts[:no_pool] = true }
+  p.on('--pool N', Integer, 'pooled export width (default 5)') { |v| opts[:pool] = v }
+end.parse!
+opts[:no_pool] = true unless HAVE_POOL # no export_pool.rb vendored → serial transport
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+# Transport is ExportPool's shared export → poll → download seam (one
+# Deadline per export = the old per-CSV --timeout bound); where export_pool.rb
+# is not vendored, the serial seam below walks the same wire flow through
+# Sigma.request. Either way an HTML body behind a 200 (renderer error) raises
+# instead of masquerading as comparable CSV.
+def export_csv(wb, element_id, params, timeout)
+  return serial_export_csv(wb, element_id, params, timeout) unless HAVE_POOL
+  qid = ExportPool.start_export(wb, element_id, 'csv', nil, params: params)
+  raise "export request failed: no queryId for #{element_id}" unless qid
+  status, body = ExportPool.poll_csv_download(qid, ExportPool::Deadline.new(timeout))
+  case status
+  when :timeout then raise "export timed out after #{timeout}s (queryId=#{qid})"
+  when :html    then raise "export returned HTML behind a 200 (renderer error, queryId=#{qid})"
+  else body
+  end
+end
+
+# Serial fallback transport (no export_pool.rb vendored — see the soft require
+# above): POST the export and poll the download through the shared REST layer,
+# bounded by the same per-CSV --timeout. Same wire flow, same HTML-behind-200
+# guard as the pooled seam.
+def serial_export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: no queryId for #{element_id}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    begin
+      b = Sigma.request(:get, "/v2/query/#{qid}/download", accept: 'text/csv', binary: true)
+      if b && !b.to_s.empty?
+        raise "export returned HTML behind a 200 (renderer error, queryId=#{qid})" if b.to_s.lstrip.start_with?('<')
+        return b
+      end
+    rescue Sigma::Error => e
+      raise unless e.message.lines.first.to_s =~ /\b404\b/ # not materialized yet — keep polling
+    end
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 1
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec_raw = fetch_spec(WB)
+# Unwrap ONCE: ControlLint.elements/controls_report expect the plain document
+# shape (top-level `pages`) — spec_raw is kept as the full (unmodified)
+# response because it still carries the metadata fields (workbookId,
+# latestDocumentVersion, …) DOC_VERSION below needs, which live OUTSIDE
+# `document` and must not be read through the unwrapped `spec`.
+spec  = CODE_REP_LOADED ? Sigma::CodeRep.document(spec_raw) : spec_raw
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+# PAGINATED: this map resolves control targets to display labels; truncation left
+# controls past column 50 unlabeled.
+cols = Sigma.list_entries("/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+cols.each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# --- version-keyed raw evidence ----------------------------------------------
+# Every CSV written under --out is the UNTOUCHED wire body; probe-evidence.json
+# binds each file's sha256 to the workbook doc version at probe time. Verdicts
+# are recomputed from these bytes on every run — never reused from a record.
+DOC_VERSION = if HAVE_POOL
+                ExportPool.resolve_doc_version(spec_raw)
+              else # same resolution, inlined for twins without export_pool.rb
+                v = spec_raw.is_a?(Hash) ? spec_raw['latestDocumentVersion'] || spec_raw['latestVersion'] : nil
+                v.nil? || v.to_s.empty? ? nil : v.to_s
+              end
+EVIDENCE = {}
+record_evidence = lambda do |fname, text|
+  File.write(File.join(OUT, fname), text)
+  EVIDENCE[fname] = Digest::SHA256.hexdigest(text.to_s)
+end
+
+# In/out-of-closure element selection (shared by the pooled prefetch and the
+# probe loop so the two can never diverge).
+pick_in_el = lambda do |r|
+  (r[:reach] & r[:page_queryable]).first ||
+    r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+end
+pick_out_el = lambda do |r|
+  r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+end
+
+# Resolve a control's value-source column (source.columnId, falling back to
+# the first filter target's columnId) — shared by pick_value and the pooled
+# baseline prefetch.
+value_src = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  src = el['source']
+  src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+  src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+  src.is_a?(Hash) && src['elementId'] && src['columnId'] ? src : nil
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = value_src.call(r)
+    return [nil, 'no value-source column resolvable — pass --value'] unless src
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  when 'date-range', 'date'
+    # A Sigma date-range control's value MUST be encoded "min:<date>,max:<date>"
+    # (issue #540). Every other plausible spelling is accepted by the export API
+    # and then silently IGNORED, so the element exports unchanged and the probe
+    # concludes "wired but inert" — a false failure pointing at a control that
+    # works. Measured against a live date-range control:
+    #
+    #   2025-01-01,2025-06-30                          -> FAIL (ignored)
+    #   2025-01-01T00:00:00.000Z,2025-06-30T00:00:00Z  -> FAIL (ignored)
+    #   2025-01-01..2025-06-30                         -> FAIL (ignored)
+    #   min:2025-01-01,max:2025-06-30                   -> PASS (export differs)
+    #
+    # So derive the range here instead of making the operator guess: read the
+    # target column's own values and flip to the EARLIER HALF (min..midpoint),
+    # which is a strict subset and therefore must change the export.
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first
+    src = el['source'].is_a?(Hash) && el['source']['kind'] == 'source' ? el['source']['source'].merge('columnId' => el['source']['columnId']) : src
+    return [nil, 'date-range: no target column resolvable — pass --value "min:<YYYY-MM-DD>,max:<YYYY-MM-DD>"'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "date-range: no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value \"min:<YYYY-MM-DD>,max:<YYYY-MM-DD>\""] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "date-range: column #{label.inspect} not in export — pass --value \"min:<YYYY-MM-DD>,max:<YYYY-MM-DD>\""] unless csv.headers.include?(label)
+    days = csv.map { |row| (Date.parse(row[label].to_s) rescue nil) }.compact.uniq.sort
+    return [nil, "date-range: fewer than 2 distinct dates in #{label.inspect} — nothing to narrow; pass --value"] if days.size < 2
+    lo = days.first
+    mid = days[(days.size - 1) / 2]
+    mid = days[-2] if mid >= days.last   # guarantee a STRICT subset
+    [format('min:%s,max:%s', lo.strftime('%Y-%m-%d'), mid.strftime('%Y-%m-%d')),
+     "auto-picked earlier-half date range from #{label.inspect} (min:…,max:… encoding)"]
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value " \
+          '(date-range controls require the "min:<YYYY-MM-DD>,max:<YYYY-MM-DD>" encoding; ' \
+          'a bare/ISO/dotted range is accepted and then ignored, which reads as a false "inert" FAIL)']
+  end
+end
+
+# --- W2.12 pooled prefetch (TRANSPORT ONLY) ----------------------------------
+# Pools exactly the exports the serial path would make — never more. Round 1:
+# value-source baselines for auto-pickable controls (only where the /columns
+# label resolves — serial pick_value returns SKIP before exporting when it
+# doesn't) + in/out-closure baselines
+# for controls whose flip value is already certain (explicit --value, switch).
+# Round 2 (after value picking): remaining baselines + every flip export. A
+# pooled failure is NOT a verdict — the affected export falls back to the
+# serial seam at its call site; verdict logic below is untouched.
+flip_cache = {}
+picked = {} # control_element_id → [value, note]
+unless opts[:no_pool]
+  probeable = rows.reject { |r| r[:reach].empty? || pick_in_el.call(r).nil? }
+  round1 = []
+  probeable.each do |r|
+    el = elems[r[:control_element_id]][:el]
+    if opts[:values].key?(r[:control_id]) || el['controlType'].to_s == 'switch'
+      round1 << pick_in_el.call(r)
+      round1 << pick_out_el.call(r) if opts[:check_out]
+    elsif %w[list segmented text].include?(el['controlType'].to_s)
+      src = value_src.call(r)
+      # Label check mirrors pick_value: a missing /columns label SKIPs the
+      # control before any export on the serial path — pooling its baseline
+      # here would be an export the serial path never makes (no-waste pin).
+      round1 << src['elementId'] if src && col_label[[src['elementId'], src['columnId']]]
+    end
+  end
+  round1 = round1.compact.uniq.reject { |e| baseline_cache.key?(e) }
+  ExportPool.pooled_element_exports(WB, round1.map { |e| { 'element_id' => e } },
+                                    pool: opts[:pool], timeout_per_job: opts[:timeout])
+            .each_with_index { |(st, body), j| baseline_cache[round1[j]] = body if st == :ok }
+  probeable.each { |r| picked[r[:control_element_id]] = pick_value.call(r) }
+  base_needed = []
+  flips = []
+  probeable.each do |r|
+    val, = picked[r[:control_element_id]]
+    next if val.nil?
+    cid = r[:control_id]
+    els = [pick_in_el.call(r)]
+    els << pick_out_el.call(r) if opts[:check_out]
+    els.compact.each do |e|
+      base_needed << e
+      flips << { 'element_id' => e, 'params' => { cid => val } }
+    end
+  end
+  round2 = base_needed.uniq.reject { |e| baseline_cache.key?(e) }
+                     .map { |e| { 'element_id' => e } } + flips
+  ExportPool.pooled_element_exports(WB, round2, pool: opts[:pool], timeout_per_job: opts[:timeout])
+            .each_with_index do |(st, body), j|
+    job = round2[j]
+    next unless st == :ok
+    if job['params'].nil?
+      baseline_cache[job['element_id']] = body
+    else
+      cid, val = job['params'].first
+      flip_cache[[job['element_id'], cid, val]] = body
+    end
+  end
+end
+get_flip = lambda do |eid, cid, val|
+  flip_cache[[eid, cid, val]] || export_csv(WB, eid, { cid => val }, opts[:timeout])
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = pick_in_el.call(r)
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = picked[r[:control_element_id]] || pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = get_flip.call(in_el, cid, val)
+  record_evidence.call("#{cid}--#{in_el}--base.csv", base)
+  record_evidence.call("#{cid}--#{in_el}--flip.csv", flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    # A date-range value in ANY spelling other than "min:<date>,max:<date>" is
+    # accepted by the export API and then IGNORED, so it produces this exact
+    # symptom on a control that actually works (issue #540). Say so here rather
+    # than letting an encoding slip read as a real defect.
+    hint = if elems[r[:control_element_id]][:el]['controlType'].to_s.start_with?('date') &&
+              !val.to_s.match?(/\Amin:.*,max:/)
+             ' — NOTE: date-range values MUST be encoded "min:<YYYY-MM-DD>,max:<YYYY-MM-DD>";' \
+             ' this value is not, so it was very likely IGNORED rather than applied. Re-probe' \
+             ' without --value to let the auto-picker derive the encoding.'
+           else
+             ''
+           end
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert#{hint}" }
+  end
+
+  next unless opts[:check_out]
+  out_el = pick_out_el.call(r)
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = get_flip.call(out_el, cid, val)
+    record_evidence.call("#{cid}--#{out_el}--out-base.csv", obase)
+    record_evidence.call("#{cid}--#{out_el}--out-flip.csv", oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+# Version-keyed raw-evidence sidecar: binds each raw CSV's sha256 to the
+# workbook doc version this probe ran against. probe-results.json keeps its
+# ARRAY shape untouched — FlipGate / gate 7b parse it as-is.
+File.write(File.join(OUT, 'probe-evidence.json'), JSON.pretty_generate(
+             'workbook_id' => WB,
+             'doc_version' => DOC_VERSION, # nil = spec carried no version (evidence unattributable to a version)
+             'transport' => opts[:no_pool] ? 'serial' : "pooled(#{opts[:pool]})",
+             'probed_at' => Time.now.utc.strftime('%Y-%m-%dT%H:%M:%SZ'),
+             'contract' => 'raw wire CSVs only; verdicts recomputed from these bytes every run, never reused',
+             'exports' => EVIDENCE))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json + probe-evidence.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/remap-wb-to-dm-ids.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/remap-wb-to-dm-ids.mjs
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+// remap-wb-to-dm-ids.mjs — wire a Metabase-converted workbook spec to a freshly-posted DM.
+//
+// The report converter emits each element's `source.elementId` as the query's
+// SUBJECT DISPLAY NAME (a placeholder), because the real Sigma element IDs don't
+// exist until the DM is POSTed. After you POST the DM, run this to rewrite every
+// element's `source.elementId` (and `dataModelId`) to the real IDs, matched by
+// element NAME from the DM readback. (This was a manual step in every live test.)
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/remap-wb-to-dm-ids.mjs --wb wb-spec.json --dm-id <dataModelId> [--out wb.remapped.json]
+import { readFileSync, writeFileSync } from 'node:fs';
+import { api, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+import { document, metadata, workbookElements, wrap } from './lib/code_rep.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.wb || !a['dm-id']) { console.error('need --wb <spec.json> --dm-id <dataModelId>'); process.exit(2); }
+const dmId = a['dm-id'];
+const rawWb = JSON.parse(readFileSync(a.wb, 'utf8'));
+const wbDoc = document(rawWb);
+const wbEls = workbookElements(rawWb);
+
+const els = elementsOf((await api('GET', `/v2/dataModels/${dmId}/elements`)).json);
+if (!els.length) { console.error(`No elements found on data model ${dmId} (token? wrong id?)`); process.exit(1); }
+const byName = new Map(els.map((e) => [e.name.toLowerCase(), e.id]));
+
+let remapped = 0; const unresolved = [];
+// Column-set fallback: Sigma does NOT honor sql-element names (all read back as
+// "Custom SQL"), so native-card placeholders never match by name. Fingerprint each
+// DM element by its column display names and match the workbook element's bare
+// [Col] refs against them (best unique superset wins).
+// Normalize: DM sql columns keep RAW aliases (NET_REVENUE), workbook refs are
+// prettified (Net Revenue) — compare alphanumerics only.
+const norm = (s) => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const colEntries = (await api('GET', `/v2/dataModels/${dmId}/columns?limit=500`)).json?.entries || [];
+const colsByElement = new Map();
+for (const c of colEntries) {
+  if (!colsByElement.has(c.elementId)) colsByElement.set(c.elementId, new Set());
+  colsByElement.get(c.elementId).add(norm(c.name));
+}
+const wantedCols = (e) => {
+  const names = new Set();
+  for (const c of e.columns || []) {
+    const m = /^\[([^\]/]+)\]$/.exec(String(c.formula || ''));
+    if (m) names.add(norm(m[1]));
+  }
+  return names;
+};
+const byColumns = (e) => {
+  const want = wantedCols(e);
+  if (!want.size) return undefined;
+  const hits = [];
+  for (const [elId, have] of colsByElement) {
+    if ([...want].every((n) => have.has(n))) hits.push({ elId, extra: have.size - want.size });
+  }
+  if (!hits.length) return undefined;
+  // Smallest superset wins (a native card's sql element carries EXACTLY its result
+  // columns; wide base tables also match but with many extras). Tie → ambiguous.
+  hits.sort((x, y) => x.extra - y.extra);
+  if (hits.length > 1 && hits[0].extra === hits[1].extra) return undefined;
+  return hits[0].elId;
+};
+
+// Ref repair: workbook formulas must be [<DM element name>/<ACTUAL column name>]
+// (DM sql elements keep RAW aliases like NET_REVENUE; derived views suffix duplicate
+// names like "Category (PRODUCT_DIM)"). Bare or prettified refs POST 200 but resolve
+// to type "error" — rewrite every bracket token against the live DM columns.
+const nameByElement = new Map(els.map((e) => [e.id, e.name]));
+const colNamesByElement = new Map(); // elId -> Map(norm -> [actual names])
+for (const c of colEntries) {
+  if (!colNamesByElement.has(c.elementId)) colNamesByElement.set(c.elementId, new Map());
+  const m = colNamesByElement.get(c.elementId);
+  const n = norm(c.name);
+  if (!m.has(n)) m.set(n, []);
+  if (!m.get(n).includes(c.name)) m.get(n).push(c.name);
+}
+let repaired = 0; const unrepairable = [];
+// Control references ([<controlId>] in boolean match columns like
+// `[Region] = [region]`) must survive repair UNTOUCHED — rewriting `[region]`
+// to `[Customer Dim/Region]` turns the filter into always-true (live-caught by
+// the control lint: the control reads back dead).
+const controlIds = new Set();
+for (const e of wbEls) {
+  if (e.kind === 'control' && e.controlId) controlIds.add(e.controlId);
+}
+const repairRefs = (e, elId) => {
+  const elName = nameByElement.get(elId);
+  const colMap = colNamesByElement.get(elId);
+  if (!elName || !colMap) return;
+  const resolveCol = (token) => {
+    const n = norm(token);
+    const exact = colMap.get(n);
+    if (exact?.length === 1) return exact[0];
+    // tolerate the derived-view disambiguation suffix: Category -> "Category (PRODUCT_DIM)"
+    const cands = [];
+    for (const [k, names] of colMap) {
+      if (k !== n && k.startsWith(n)) cands.push(...names.filter((nm) => /\(.+\)\s*$/.test(nm)));
+    }
+    return cands.length === 1 ? cands[0] : undefined;
+  };
+  for (const c of e.columns || []) {
+    if (typeof c.formula !== 'string') continue;
+    c.formula = c.formula.replace(/\[([^\]]+)\]/g, (whole, inner) => {
+      if (controlIds.has(inner)) return whole;       // control ref — never a column
+      const slash = inner.indexOf('/');
+      const colTok = slash >= 0 ? inner.slice(slash + 1) : inner;
+      const real = resolveCol(colTok);
+      if (!real) { unrepairable.push(`${e.name || e.id}: ${whole}`); return whole; }
+      repaired++;
+      return `[${elName}/${real}]`;
+    });
+  }
+};
+
+// Intra-workbook sources (charts re-rooted through a hidden base TABLE so a
+// range control's `filters` target has a table to point at — see the converter's
+// pendingRanges) reference another element's id, not a DM placeholder: skip them.
+const inWorkbookIds = new Set();
+for (const e of wbEls) if (e.id) inWorkbookIds.add(e.id);
+
+for (const e of wbEls) {
+  const s = e.source; if (!s || !('elementId' in s)) continue;
+  if (inWorkbookIds.has(s.elementId)) continue;          // base-table source — already real
+  s.dataModelId = dmId;
+  const want = String(s.elementId || '').toLowerCase();
+  const real = byName.get(want) || byColumns(e) || (els.length === 1 ? els[0].id : undefined);
+  if (real) { s.elementId = real; remapped++; repairRefs(e, real); } else unresolved.push(s.elementId);
+}
+
+// ── wire workbook controls to the DM controls they duplicate ─────────────────
+// The DM converter emits a control per {{tag}} (the tag lives in DM SQL); the
+// dashboard converter emits a control per dashboard parameter with the SAME
+// controlId (slug). Without wiring, the workbook control is decorative — pass
+// --dm-spec <the dm spec JSON you POSTed> to set control.parameters so the
+// workbook control DRIVES the DM control.
+let wired = 0;
+if (a['dm-spec']) {
+  const dmSpec = JSON.parse(readFileSync(a['dm-spec'], 'utf8'));
+  const dmControlIds = new Set();
+  for (const p of dmSpec.pages || []) for (const e of p.elements || []) {
+    if (e.kind === 'control' && e.controlId) dmControlIds.add(e.controlId);
+  }
+  const wireControl = (c) => {
+    if (c?.kind !== 'control' || !dmControlIds.has(c.controlId)) return;
+    c.parameters = [{ kind: 'data-model', dataModelId: dmId, controlId: c.controlId }];
+    wired++;
+  };
+  for (const e of wbEls) wireControl(e);
+}
+
+const out = a.out || a.wb.replace(/\.json$/, '.remapped.json');
+const wb = rawWb.document ? rawWb : wrap(wbDoc, metadata(rawWb));
+writeFileSync(out, JSON.stringify(wb, null, 2));
+console.log(JSON.stringify({ dataModelId: dmId, dmElements: els.length, remapped, repaired, unrepairable, controlsWired: wired, unresolved, out }, null, 2));
+if (unresolved.length) { console.error(`WARN: ${unresolved.length} elementId(s) unresolved — DM has no element named: ${unresolved.join(', ')}`); process.exit(1); }

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/report-telemetry.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/report-telemetry.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// report-telemetry.mjs — fire an anonymous usage ping after a successful migration.
+//
+// Usage (after get-token.sh has been eval'd):
+//   node scripts/report-telemetry.mjs --duration <seconds> [--failed]
+//
+// What IS sent:  tool, sigma_region, org_id_hash (SHA256 of SIGMA_CLIENT_ID first 8 chars),
+//               duration_seconds, success flag, skill_version
+// What is NOT sent: workbook names/IDs, SQL, column names, dashboard titles, user email
+// See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+
+import { createHash } from 'node:crypto';
+import { parseArgs } from './lib/sigma-rest.mjs';
+
+const ENDPOINT = 'https://sigma-migration-telemetry.onrender.com/track';
+const SKILL_VERSION = '1.0';
+
+function regionFromBase(base = '') {
+  if (base.includes('.au.')) return 'au';
+  if (base.includes('.eu.')) return 'eu';
+  if (base.includes('.uk.')) return 'uk';
+  if (base.includes('.ca.')) return 'ca';
+  return 'us';
+}
+
+function orgHash(clientId = '') {
+  return createHash('sha256').update(clientId).digest('hex').slice(0, 8);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const success = !args.failed;
+const duration = parseInt(args.duration ?? '0', 10);
+
+const payload = {
+  event:            'migration_complete',
+  tool:             'metabase-to-sigma',
+  sigma_region:     regionFromBase(process.env.SIGMA_BASE_URL),
+  org_id_hash:      orgHash(process.env.SIGMA_CLIENT_ID),
+  duration_seconds: duration,
+  success,
+  skill_version:    SKILL_VERSION,
+};
+
+console.log('\nReporting anonymous migration telemetry (no customer data sent):');
+for (const [k, v] of Object.entries(payload)) {
+  if (k !== 'event') console.log(`  ${k}: ${v}`);
+}
+
+try {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  });
+  console.log(`  → telemetry sent (${res.status})\n`);
+} catch {
+  console.log('  → telemetry unavailable (skipped)\n');
+}

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/scout-validate-and-persist.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/scout-validate-and-persist.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scout-validate-and-persist.mjs — the gap-scout's terminal step.
+// Given a candidate Sigma formula + the gap context, validate it against the customer's
+// Sigma site (POST a throwaway probe data model whose one calc column IS the candidate,
+// check it resolves to a concrete type), then PERSIST the rule on success or report an
+// escalation command on failure. The subagent does the reasoning (proposing the
+// candidate); this script does the deterministic POST/validate/write.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/scout-validate-and-persist.mjs \
+//     --feature 'running-total' \
+//     --pattern '\brunning-total\s*\(\s*\[([^\]]+)\]\s*\)' \
+//     --template 'CumulativeSum([$1])' \
+//     --test-formula 'CumulativeSum([Net Revenue])' \
+//     --connection <connId> --table-path DEMO_DB.DEMO.ORDER_FACT \
+//     --folder <folderId> [--description '...'] [--hint '...']
+//
+// Output (JSON): { status: "validated"|"escalated", rule_path?, escalation? , ... }
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { api, extractId, parseArgs } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+for (const k of ['feature', 'template', 'test-formula', 'connection', 'table-path', 'folder']) {
+  if (!a[k]) { console.error(`need --${k}`); process.exit(2); }
+}
+const [db, schema, ...t] = a['table-path'].split('.');
+const table = t.join('.');
+const RULES = join(homedir(), '.metabase-to-sigma', 'learned-rules.json');
+
+// minimal probe DM: a warehouse-table element exposing the raw columns the candidate
+// references (bare `[Name]` refs → raw cols `[TABLE/Name]`), plus the candidate calc col.
+const tail = table.toUpperCase();
+const refNames = [...new Set([...a['test-formula'].matchAll(/\[([^\]\/]+)\]/g)].map((m) => m[1]))];
+const rawCols = refNames.map((nm, i) => ({ id: `r${i}`, name: nm, formula: `[${tail}/${nm}]` }));
+const cols = [...rawCols, { id: 'c1', name: 'scout_candidate', formula: a['test-formula'] }];
+const probe = {
+  folderId: a.folder, name: `GAPSCOUT PROBE ${a.feature} ${Date.now()}`, schemaVersion: 1,
+  pages: [{ id: 'p1', name: 'P', elements: [{
+    id: 'e1', kind: 'table', name: 'Probe',
+    source: { connectionId: a.connection, kind: 'warehouse-table', path: [db, schema, table] },
+    columns: cols, order: cols.map((c) => c.id),
+  }] }],
+};
+const post = await api('POST', '/v2/dataModels/spec', probe);
+const id = extractId(post, 'dataModelId');
+let resolved = false, detail = '';
+if (id) {
+  const cols = await api('GET', `/v2/dataModels/${id}/columns`);
+  const list = cols.json?.entries || cols.json?.columns || (Array.isArray(cols.json) ? cols.json : []);
+  const cand = (Array.isArray(list) ? list : []).find((c) => (c.name || c.columnName) === 'scout_candidate');
+  const type = cand && (cand.type?.type || cand.columnType || cand.type);
+  resolved = !!type && String(type).toLowerCase() !== 'error';
+  detail = `column type=${type || 'missing'}`;
+  await api('DELETE', `/v2/files/${id}`); // always clean up the probe
+} else {
+  detail = `POST rejected: ${post.text.slice(0, 200)}`;
+}
+
+if (resolved) {
+  let rules = [];
+  try { rules = JSON.parse(readFileSync(RULES, 'utf8')); rules = Array.isArray(rules) ? rules : (rules.rules || []); } catch {}
+  rules = rules.filter((r) => r.feature !== a.feature);
+  rules.push({ feature: a.feature, pattern: a.pattern || a['test-formula'], template: a.template, flags: 'gi', description: a.description || '', hint: a.hint || '', validatedAt: new Date().toISOString() });
+  mkdirSync(join(homedir(), '.metabase-to-sigma'), { recursive: true });
+  writeFileSync(RULES, JSON.stringify(rules, null, 2));
+  console.log(JSON.stringify({ status: 'validated', feature: a.feature, rule_path: RULES, detail }, null, 2));
+  process.exit(0);
+}
+
+// escalation (opt-in; this script does NOT file — it hands back the command)
+const dry = `python3 scripts/escalate-gap.py --skill metabase-to-sigma --category converter --feature ${JSON.stringify(a.feature)} --description ${JSON.stringify(a.description || '')} --source-pattern ${JSON.stringify(a.pattern || '')} --template-attempted ${JSON.stringify(a.template)} --test-formula ${JSON.stringify(a['test-formula'])} --sigma-response ${JSON.stringify(detail)}`;
+console.log(JSON.stringify({ status: 'escalated', feature: a.feature, detail, escalation: { dry_run_cmd: dry, file_cmd: dry + ' --yes' } }, null, 2));
+process.exit(0);

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/setup.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/setup.rb
@@ -1,0 +1,226 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+#
+# THE USER RUNS THIS ONCE, in a real terminal. Three modes:
+#   * interactive (a TTY): prompts for each value (secret hidden), OR
+#   * flags (no TTY / automation):
+#       ruby scripts/setup.rb --client-id <id> --client-secret <secret> \
+#         [--base-url https://aws-api.sigmacomputing.com] [--connection-id <uuid>]
+#   * environment (--from-env, or automatic when stdin is not a TTY):
+#       SIGMA_CLIENT_ID + SIGMA_CLIENT_SECRET [+ SIGMA_BASE_URL,
+#       SIGMA_CONNECTION_ID] — persists the already-exported values without
+#       inlining the secret into any command line or transcript.
+# When stdin is NOT a TTY (agent harness, piped run) and neither flags nor env
+# vars supply the values, this prints both non-interactive invocations and
+# exits 2 instead of hanging forever on a prompt nobody can answer. The secret
+# is NEVER read via an echoing prompt (IO#noecho raises Errno::EBADF on
+# Windows Git-Bash mintty; the fallback is the env var, not visible typing).
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+require 'optparse'
+require 'uri'
+begin
+  require_relative 'lib/redact'   # vendored plugin layout (scripts/lib/redact.rb)
+rescue LoadError
+  require_relative '../lib/redact' # canonical layout (shared/scripts + shared/lib)
+end
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+DEFAULT_BASE  = "https://aws-api.sigmacomputing.com"
+
+flags = {}
+OptionParser.new do |p|
+  p.banner = "usage: ruby scripts/setup.rb [--client-id ID --client-secret SECRET] " \
+             "[--base-url URL] [--connection-id UUID] [--from-env]"
+  p.on('--base-url URL',       "Sigma API base URL (default: #{DEFAULT_BASE})") { |v| flags[:base] = v }
+  p.on('--client-id ID',       'Sigma API client id (not a secret)')            { |v| flags[:cid]  = v }
+  p.on('--client-secret SEC',  'Sigma API client secret')                       { |v| flags[:sec]  = v }
+  p.on('--connection-id UUID', 'full warehouse-connection UUID (optional)')     { |v| flags[:conn] = v }
+  p.on('--from-env', 'read SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET/SIGMA_BASE_URL/SIGMA_CONNECTION_ID from the environment (no prompts, nothing echoed)') { flags[:from_env] = true }
+  p.on('-h', '--help') { puts p; exit 0 }
+end.parse!
+
+# --from-env (explicit, or implicitly attempted when no TTY): pull the values
+# already exported in this shell. Reported per-value below.
+$value_sources = {}
+if flags[:from_env] || (!$stdin.tty? && flags[:cid].to_s.empty? && flags[:sec].to_s.empty?)
+  { base: 'SIGMA_BASE_URL', cid: 'SIGMA_CLIENT_ID', sec: 'SIGMA_CLIENT_SECRET', conn: 'SIGMA_CONNECTION_ID' }.each do |k, var|
+    next unless flags[k].to_s.empty? && !ENV[var].to_s.empty?
+    flags[k] = ENV[var]
+    $value_sources[k] = "env #{var}"
+  end
+  if flags[:from_env] && (flags[:cid].to_s.empty? || flags[:sec].to_s.empty?)
+    warn 'ERROR: --from-env given but SIGMA_CLIENT_ID and/or SIGMA_CLIENT_SECRET are not set.'
+    warn "Export them first (they are stored, never echoed):"
+    warn "  export SIGMA_CLIENT_ID='<id>'  SIGMA_CLIENT_SECRET='<secret>'"
+    warn "  [export SIGMA_BASE_URL='#{DEFAULT_BASE}'  SIGMA_CONNECTION_ID='<uuid>']"
+    exit 2
+  end
+end
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  # encoding: 'UTF-8' — this body is regexp-matched below, so a raw read would
+  # inherit the locale's default external encoding and raise
+  # `invalid byte sequence in US-ASCII` on any non-ASCII byte already in the file
+  # (a password or path with an accent is enough). F5 crash class, #752.
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH, encoding: 'UTF-8') : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup — the user runs this ONCE (interactive or via flags)."
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+interactive = $stdin.tty?
+need_prompt = flags[:cid].to_s.empty? || flags[:sec].to_s.empty?
+
+if need_prompt && !interactive
+  # No TTY, no flags, no env vars: NEVER hang on gets — print the exact
+  # non-interactive invocations instead (env path first: it keeps the secret
+  # out of command lines and transcripts).
+  warn 'ERROR: stdin is not a TTY, so the interactive prompts cannot run — and'
+  warn '--client-id/--client-secret were not passed (and SIGMA_CLIENT_ID/'
+  warn 'SIGMA_CLIENT_SECRET are not in the environment). Run it non-interactively:'
+  warn ''
+  warn '  # preferred (secret stays out of the command line):'
+  warn "  export SIGMA_CLIENT_ID='<id>'  SIGMA_CLIENT_SECRET='<secret>'"
+  warn '  ruby scripts/setup.rb --from-env'
+  warn ''
+  warn '  # or via flags:'
+  warn '  ruby scripts/setup.rb \\'
+  warn "    --client-id <SIGMA_CLIENT_ID> --client-secret '<SIGMA_CLIENT_SECRET>' \\"
+  warn "    [--base-url #{DEFAULT_BASE}] [--connection-id <uuid>]"
+  warn ''
+  warn '…or run it once from a real terminal (it will prompt). Never inline the'
+  warn 'secret into a shared command log — prefer the interactive prompt when a'
+  warn 'human is present.'
+  exit 2
+end
+
+base = flags[:base].to_s
+cid  = flags[:cid].to_s
+sec  = flags[:sec].to_s
+conn = flags[:conn].to_s
+
+if need_prompt
+  if base.empty?
+    print "Base URL [#{DEFAULT_BASE}]: "
+    base = $stdin.gets.to_s.chomp
+  end
+  # Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+  # (noecho) prompt here was a recurring quickstart confusion: people paste the
+  # wrong value blind and only discover it when auth fails.
+  if cid.empty?
+    print "Client ID (not a secret — will echo): "
+    cid = $stdin.gets.to_s.chomp
+  end
+  if sec.empty?
+    print "Client Secret (hidden): "
+    # HIDDEN-OR-ENV ONLY. IO#noecho raises (Errno::EBADF on Windows Git-Bash
+    # mintty; ENOTTY/ENXIO/IOError elsewhere) when stdin is not a real TTY even
+    # though tty? said it was — the field crash echoed secrets on the retry.
+    # On that failure: use SIGMA_CLIENT_SECRET from the environment if present,
+    # else exit 2 with instructions — NEVER fall back to an echoing gets.
+    sec = begin
+      s = $stdin.noecho(&:gets)
+      puts
+      s.to_s.chomp
+    rescue StandardError => e
+      puts
+      env_sec = ENV['SIGMA_CLIENT_SECRET'].to_s
+      if env_sec.empty?
+        warn "ERROR: hidden prompt unavailable (#{e.class}: #{e.message}) and SIGMA_CLIENT_SECRET is not set."
+        warn 'Refusing to read the secret via an echoing prompt. Either:'
+        warn "  export SIGMA_CLIENT_SECRET='<secret>'   # then re-run (or use --from-env)"
+        warn '  …or pass --client-secret, or run from a real terminal.'
+        exit 2
+      end
+      warn "(hidden prompt unavailable — #{e.class}; using SIGMA_CLIENT_SECRET from the environment, value not echoed)"
+      $value_sources[:sec] = "env SIGMA_CLIENT_SECRET (hidden prompt unavailable: #{e.class})"
+      env_sec
+    end
+  end
+end
+base = DEFAULT_BASE if base.empty?
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# Security (A2): refuse to persist credentials for a non-https / non-sigmacomputing.com
+# base URL — a poisoned base would exfiltrate the client id/secret on every run.
+# Opt out (self-hosted/dev) with SIGMA_ALLOW_INSECURE_BASE_URL=1 (loud warning).
+if ENV['SIGMA_ALLOW_INSECURE_BASE_URL'] == '1'
+  warn "WARNING: SIGMA_ALLOW_INSECURE_BASE_URL=1 — skipping SIGMA_BASE_URL validation (#{base})"
+else
+  _bu = (URI.parse(base) rescue nil)
+  _bh = _bu&.host&.downcase
+  abort "SIGMA_BASE_URL must use https:// (got '#{base}'). Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override (self-hosted/dev)." unless _bu&.scheme == 'https'
+  abort "SIGMA_BASE_URL host '#{_bh}' is not a sigmacomputing.com host. Refusing to write credentials. Set SIGMA_ALLOW_INSECURE_BASE_URL=1 to override." unless _bh == 'sigmacomputing.com' || _bh&.end_with?('.sigmacomputing.com')
+end
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+if conn.empty? && need_prompt
+  print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+  conn = $stdin.gets.to_s.chomp
+end
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+# Contract: never echo credential values — mask all but the last 4 characters.
+redacted_secret = "#{Redact.mask(sec)} (#{sec.length} chars)"
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+_src = ->(k) { $value_sources[k] ? "  [from #{$value_sources[k]}]" : '' }
+puts "  SIGMA_BASE_URL:      #{base}#{_src.call(:base)}"
+puts "  SIGMA_CLIENT_ID:     #{cid}#{_src.call(:cid)}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}#{_src.call(:sec)}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}#{_src.call(:conn)}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/sigma-export-png.py
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# NOTE: requires SIGMA_API_TOKEN (+SIGMA_BASE_URL) in env. The orchestrator injects
+# them; for HAND-DRIVEN runs: set -a; source ~/.sigma-migration/env; set +a; then
+# mint via scripts/get_token.py (A/B-report field note).
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --param <controlId>=<value> --out /tmp/x.png
+
+--param (repeatable) sets a control value for the render via the export body's
+"parameters" map — the ONLY programmatic way to render a non-default control
+state (same channel probe-controls.rb proved for CSV exports on 2026-06-12).
+Used by verify-interaction.rb for the flipped-state render EVIDENCE; callers
+must treat a failure here as advisory (PNG+parameters is unproven — the
+interaction verdict never depends on it).
+"""
+import argparse, os, sys, time, requests
+
+def credentials():
+    base = os.environ.get("SIGMA_BASE_URL")
+    token = os.environ.get("SIGMA_API_TOKEN")
+    if base and token:
+        return base, token
+    # Shell-neutral no-Ruby path: mint from client credentials or the neutral
+    # env file using the co-located stdlib helper. Never print the token.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    try:
+        from get_token import mint_token
+        return mint_token()
+    except (ImportError, SystemExit) as exc:
+        raise SystemExit(
+            "Sigma token unavailable: set SIGMA_API_TOKEN or provide "
+            "SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET/SIGMA_BASE_URL"
+        ) from exc
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    ap.add_argument("--param", action="append", default=[],
+                    metavar="CID=VALUE", help="control value for the render (repeatable)")
+    a = ap.parse_args()
+    base, tok = credentials()
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    if a.param:
+        params = {}
+        for spec in a.param:
+            cid, sep, val = spec.partition("=")
+            if not sep or not cid: sys.exit(f"bad --param {spec!r} (want <controlId>=<value>)")
+            params[cid] = val
+        body["parameters"] = params
+    # Explicit network timeouts (field-caught: a stuck render job left the
+    # bare POST/GET hanging INDEFINITELY — the caller saw a frozen script, not
+    # a diagnosable failure). Repeated 500s on the poll are surfaced loudly:
+    # that pattern is usually the workbook's own content — run the bisect
+    # playbook (refs/layout-visual-qa.md) before blaming the service.
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body, timeout=60)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    n500 = 0
+    for i in range(60):
+        try:
+            g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"}, timeout=60)
+        except requests.exceptions.Timeout:
+            time.sleep(3); continue
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        if g.status_code == 500:
+            n500 += 1
+            if n500 >= 5:
+                sys.exit("render job failed: HTTP 500 x5 on download — this is usually the "
+                         "WORKBOOK'S OWN content (e.g. an unbounded pivot dimension), not a "
+                         "service outage. Run the bisect playbook in refs/layout-visual-qa.md "
+                         "('Render 500 / export-timeout bisect') before waiving any gate.")
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG (job never materialized) — run the bisect playbook in "
+             "refs/layout-visual-qa.md before treating this as a service outage.")
+
+if __name__ == "__main__":
+    main()

--- a/shared/manifest.json
+++ b/shared/manifest.json
@@ -87,7 +87,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/sigma_rest.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/sigma_rest.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/sigma_rest.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/sigma_rest.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/sigma_rest.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/sigma_rest.rb"
       ]
     },
     {
@@ -109,7 +110,8 @@
         "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb",
         "plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/code_rep.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/code_rep.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.rb"
       ]
     },
     {
@@ -148,7 +150,8 @@
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs",
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs",
-        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs"
+        "plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.mjs"
       ]
     },
     {
@@ -166,7 +169,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/preflight_lint.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/preflight_lint.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/preflight_lint.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/preflight_lint.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/preflight_lint.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/preflight_lint.rb"
       ]
     },
     {
@@ -185,7 +189,8 @@
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/layout_lint.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/layout_lint.rb",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/layout_lint.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/layout_lint.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/layout_lint.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/layout_lint.rb"
       ]
     },
     {
@@ -236,7 +241,8 @@
         "plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/control_lint.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/control_lint.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/control_lint.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/control_lint.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/control_lint.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/control_lint.rb"
       ]
     },
     {
@@ -470,7 +476,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/escalate-gap.py",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/escalate-gap.py",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/escalate-gap.py",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/escalate-gap.py"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/escalate-gap.py",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/escalate-gap.py"
       ]
     },
     {
@@ -487,7 +494,8 @@
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/probe-controls.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/probe-controls.rb",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/probe-controls.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/probe-controls.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/probe-controls.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/probe-controls.rb"
       ]
     },
     {
@@ -504,7 +512,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/sigma-export-png.py",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/sigma-export-png.py",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/sigma-export-png.py",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/sigma-export-png.py"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/sigma-export-png.py",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/sigma-export-png.py"
       ]
     },
     {
@@ -523,7 +532,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/find-or-pick-dm.rb",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/find-or-pick-dm.rb",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/find-or-pick-dm.rb",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/find-or-pick-dm.rb"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/find-or-pick-dm.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/find-or-pick-dm.rb"
       ]
     },
     {
@@ -612,7 +622,8 @@
         "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/get-token.sh",
         "plugins/hex-to-sigma/skills/hex-to-sigma/scripts/get-token.sh",
         "plugins/mode-to-sigma/skills/mode-to-sigma/scripts/get-token.sh",
-        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/get-token.sh"
+        "plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/get-token.sh",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/get-token.sh"
       ]
     },
     {
@@ -652,7 +663,8 @@
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/setup.rb",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/setup.rb",
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/setup.rb",
-        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb"
+        "plugins/domo-to-sigma/skills/domo-to-sigma/scripts/setup.rb",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/setup.rb"
       ]
     },
     {
@@ -710,7 +722,8 @@
         "plugins/thoughtspot-to-sigma/skills/thoughtspot-assessment/scripts/dup-dashboards.py",
         "plugins/domo-to-sigma/skills/domo-assessment/scripts/dup-dashboards.py",
         "plugins/mode-to-sigma/skills/mode-assessment/scripts/dup-dashboards.py",
-        "plugins/streamlit-to-sigma/skills/streamlit-assessment/scripts/dup-dashboards.py"
+        "plugins/streamlit-to-sigma/skills/streamlit-assessment/scripts/dup-dashboards.py",
+        "plugins/metabase-to-sigma/skills/metabase-assessment/scripts/dup-dashboards.py"
       ]
     },
     {
@@ -726,7 +739,8 @@
         "plugins/quicksight-to-sigma/skills/quicksight-to-sigma/refs/layout-visual-qa.md",
         "plugins/sisense-to-sigma/skills/sisense-to-sigma/refs/layout-visual-qa.md",
         "plugins/tableau-to-sigma/skills/tableau-to-sigma/refs/layout-visual-qa.md",
-        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/layout-visual-qa.md"
+        "plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/refs/layout-visual-qa.md",
+        "plugins/metabase-to-sigma/skills/metabase-to-sigma/refs/layout-visual-qa.md"
       ]
     },
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Graduates the live-validated standalone Metabase converter and read-only assessment into the migration marketplace, then updates workbook generation to the released Sigma code representation and current chart-channel contracts.

## Scope

- Plugin(s) touched: `metabase-to-sigma`
- [x] This PR touches exactly one plugin **or** is an isolated shared-lib change (not both)

## Checklist

- [x] `ruby tools/check-shared.rb` — green (886 copies)
- [x] `ruby tools/lint-skills.rb` — green; Metabase SKILL.md is within the 20 KB budget and pre-read limit
- [x] `./corpus/run-corpus.sh --check` — 34/34 cases green
- [x] Metabase data-model and workbook reconversions are byte-identical after normalization
- [x] TypeScript typecheck + fixture/contract suite — green
- [x] Assessment scorer/HTML renderer smoke — green
- [x] Dependency audit — 0 vulnerabilities
- [x] Full governance hook, script syntax checks, and hygiene sweep — green
- [x] Converter provenance and plugin-version range guards — green
- [x] Phase numbers unchanged; Metabase mapping added to `docs/phase-schema.md`
- [x] No unrelated working-tree changes swept in
- [x] Plugin version `0.1.1`

## If this changes a shared lib

- [x] No canonical shared-library behavior changed; new plugin copies are registered and synchronized.

## If this adds a converter

- [x] Scaffolded with `tools/new-skill.rb`; marketplace entry + AGENTS.md rows + corpus case added

## Highlights

- Imports converter and assessment from standalone source commit `43df3fd`.
- Emits outer metadata + `document`, flat workbook elements, metadata-only pages, canonical `<Element>` layout, and current `{columnId}` pointers.
- Adds native funnel, gauge, waterfall, and sankey mappings while retaining an explicit progress fallback.
- Adds TypeScript contract tests, dependency-audit CI, assessment smoke coverage, deterministic Metabase corpus goldens, and in-skill converter provenance.
- Documents Metabase installation, marketplace contents, corpus coverage, and source-access requirements in the main README.
- Fixes the standalone converter's latent warehouse-transform `ReferenceError`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6771638c-4013-457a-be1c-9ad0ddc56ddf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6771638c-4013-457a-be1c-9ad0ddc56ddf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

