### PR TITLE
Canonicalize workbook alignment fields in CodeRep

### DIFF
--- a/.github/workflows/corpus-check.yml
+++ b/.github/workflows/corpus-check.yml
@@ -485,6 +485,7 @@ jobs:
             shared/lib/test_plugin_embed.rb
             shared/lib/test_composition.rb
             shared/lib/test_composition_lint.rb
+            shared/lib/tests/test_code_rep.rb
             shared/lib/test_shared_script_closure.rb
             shared/lib/test_styling.rb
             shared/lib/test_coverage_catalog.rb
@@ -611,6 +612,7 @@ jobs:
             plugins/powerbi-to-sigma/skills/powerbi-to-sigma/tests/test-extract-report-classic.py
             shared/lib/test_plugin_embed.py
             shared/lib/test_composition.py
+            shared/lib/tests/test_code_rep.py
             shared/lib/test_styling.py
             shared/lib/test_coverage_catalog.py
             shared/lib/test_kpi_card.py
@@ -684,6 +686,7 @@ jobs:
             plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-scout-ledger-integrity.mjs
             plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-metric-reference.mjs
             plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/test-warehouse-column-refs.mjs
+            shared/lib/tests/test_code_rep.mjs
           )
           fail=0
           for t in "${tests[@]}"; do

--- a/corpus/streamlit/retail-fulfillment-control-tower/golden/workbook.json
+++ b/corpus/streamlit/retail-fulfillment-control-tower/golden/workbook.json
@@ -577,7 +577,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -604,7 +604,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -631,7 +631,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -658,7 +658,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -685,7 +685,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -708,7 +708,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -1187,7 +1187,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {

--- a/corpus/streamlit/simple-retail/golden/workbook.json
+++ b/corpus/streamlit/simple-retail/golden/workbook.json
@@ -105,7 +105,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -132,7 +132,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -159,7 +159,7 @@
             "fontSize": 26
           },
           "layout": {
-            "anchor": "middle"
+            "anchor": "center"
           }
         },
         {
@@ -310,7 +310,7 @@
             }
           ],
           "tabBar": {
-            "alignment": "start"
+            "alignment": "left"
           }
         }
       ],

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/cognos-to-sigma/skills/cognos-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/domo-to-sigma/skills/domo-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/gooddata-to-sigma/skills/gooddata-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/hex-to-sigma/skills/hex-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/looker-to-sigma/skills/looker-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/metabase-to-sigma/skills/metabase-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/microstrategy-to-sigma/skills/microstrategy-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/mode-to-sigma/skills/mode-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/powerbi-to-sigma/skills/powerbi-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
+++ b/plugins/qlik-to-sigma/skills/qlik-to-sigma/scripts/vendor/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/quicksight-to-sigma/skills/quicksight-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/custom-sql-to-data-model/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
+++ b/plugins/sigma-authoring/skills/sigma-workbooks/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/sisense-to-sigma/skills/sisense-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/streamlit-to-sigma/skills/streamlit-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/tableau-to-sigma/skills/tableau-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/enhance-scan.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
+++ b/plugins/thoughtspot-to-sigma/skills/thoughtspot-to-sigma/scripts/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/shared/lib/code_rep.mjs
+++ b/shared/lib/code_rep.mjs
@@ -18,6 +18,8 @@ export const DOC_KEYS = [
 // unchanged - only the container path moved. document() folds the legacy pair
 // forward so specs and fixtures written before the move still produce a valid body.
 export const LEGACY_THEME_KEYS = ['themeName', 'themeOverrides'];
+export const LEGACY_HORIZONTAL_ALIGN = { start: 'left', middle: 'center', end: 'right' };
+export const LEGACY_VERTICAL_ALIGN = { start: 'top', middle: 'center', end: 'bottom' };
 
 const isObj = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
@@ -148,10 +150,60 @@ export function canonicalizeLayout(layoutXml) {
     .replace(/<([/]?)GridContainer\b/g, '<$1Container');
 }
 
+function canonicalizeElement(element) {
+  if (!isObj(element)) return element;
+  if (element.kind === 'text' && element.verticalAlign in LEGACY_VERTICAL_ALIGN) {
+    return { ...element, verticalAlign: LEGACY_VERTICAL_ALIGN[element.verticalAlign] };
+  }
+  if (element.kind === 'kpi-chart' && isObj(element.layout)) {
+    const layout = { ...element.layout };
+    if (layout.anchor in LEGACY_HORIZONTAL_ALIGN) {
+      layout.anchor = LEGACY_HORIZONTAL_ALIGN[layout.anchor];
+    }
+    if (layout.verticalAnchor in LEGACY_VERTICAL_ALIGN) {
+      layout.verticalAnchor = LEGACY_VERTICAL_ALIGN[layout.verticalAnchor];
+    }
+    return { ...element, layout };
+  }
+  if (element.kind === 'tabbed-container' && isObj(element.tabBar)
+      && element.tabBar.alignment in LEGACY_HORIZONTAL_ALIGN) {
+    return {
+      ...element,
+      tabBar: {
+        ...element.tabBar,
+        alignment: LEGACY_HORIZONTAL_ALIGN[element.tabBar.alignment],
+      },
+    };
+  }
+  if (element.kind === 'divider' && element.align in LEGACY_VERTICAL_ALIGN) {
+    const mapping = element.direction === 'vertical'
+      ? LEGACY_HORIZONTAL_ALIGN
+      : LEGACY_VERTICAL_ALIGN;
+    return { ...element, align: mapping[element.align] };
+  }
+  return element;
+}
+
+function canonicalizeOverlay(overlay) {
+  if (!isObj(overlay) || !isObj(overlay.drawer) || !('position' in overlay.drawer)) {
+    return overlay;
+  }
+  const { position: _removed, ...drawer } = overlay.drawer;
+  return { ...overlay, drawer };
+}
+
 export function wrap(doc, extra = {}) {
   const flattened = flattenElements(doc);
-  const canonical = isObj(flattened) && 'layout' in flattened
-    ? { ...flattened, layout: canonicalizeLayout(flattened.layout) }
-    : flattened;
+  let canonical = flattened;
+  if (isObj(flattened)) {
+    canonical = { ...flattened };
+    if (Array.isArray(flattened.elements)) {
+      canonical.elements = flattened.elements.map(canonicalizeElement);
+    }
+    if (Array.isArray(flattened.overlays)) {
+      canonical.overlays = flattened.overlays.map(canonicalizeOverlay);
+    }
+    if ('layout' in flattened) canonical.layout = canonicalizeLayout(flattened.layout);
+  }
   return { ...extra, document: canonical };
 }

--- a/shared/lib/code_rep.py
+++ b/shared/lib/code_rep.py
@@ -26,6 +26,8 @@ DOC_KEYS = (
 # unchanged - only the container path moved. document() folds the legacy pair
 # forward so specs and fixtures written before the move still produce a valid body.
 LEGACY_THEME_KEYS = ("themeName", "themeOverrides")
+LEGACY_HORIZONTAL_ALIGN = {"start": "left", "middle": "center", "end": "right"}
+LEGACY_VERTICAL_ALIGN = {"start": "top", "middle": "center", "end": "bottom"}
 
 
 def _fold_legacy_theme(doc, source):
@@ -179,11 +181,68 @@ def canonicalize_layout(layout_xml):
     return re.sub(r'<(/?)GridContainer\b', r'<\1Container', layout)
 
 
+def _canonicalize_element(element):
+    if not isinstance(element, dict):
+        return element
+    kind = element.get("kind")
+    if kind == "text" and element.get("verticalAlign") in LEGACY_VERTICAL_ALIGN:
+        return {**element, "verticalAlign": LEGACY_VERTICAL_ALIGN[element["verticalAlign"]]}
+    if kind == "kpi-chart" and isinstance(element.get("layout"), dict):
+        layout = element["layout"]
+        canonical = dict(layout)
+        if layout.get("anchor") in LEGACY_HORIZONTAL_ALIGN:
+            canonical["anchor"] = LEGACY_HORIZONTAL_ALIGN[layout["anchor"]]
+        if layout.get("verticalAnchor") in LEGACY_VERTICAL_ALIGN:
+            canonical["verticalAnchor"] = LEGACY_VERTICAL_ALIGN[layout["verticalAnchor"]]
+        return element if canonical == layout else {**element, "layout": canonical}
+    if kind == "tabbed-container" and isinstance(element.get("tabBar"), dict):
+        tab_bar = element["tabBar"]
+        if tab_bar.get("alignment") in LEGACY_HORIZONTAL_ALIGN:
+            return {
+                **element,
+                "tabBar": {
+                    **tab_bar,
+                    "alignment": LEGACY_HORIZONTAL_ALIGN[tab_bar["alignment"]],
+                },
+            }
+    if kind == "divider" and element.get("align") in LEGACY_VERTICAL_ALIGN:
+        mapping = (
+            LEGACY_HORIZONTAL_ALIGN
+            if element.get("direction") == "vertical"
+            else LEGACY_VERTICAL_ALIGN
+        )
+        return {**element, "align": mapping[element["align"]]}
+    return element
+
+
+def _canonicalize_overlay(overlay):
+    if not isinstance(overlay, dict) or not isinstance(overlay.get("drawer"), dict):
+        return overlay
+    drawer = overlay["drawer"]
+    if "position" not in drawer:
+        return overlay
+    return {
+        **overlay,
+        "drawer": {key: value for key, value in drawer.items() if key != "position"},
+    }
+
+
 def wrap(doc, extra=None):
-    """Build a current request body with flat elements and canonical layout."""
+    """Build a current request body with canonical layout and element fields."""
     out = dict(extra or {})
     flattened = _flatten_elements(doc)
-    if isinstance(flattened, dict) and "layout" in flattened:
-        flattened = {**flattened, "layout": canonicalize_layout(flattened["layout"])}
+    if isinstance(flattened, dict):
+        canonical = dict(flattened)
+        if isinstance(flattened.get("elements"), list):
+            canonical["elements"] = [
+                _canonicalize_element(element) for element in flattened["elements"]
+            ]
+        if isinstance(flattened.get("overlays"), list):
+            canonical["overlays"] = [
+                _canonicalize_overlay(overlay) for overlay in flattened["overlays"]
+            ]
+        if "layout" in flattened:
+            canonical["layout"] = canonicalize_layout(flattened["layout"])
+        flattened = canonical
     out["document"] = flattened
     return out

--- a/shared/lib/code_rep.rb
+++ b/shared/lib/code_rep.rb
@@ -31,6 +31,12 @@ module Sigma
     # container path moved. document() folds the legacy pair forward so specs
     # and fixtures written before the move still produce a valid body.
     LEGACY_THEME_KEYS = %w[themeName themeOverrides].freeze
+    LEGACY_HORIZONTAL_ALIGN = {
+      'start' => 'left', 'middle' => 'center', 'end' => 'right'
+    }.freeze
+    LEGACY_VERTICAL_ALIGN = {
+      'start' => 'top', 'middle' => 'center', 'end' => 'bottom'
+    }.freeze
 
     class << self
       # Read path: accepts the live nested shape OR a legacy flat artifact.
@@ -72,9 +78,9 @@ module Sigma
 
       # Write path: every live workbook code-rep endpoint requires the wrapper
       # and flat document.elements. Flatten legacy page-nested artifacts and
-      # canonicalize legacy layout tags at this boundary so older converter
-      # output remains postable during migration; emitters always send the
-      # live-verified <Element>/<Container> vocabulary.
+      # canonicalize rejected legacy layout tags and element alignment enums at
+      # this boundary so older converter output remains postable during
+      # migration. Also remove drawer.position, which no longer exists.
       def wrap(document_hash, extra: {})
         extra.merge('document' => canonicalize_document(flatten_elements(document_hash)))
       end
@@ -145,8 +151,53 @@ module Sigma
       private
 
       def canonicalize_document(doc)
-        return doc unless doc.is_a?(Hash) && doc.key?('layout')
-        doc.merge('layout' => canonicalize_layout(doc['layout']))
+        return doc unless doc.is_a?(Hash)
+        out = doc
+        if doc['elements'].is_a?(Array)
+          out = out.merge('elements' => doc['elements'].map { |el| canonicalize_element(el) })
+        end
+        if doc['overlays'].is_a?(Array)
+          out = out.merge('overlays' => doc['overlays'].map { |overlay| canonicalize_overlay(overlay) })
+        end
+        out = out.merge('layout' => canonicalize_layout(doc['layout'])) if doc.key?('layout')
+        out
+      end
+
+      def canonicalize_element(element)
+        return element unless element.is_a?(Hash)
+        case element['kind']
+        when 'text'
+          mapped = LEGACY_VERTICAL_ALIGN[element['verticalAlign']]
+          mapped ? element.merge('verticalAlign' => mapped) : element
+        when 'kpi-chart'
+          layout = element['layout']
+          return element unless layout.is_a?(Hash)
+          canonical = layout.dup
+          canonical['anchor'] = LEGACY_HORIZONTAL_ALIGN[layout['anchor']] if LEGACY_HORIZONTAL_ALIGN.key?(layout['anchor'])
+          if LEGACY_VERTICAL_ALIGN.key?(layout['verticalAnchor'])
+            canonical['verticalAnchor'] = LEGACY_VERTICAL_ALIGN[layout['verticalAnchor']]
+          end
+          canonical == layout ? element : element.merge('layout' => canonical)
+        when 'tabbed-container'
+          tab_bar = element['tabBar']
+          return element unless tab_bar.is_a?(Hash)
+          mapped = LEGACY_HORIZONTAL_ALIGN[tab_bar['alignment']]
+          mapped ? element.merge('tabBar' => tab_bar.merge('alignment' => mapped)) : element
+        when 'divider'
+          legacy = element['align']
+          return element unless %w[start middle end].include?(legacy)
+          mapping = element['direction'] == 'vertical' ? LEGACY_HORIZONTAL_ALIGN : LEGACY_VERTICAL_ALIGN
+          element.merge('align' => mapping.fetch(legacy))
+        else
+          element
+        end
+      end
+
+      def canonicalize_overlay(overlay)
+        return overlay unless overlay.is_a?(Hash)
+        drawer = overlay['drawer']
+        return overlay unless drawer.is_a?(Hash) && drawer.key?('position')
+        overlay.merge('drawer' => drawer.reject { |key, _| key == 'position' })
       end
 
       # Emit only the current API shape. Elements are workbook-global in the

--- a/shared/lib/composition.py
+++ b/shared/lib/composition.py
@@ -149,7 +149,7 @@ def _indent(text):
 # render order. The <Tab> is itself a mini-grid (gridTemplateColumns /
 # gridTemplateRows), so elements position directly within it; no inner
 # Container is needed.
-def tabbed_container(id, tabs, grid_column, grid_row, tab_bar_alignment="start"):
+def tabbed_container(id, tabs, grid_column, grid_row, tab_bar_alignment="left"):
     if not id:
         raise ValueError("tabbed_container: id required")
     if not tabs:

--- a/shared/lib/composition.rb
+++ b/shared/lib/composition.rb
@@ -144,7 +144,7 @@ module Composition
   # render order. The <Tab> is itself a mini-grid (gridTemplateColumns /
   # gridTemplateRows), so elements position directly within it; no inner
   # Container is needed.
-  def self.tabbed_container(id:, tabs:, grid_column:, grid_row:, tab_bar_alignment: 'start')
+  def self.tabbed_container(id:, tabs:, grid_column:, grid_row:, tab_bar_alignment: 'left')
     raise ArgumentError, 'tabbed_container: id required' if id.to_s.empty?
     raise ArgumentError, 'tabbed_container: tabs required' if tabs.nil? || tabs.empty?
     tabs.each do |t|

--- a/shared/lib/styling.py
+++ b/shared/lib/styling.py
@@ -306,7 +306,7 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
     # See feature-coverage-report for the full finding (mirrors the styling.rb fix).
     container_el = {"id": container_id, "kind": "container", "style": {"borderRadius": "round"},
                      "backgroundImage": {"source": {"kind": "url", "url": bg_url}, "style": {"fit": "cover"}}}
-    title_el = {"id": title_id, "kind": "text", "verticalAlign": "middle",
+    title_el = {"id": title_id, "kind": "text", "verticalAlign": "center",
                 "body": '# <span style="color: #FFFFFF">%s</span>' % title}
 
     elements = [container_el]
@@ -314,7 +314,7 @@ def gradient_header(id, title, subtitle=None, gradient=None, motif="glow", motif
         elements.append({"id": logo_id, "kind": "image", "url": logo_url, "style": {"fit": "contain"}})
     elements.append(title_el)
     if subtitle:
-        elements.append({"id": subtitle_id, "kind": "text", "verticalAlign": "middle",
+        elements.append({"id": subtitle_id, "kind": "text", "verticalAlign": "center",
                           "body": '<span style="color: #CBD5E1">%s</span>' % subtitle})
 
     r0, r1 = 1, 4

--- a/shared/lib/styling.rb
+++ b/shared/lib/styling.rb
@@ -287,14 +287,14 @@ module Styling
     # See feature-coverage-report for the full finding.
     container_el = { 'id' => container_id, 'kind' => 'container', 'style' => { 'borderRadius' => 'round' },
                      'backgroundImage' => { 'source' => { 'kind' => 'url', 'url' => bg_url }, 'style' => { 'fit' => 'cover' } } }
-    title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+    title_el = { 'id' => title_id, 'kind' => 'text', 'verticalAlign' => 'center',
                  'body' => "# <span style=\"color: #FFFFFF\">#{title}</span>" }
 
     elements = [container_el]
     elements << { 'id' => logo_id, 'kind' => 'image', 'url' => logo_url, 'style' => { 'fit' => 'contain' } } if logo_url
     elements << title_el
     if subtitle
-      elements << { 'id' => subtitle_id, 'kind' => 'text', 'verticalAlign' => 'middle',
+      elements << { 'id' => subtitle_id, 'kind' => 'text', 'verticalAlign' => 'center',
                     'body' => "<span style=\"color: #CBD5E1\">#{subtitle}</span>" }
     end
 

--- a/shared/lib/test_composition.py
+++ b/shared/lib/test_composition.py
@@ -177,7 +177,7 @@ class CompositionTest(unittest.TestCase):
     def test_tabbed_container_labels_only_in_order_with_tab_bar(self):
         out = composition.tabbed_container("tc", self._tabbed_tabs(), "1 / 25", "7 / 60")
         self.assertEqual(out["element"]["tabs"], [{"name": "Overview"}, {"name": "Details"}])
-        self.assertEqual(out["element"]["tabBar"], {"alignment": "start"})
+        self.assertEqual(out["element"]["tabBar"], {"alignment": "left"})
 
     def test_tabbed_container_honors_non_default_tab_bar_alignment(self):
         out = composition.tabbed_container(

--- a/shared/lib/test_composition.rb
+++ b/shared/lib/test_composition.rb
@@ -161,9 +161,9 @@ end
 check('tabbed_container: element tabs are labels-only, in order, with tabBar.alignment') do
   out = Composition.tabbed_container(id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60')
   out[:element]['tabs'] == [{ 'name' => 'Overview' }, { 'name' => 'Details' }] &&
-    out[:element]['tabBar'] == { 'alignment' => 'start' }
+    out[:element]['tabBar'] == { 'alignment' => 'left' }
 end
-check('tabbed_container: non-default tab_bar_alignment is honored (not hardcoded to start)') do
+check('tabbed_container: non-default tab_bar_alignment is honored (not hardcoded to left)') do
   out = Composition.tabbed_container(
     id: 'tc', tabs: tabbed_tabs, grid_column: '1 / 25', grid_row: '7 / 60', tab_bar_alignment: 'center'
   )

--- a/shared/lib/testdata/composition_tabbed_golden.json
+++ b/shared/lib/testdata/composition_tabbed_golden.json
@@ -6,7 +6,7 @@
       { "name": "Overview" },
       { "name": "Details" }
     ],
-    "tabBar": { "alignment": "start" }
+    "tabBar": { "alignment": "left" }
   },
   "layout": "<TabbedContainer elementId=\"tc\" type=\"tabbed-container\" gridColumn=\"1 / 25\" gridRow=\"7 / 60\">\n  <Tab gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n    <Element elementId=\"a1\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>\n  </Tab>\n  <Tab gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n    <Element elementId=\"b1\" gridColumn=\"1 / 25\" gridRow=\"1 / 7\"/>\n  </Tab>\n</TabbedContainer>"
 }

--- a/shared/lib/testdata/styling_golden.json
+++ b/shared/lib/testdata/styling_golden.json
@@ -93,7 +93,7 @@
       {
         "id": "ghdr4-title",
         "kind": "text",
-        "verticalAlign": "middle",
+        "verticalAlign": "center",
         "body": "# <span style=\"color: #FFFFFF\">Custom</span>"
       }
     ],
@@ -128,13 +128,13 @@
       {
         "id": "ghdr-title",
         "kind": "text",
-        "verticalAlign": "middle",
+        "verticalAlign": "center",
         "body": "# <span style=\"color: #FFFFFF\">Command Center</span>"
       },
       {
         "id": "ghdr-subtitle",
         "kind": "text",
-        "verticalAlign": "middle",
+        "verticalAlign": "center",
         "body": "<span style=\"color: #CBD5E1\">Live metrics</span>"
       }
     ],
@@ -161,7 +161,7 @@
       {
         "id": "ghdr3-title",
         "kind": "text",
-        "verticalAlign": "middle",
+        "verticalAlign": "center",
         "body": "# <span style=\"color: #FFFFFF\">Plain</span>"
       }
     ],
@@ -188,7 +188,7 @@
       {
         "id": "ghdr2-title",
         "kind": "text",
-        "verticalAlign": "middle",
+        "verticalAlign": "center",
         "body": "# <span style=\"color: #FFFFFF\">Ops</span>"
       }
     ],

--- a/shared/lib/tests/test_code_rep.mjs
+++ b/shared/lib/tests/test_code_rep.mjs
@@ -49,4 +49,42 @@ assert.equal(
 );
 assert.doesNotMatch(canonicalLayout, /LayoutElement|GridContainer/);
 
+const legacyFields = {
+  pages: [],
+  elements: [
+    { id: 'text', kind: 'text', verticalAlign: 'middle' },
+    {
+      id: 'kpi',
+      kind: 'kpi-chart',
+      layout: { anchor: 'start', verticalAnchor: 'end', titleOrient: 'bottom' },
+    },
+    { id: 'tabs', kind: 'tabbed-container', tabBar: { alignment: 'end' } },
+    { id: 'h-rule', kind: 'divider', align: 'start' },
+    { id: 'v-rule', kind: 'divider', direction: 'vertical', align: 'end' },
+  ],
+  overlays: [
+    {
+      id: 'filters',
+      type: 'drawer',
+      drawer: { width: 'medium', position: 'end', showShadow: 'shown' },
+    },
+  ],
+};
+const canonicalFields = wrap(legacyFields).document;
+const fieldsById = Object.fromEntries(canonicalFields.elements.map((element) => [element.id, element]));
+assert.equal(fieldsById.text.verticalAlign, 'center');
+assert.deepEqual(
+  fieldsById.kpi.layout,
+  { anchor: 'left', verticalAnchor: 'bottom', titleOrient: 'bottom' },
+);
+assert.equal(fieldsById.tabs.tabBar.alignment, 'right');
+assert.equal(fieldsById['h-rule'].align, 'top');
+assert.equal(fieldsById['v-rule'].align, 'right');
+assert.deepEqual(
+  canonicalFields.overlays[0].drawer,
+  { width: 'medium', showShadow: 'shown' },
+);
+assert.equal(legacyFields.elements[0].verticalAlign, 'middle');
+assert.equal(legacyFields.overlays[0].drawer.position, 'end');
+
 console.log('PASS — JavaScript workbook code representation');

--- a/shared/lib/tests/test_code_rep.py
+++ b/shared/lib/tests/test_code_rep.py
@@ -82,6 +82,43 @@ class TestCodeRep(unittest.TestCase):
         )
         self.assertNotRegex(emitted, r'LayoutElement|GridContainer')
 
+    def test_wrap_canonicalizes_legacy_alignment_fields_and_drawer_position(self):
+        legacy = {
+            'pages': [],
+            'elements': [
+                {'id': 'text', 'kind': 'text', 'verticalAlign': 'middle'},
+                {'id': 'kpi', 'kind': 'kpi-chart',
+                 'layout': {'anchor': 'start', 'verticalAnchor': 'end',
+                            'titleOrient': 'bottom'}},
+                {'id': 'tabs', 'kind': 'tabbed-container',
+                 'tabBar': {'alignment': 'end'}},
+                {'id': 'h-rule', 'kind': 'divider', 'align': 'start'},
+                {'id': 'v-rule', 'kind': 'divider',
+                 'direction': 'vertical', 'align': 'end'},
+            ],
+            'overlays': [
+                {'id': 'filters', 'type': 'drawer',
+                 'drawer': {'width': 'medium', 'position': 'end',
+                            'showShadow': 'shown'}},
+            ],
+        }
+        emitted = code_rep.wrap(legacy)['document']
+        by_id = {element['id']: element for element in emitted['elements']}
+        self.assertEqual(by_id['text']['verticalAlign'], 'center')
+        self.assertEqual(
+            by_id['kpi']['layout'],
+            {'anchor': 'left', 'verticalAnchor': 'bottom', 'titleOrient': 'bottom'},
+        )
+        self.assertEqual(by_id['tabs']['tabBar']['alignment'], 'right')
+        self.assertEqual(by_id['h-rule']['align'], 'top')
+        self.assertEqual(by_id['v-rule']['align'], 'right')
+        self.assertEqual(
+            emitted['overlays'][0]['drawer'],
+            {'width': 'medium', 'showShadow': 'shown'},
+        )
+        self.assertEqual(legacy['elements'][0]['verticalAlign'], 'middle')
+        self.assertEqual(legacy['overlays'][0]['drawer']['position'], 'end')
+
     def test_page_membership_accepts_legacy_aliases_only_for_layout_nodes(self):
         legacy_layout = (
             '<Page id="p"><GridContainer elementId="c">'

--- a/shared/lib/tests/test_code_rep.rb
+++ b/shared/lib/tests/test_code_rep.rb
@@ -85,6 +85,36 @@ class TestCodeRep < Minitest::Test
     refute_match(/LayoutElement|GridContainer/, emitted)
   end
 
+  def test_wrap_canonicalizes_legacy_alignment_fields_and_drawer_position
+    legacy = {
+      'pages' => [],
+      'elements' => [
+        { 'id' => 'text', 'kind' => 'text', 'verticalAlign' => 'middle' },
+        { 'id' => 'kpi', 'kind' => 'kpi-chart',
+          'layout' => { 'anchor' => 'start', 'verticalAnchor' => 'end', 'titleOrient' => 'bottom' } },
+        { 'id' => 'tabs', 'kind' => 'tabbed-container', 'tabBar' => { 'alignment' => 'end' } },
+        { 'id' => 'h-rule', 'kind' => 'divider', 'align' => 'start' },
+        { 'id' => 'v-rule', 'kind' => 'divider', 'direction' => 'vertical', 'align' => 'end' }
+      ],
+      'overlays' => [
+        { 'id' => 'filters', 'type' => 'drawer',
+          'drawer' => { 'width' => 'medium', 'position' => 'end', 'showShadow' => 'shown' } }
+      ]
+    }
+    emitted = Sigma::CodeRep.wrap(legacy)['document']
+    by_id = emitted['elements'].each_with_object({}) { |element, out| out[element['id']] = element }
+    assert_equal 'center', by_id['text']['verticalAlign']
+    assert_equal({ 'anchor' => 'left', 'verticalAnchor' => 'bottom', 'titleOrient' => 'bottom' },
+                 by_id['kpi']['layout'])
+    assert_equal 'right', by_id['tabs'].dig('tabBar', 'alignment')
+    assert_equal 'top', by_id['h-rule']['align']
+    assert_equal 'right', by_id['v-rule']['align']
+    assert_equal({ 'width' => 'medium', 'showShadow' => 'shown' },
+                 emitted.dig('overlays', 0, 'drawer'))
+    assert_equal 'middle', legacy.dig('elements', 0, 'verticalAlign')
+    assert_equal 'end', legacy.dig('overlays', 0, 'drawer', 'position')
+  end
+
   def test_page_membership_accepts_legacy_aliases_but_ignores_unrelated_attributes
     legacy_layout = '<Page id="p"><GridContainer elementId="c"><LayoutElement elementId="e1"/>' \
                     '<Noise elementId="not-layout"/></GridContainer></Page>'

--- a/shared/scripts/enhance-scan.rb
+++ b/shared/scripts/enhance-scan.rb
@@ -613,7 +613,7 @@ if fresh_note
     'verdict_hint' => 'apply',
     'patch' => { 'op' => 'add_elements', 'page_id' => dash_pages.first&.dig('id'),
                  'elements' => [{ 'id' => 'el-phasee-freshness', 'kind' => 'text',
-                                  'body' => fresh_note, 'verticalAlign' => 'middle', 'overflow' => 'clip' }],
+                                  'body' => fresh_note, 'verticalAlign' => 'center', 'overflow' => 'clip' }],
                  'layout' => [{ 'element_id' => 'el-phasee-freshness', 'grid_column' => '1 / 25', 'height' => 2 }] }
   }
 end

--- a/shared/scripts/verify-richness-surfaces-e2e.rb
+++ b/shared/scripts/verify-richness-surfaces-e2e.rb
@@ -322,7 +322,7 @@ def build_spec(home, schema_version, cortex_model, flags)
             'comparison' => { 'display' => 'delta', 'colorGood' => '#1a7f37', 'colorBad' => '#cf222e' },
             'trend' => { 'shape' => 'line' } },
           # SURFACE 2: CallText / AI-insight.
-          { 'id' => AI_TEXT_ID, 'kind' => 'text', 'verticalAlign' => 'middle', 'body' => ai_body },
+          { 'id' => AI_TEXT_ID, 'kind' => 'text', 'verticalAlign' => 'center', 'body' => ai_body },
           # SURFACE 3: dynamic grain — segmented control (documented
           # "date-grain switcher" idiom: manual value-list, no `filters`,
           # consumed only via the chart column's own Switch([GrainCtl],…)).

--- a/shared/scripts/verify-ws4-e2e.rb
+++ b/shared/scripts/verify-ws4-e2e.rb
@@ -331,7 +331,7 @@ def build_spec(home, schema_version)
                                         'orders, margin, region, and category, and trends over time. Be concise ' \
                                         'and quantitative; cite the numbers you used.',
                           data_source_ids: [SRC_ID])
-  chat_hd = { 'id' => 'chat-hd', 'kind' => 'text', 'verticalAlign' => 'middle', 'body' => '**Ask the WS4 Analyst**' }
+  chat_hd = { 'id' => 'chat-hd', 'kind' => 'text', 'verticalAlign' => 'center', 'body' => '**Ask the WS4 Analyst**' }
   chat = Richness.chat(id: 'chat', agent_id: 'ag-ws4')
 
   # ==== SURFACE: Styling.gradient_header — second live motif (:rings) ======

--- a/shared/scripts/verify-ws5-tabbed-e2e.rb
+++ b/shared/scripts/verify-ws5-tabbed-e2e.rb
@@ -263,7 +263,7 @@ begin
     'Composition.tabbed_container element (2 labels + tabBar)' => {
       post_accepted: !!(tc_back && tc_back['kind'] == 'tabbed-container' &&
                          tc_back['tabs'] == [{ 'name' => 'Table' }, { 'name' => 'Chart' }] &&
-                         tc_back.dig('tabBar', 'alignment') == 'start'),
+                         tc_back.dig('tabBar', 'alignment') == 'left'),
       render_hint: 'Read the pg-main render — a tab bar should be visible near the top of the ' \
                     'container reading "Table" and "Chart", with one tab active.'
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What & why

Sigma workbook alignment enums changed in `sigma-skills` PR #61. Migration converters still emit the legacy vocabulary in several paths. This shared compatibility update canonicalizes those fields at every workbook CodeRep write boundary, removes deprecated `drawer.position`, and updates shared composition/styling/Phase E emitters to current values.

Legacy mappings are context-aware:
- text `verticalAlign`: `start/middle/end` → `top/center/bottom`
- KPI `layout.anchor`: `start/middle/end` → `left/center/right`
- KPI `layout.verticalAnchor`: `start/middle/end` → `top/center/bottom`
- tab bar alignment: `start/middle/end` → `left/center/right`
- divider alignment: horizontal → vertical-axis terms; vertical → horizontal-axis terms
- drawer `position`: removed

## Scope

- Shared CodeRep implementations and synchronized plugin copies
- Shared composition/styling helpers and Phase E emitter
- Shared Ruby/Python/JavaScript regression tests, now registered in CI
- Streamlit corpus goldens refreshed to the canonical wire representation
- [x] Isolated shared-library change; plugin-owned emitter cleanup remains in separate follow-up PRs

## Verification

- [x] CodeRep Ruby: 19 tests / 96 assertions
- [x] CodeRep Python: 19 tests
- [x] CodeRep JavaScript regression
- [x] Shared composition/styling Ruby and Python tests
- [x] Full corpus: 34/34 cases
- [x] Shared-copy drift check: 886 copies match canonical
- [x] Ruby/Python twin parity
- [x] Syntax, skill, path, layout-tag, version, and converter-provenance guards

## Checklist

- [x] `ruby tools/check-shared.rb` — green
- [x] CodeRep Ruby/Python/JavaScript tests — green
- [x] Composition/styling tests — green
- [x] `ruby tools/lint-twin-parity.rb` — green
- [x] `./corpus/run-corpus.sh --check` — green
- [x] Phase numbers unchanged
- [x] No unrelated working-tree changes included
- [x] `Skip-Version-Bump: shared compatibility layer; plugin releases follow in per-plugin emitter PRs`

## If this changes a shared lib

- [x] Edited canonical files under `shared/`
- [x] Ran `ruby tools/sync-shared.rb`
- [x] Standalone shared-infrastructure PR

## If this adds a converter

- [x] Not applicable
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c0b885f7-b59c-4a17-982b-527abcb3ce17?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0b885f7-b59c-4a17-982b-527abcb3ce17&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

